### PR TITLE
Force QS evaluation during copy

### DIFF
--- a/interventions/utils.py
+++ b/interventions/utils.py
@@ -21,7 +21,7 @@ def copy_intervention_to_study(study, intervention):
     """
     Copies the given Intervention to the given Study
     """
-    setting = intervention.setting.all()
+    setting = list(intervention.setting.all())
 
     i = intervention
     i.pk = None

--- a/observations/utils.py
+++ b/observations/utils.py
@@ -15,8 +15,8 @@ def observation_url(study):
 
 
 def copy_observation_to_study(study, observation):
-    setting = observation.setting.all()
-    registrations = observation.registrations.all()
+    setting = list(observation.setting.all())
+    registrations = list(observation.registrations.all())
 
     o = observation
     o.pk = None
@@ -25,5 +25,5 @@ def copy_observation_to_study(study, observation):
     o.save()
 
     o.setting.set(setting)
-    o.registrations.set(registrations.all())
+    o.registrations.set(registrations)
     o.save()

--- a/proposals/copy.py
+++ b/proposals/copy.py
@@ -11,9 +11,13 @@ def copy_proposal(self, form):
     parent = form.cleaned_data['parent']
     parent_pk = parent.pk
     relation = parent.relation
-    applicants = parent.applicants.all()
-    funding = parent.funding.all()
-    copy_studies = parent.study_set.all()
+    # We convert to list to force evaluation of the QS. Otherwise,
+    # the evaluation will happen after we've updated the proposal's ID and
+    # the queryset will try to retrieve the new (non-existing) data instead
+    # of the old
+    applicants = list(parent.applicants.all())
+    funding = list(parent.funding.all())
+    copy_studies = list(parent.study_set.all())
     copy_wmo = None
     if hasattr(parent, 'wmo'):
         copy_wmo = parent.wmo
@@ -26,11 +30,6 @@ def copy_proposal(self, form):
         copy_proposal.reference_number = generate_revision_ref_number(parent)
     else:
         copy_proposal.reference_number = generate_ref_number()
-
-
-    # Titles are no longer required to be unique
-    # And the Title field has been removed from the copy form
-    # copy_proposal.title = form.cleaned_data['title']
 
     copy_proposal.created_by = self.request.user
     copy_proposal.status = Proposal.DRAFT

--- a/studies/utils.py
+++ b/studies/utils.py
@@ -114,13 +114,13 @@ def copy_study_to_proposal(proposal, study):
     :return: the Proposal appended with the details of the given Study.
     """
     old_pk = study.pk
-    age_groups = study.age_groups.all()
-    traits = study.traits.all()
+    age_groups = list(study.age_groups.all())
+    traits = list(study.traits.all())
     compensation = study.compensation
-    recruitment = study.recruitment.all()
+    recruitment = list(study.recruitment.all())
     intervention = study.intervention if study.has_intervention else None
     observation = study.observation if study.has_observation else None
-    sessions = study.session_set.all() if study.has_sessions else []
+    sessions = list(study.session_set.all()) if study.has_sessions else []
 
     s = study
     s.pk = None

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -70,8 +70,8 @@ def tasks_urls(session):
 
 
 def copy_task_to_session(session, task):
-    r = task.registrations.all()
-    rk = task.registration_kinds.all()
+    r = list(task.registrations.all())
+    rk = list(task.registration_kinds.all())
 
     t = task
     t.pk = None
@@ -84,8 +84,8 @@ def copy_task_to_session(session, task):
 
 
 def copy_session_to_study(study, session):
-    setting = session.setting.all()
-    tasks = session.task_set.all()
+    setting = list(session.setting.all())
+    tasks = list(session.task_set.all())
 
     s = session
     s.pk = None


### PR DESCRIPTION
Fixes #327

This was an interesting bug to debug; when attaching a debugger and stepping through the code, the bug automagically dissappeared. Took me a while to figure it out; somewhere between Django 2.2 and 3.2 they changed the behaviour of QuerySet's lazy evaluation, in that it will insert the related PK at the last moment instead of upon definition. 

Thus, during copy it was actually querying the state of the copy proposal instead of the original, resulting in related objects not being copied. The debugger fixed this, as the debugger was forcing the evaluation of the QS directly after definition (to show in the variable list). As a result, it was actually a list of the original proposal's related objects when running with the debugger. 

This PR tries to do the same by wrapping all QS in a `list()`, ensuring the QS is evaluated immediatly. 

And no, this change in behaviour wasn't documented anywhere :-/