### PR TITLE
Refactor copying, add tests and fix #318

### DIFF
--- a/interventions/utils.py
+++ b/interventions/utils.py
@@ -17,17 +17,17 @@ def intervention_url(study):
     return result
 
 
-def copy_intervention_to_study(study, intervention):
+def copy_intervention_to_study(study, original_intervention):
     """
     Copies the given Intervention to the given Study
     """
-    setting = list(intervention.setting.all())
+    from interventions.models import Intervention
 
-    i = intervention
+    i = Intervention.objects.get(pk=original_intervention.pk)
     i.pk = None
     i.version = 2  # Auto upgrade old versions
     i.study = study
     i.save()
 
-    i.setting.set(setting)
+    i.setting.set(original_intervention.setting.all())
     i.save()

--- a/observations/utils.py
+++ b/observations/utils.py
@@ -14,16 +14,15 @@ def observation_url(study):
     return result
 
 
-def copy_observation_to_study(study, observation):
-    setting = list(observation.setting.all())
-    registrations = list(observation.registrations.all())
+def copy_observation_to_study(study, original_observation):
+    from observations.models import Observation
 
-    o = observation
+    o = Observation.objects.get(pk=original_observation.pk)
     o.pk = None
     o.version = 2
     o.study = study
     o.save()
 
-    o.setting.set(setting)
-    o.registrations.set(registrations)
+    o.setting.set(original_observation.setting.all())
+    o.registrations.set(original_observation.registrations.all())
     o.save()

--- a/proposals/copy.py
+++ b/proposals/copy.py
@@ -51,6 +51,8 @@ def copy_proposal(original_proposal, is_revision, created_by_user):
 
     if is_revision:
         copy_proposal.parent = original_proposal
+    else:
+        copy_proposal.parent = None
 
     copy_proposal.save()
 

--- a/proposals/copy.py
+++ b/proposals/copy.py
@@ -4,34 +4,31 @@ from studies.utils import copy_study_to_proposal, copy_documents_to_proposal
 from .utils import generate_ref_number, generate_revision_ref_number
 
 
-def copy_proposal(self, form):
+def copy_proposal(original_proposal, is_revision, created_by_user):
     from .models import Proposal
 
     # Save relationships
-    parent = form.cleaned_data['parent']
-    parent_pk = parent.pk
-    relation = parent.relation
-    # We convert to list to force evaluation of the QS. Otherwise,
-    # the evaluation will happen after we've updated the proposal's ID and
-    # the queryset will try to retrieve the new (non-existing) data instead
-    # of the old
-    applicants = list(parent.applicants.all())
-    funding = list(parent.funding.all())
-    copy_studies = list(parent.study_set.all())
-    copy_wmo = None
-    if hasattr(parent, 'wmo'):
-        copy_wmo = parent.wmo
+    relation = original_proposal.relation
+    applicants = original_proposal.applicants.all()
+    funding = original_proposal.funding.all()
 
-    # Create copy and save the this new model, set it to not-submitted
-    copy_proposal = parent
+    # Create copy by retrieving a new object. This should ensure the original
+    # object will not alter.
+    copy_proposal = Proposal.objects.get(pk=original_proposal.pk)
     copy_proposal.pk = None
 
-    if form.cleaned_data['is_revision']:
-        copy_proposal.reference_number = generate_revision_ref_number(parent)
+    copy_wmo = None
+    if hasattr(original_proposal, 'wmo'):
+        copy_wmo = original_proposal.wmo
+
+    if is_revision:
+        copy_proposal.reference_number = generate_revision_ref_number(
+            original_proposal
+        )
     else:
         copy_proposal.reference_number = generate_ref_number()
 
-    copy_proposal.created_by = self.request.user
+    copy_proposal.created_by = created_by_user
     copy_proposal.status = Proposal.DRAFT
     copy_proposal.status_review = None
     copy_proposal.pdf = None
@@ -44,14 +41,17 @@ def copy_proposal(self, form):
     copy_proposal.date_confirmed = None
     copy_proposal.is_exploration = False
     copy_proposal.in_course = False
-    copy_proposal.is_revision = form.cleaned_data['is_revision']
+    copy_proposal.is_revision = is_revision
     copy_proposal.save()
 
     # Copy references
     copy_proposal.relation = relation
     copy_proposal.applicants.set(applicants)
     copy_proposal.funding.set(funding)
-    copy_proposal.parent = Proposal.objects.get(pk=parent_pk)
+
+    if is_revision:
+        copy_proposal.parent = original_proposal
+
     copy_proposal.save()
 
     # Copy linked models
@@ -59,10 +59,10 @@ def copy_proposal(self, form):
         copy_wmo.pk = copy_proposal.pk
         copy_wmo.save()
 
-    for study in copy_studies:
+    for study in original_proposal.study_set.all():
         copy_study_to_proposal(copy_proposal, study)
 
     if not copy_proposal.is_pre_approved:
-        copy_documents_to_proposal(parent_pk, copy_proposal)
+        copy_documents_to_proposal(original_proposal.pk, copy_proposal)
 
     return copy_proposal

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -439,7 +439,11 @@ class ProposalCopy(UserFormKwargsMixin, CreateView):
 
     def form_valid(self, form):
         """Create a copy of the selected Proposal"""
-        form.instance = copy_proposal(self, form)
+        form.instance = copy_proposal(
+            form.cleaned_data['parent'],
+            form.cleaned_data['is_revision'],
+            self.request.user,
+        )
         return super(ProposalCopy, self).form_valid(form)
 
     def get_context_data(self, **kwargs):

--- a/studies/utils.py
+++ b/studies/utils.py
@@ -106,23 +106,24 @@ def create_documents_for_study(study):
     d.save()
 
 
-def copy_study_to_proposal(proposal, study):
+def copy_study_to_proposal(proposal, original_study):
     """
     Copies the given Study to the given Proposal.
     :param proposal: the current Proposal
     :param study: the current Study
     :return: the Proposal appended with the details of the given Study.
     """
-    old_pk = study.pk
-    age_groups = list(study.age_groups.all())
-    traits = list(study.traits.all())
-    compensation = study.compensation
-    recruitment = list(study.recruitment.all())
-    intervention = study.intervention if study.has_intervention else None
-    observation = study.observation if study.has_observation else None
-    sessions = list(study.session_set.all()) if study.has_sessions else []
+    from studies.models import Study
 
-    s = study
+    age_groups = original_study.age_groups.all()
+    traits = original_study.traits.all()
+    compensation = original_study.compensation
+    recruitment = original_study.recruitment.all()
+    intervention = original_study.intervention if original_study.has_intervention else None
+    observation = original_study.observation if original_study.has_observation else None
+    sessions = original_study.session_set.all() if original_study.has_sessions else []
+
+    s = Study.objects.get(pk=original_study.pk)
     s.pk = None
     s.proposal = proposal
     s.save()
@@ -140,7 +141,7 @@ def copy_study_to_proposal(proposal, study):
     for session in sessions:
         copy_session_to_study(s, session)
 
-    copy_documents_to_study(old_pk, s)
+    copy_documents_to_study(original_study.pk, s)
 
 
 def copy_documents_to_study(study_old, study):

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -69,31 +69,31 @@ def tasks_urls(session):
     return result
 
 
-def copy_task_to_session(session, task):
-    r = list(task.registrations.all())
-    rk = list(task.registration_kinds.all())
+def copy_task_to_session(session, original_task):
+    from tasks.models import Task
 
-    t = task
+    t = Task.objects.get(pk=original_task.pk)
     t.pk = None
     t.session = session
     t.save()
 
-    t.registrations.set(r)
-    t.registration_kinds.set(rk)
+    t.registrations.set(original_task.registrations.all())
+    t.registration_kinds.set(
+        original_task.registration_kinds.all()
+    )
     t.save()
 
 
-def copy_session_to_study(study, session):
-    setting = list(session.setting.all())
-    tasks = list(session.task_set.all())
+def copy_session_to_study(study, original_session):
+    from tasks.models import Session
 
-    s = session
+    s = Session.objects.get(pk=original_session.pk)
     s.pk = None
     s.study = study
     s.save()
 
-    s.setting.set(setting)
+    s.setting.set(original_session.setting.all())
     s.save()
 
-    for task in tasks:
+    for task in original_session.task_set.all():
         copy_task_to_session(s, task)


### PR DESCRIPTION
This PR fixes bug #318 by only adding a parent if it's a revision copy; in addition, it adds some basic tests and refactors the copying code a bit.

Scope of refactoring:
- ``copy_proposal`` has a different signature: instead of asking for both django view and form objects, it requires the bits it actually needs directly. (Thus making finding those bits someone else's problem). While this makes the function more testable, it was mainly done because the previous method was _insane_
- Instead of changing the supplied objects in place, it now retrieves a fresh version of said objects from the database and changes that. This minimizes the side effects of the copy, as it leaves the original object intact. (And thus makes sure that other pieces of code that hold a reference to it don't suddenly have a different object). 
- As the above refactor solves #327 as well in a more elegant manner, the changes in #328 have been removed

