### PR TITLE
Feature/remove unfinished pdf action

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-08 15:53+0200\n"
+"POT-Creation-Date: 2022-07-12 12:06+0200\n"
 "PO-Revision-Date: 2020-10-07 11:22+0200\n"
 "Last-Translator: Anna Asbury <anna.asbury@annaasbury.com>\n"
 "Language-Team: \n"
@@ -382,7 +382,7 @@ msgstr "Phase"
 #: main/templates/auth/user_detail.html:55 proposals/api/views.py:23
 #: proposals/api/views.py:88 proposals/api/views.py:118
 #: proposals/api/views.py:168
-#: proposals/templates/proposals/vue_templates/proposal_list.html:150
+#: proposals/templates/proposals/vue_templates/proposal_list.html:147
 #: reviews/api/views.py:49 reviews/api/views.py:280 reviews/api/views.py:342
 #: reviews/templates/reviews/vue_templates/decision_list.html:153
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:95
@@ -1096,7 +1096,7 @@ msgid ""
 msgstr "As might happen on forums where the researcher also has an account."
 
 #: observations/models.py:65 observations/models.py:75
-#: observations/models.py:88 proposals/models.py:539 studies/models.py:154
+#: observations/models.py:88 proposals/models.py:534 studies/models.py:154
 #: studies/models.py:188 studies/models.py:321
 msgid "Licht toe"
 msgstr "Explain"
@@ -1220,7 +1220,7 @@ msgstr "Date reviewed"
 #: proposals/api/views.py:31 proposals/api/views.py:73
 #: proposals/api/views.py:92 proposals/api/views.py:130
 #: proposals/api/views.py:151
-#: proposals/templates/proposals/vue_templates/proposal_list.html:105
+#: proposals/templates/proposals/vue_templates/proposal_list.html:102
 msgid "Laatst bijgewerkt"
 msgstr "Last edited"
 
@@ -1654,7 +1654,7 @@ msgid "Uitvoerende(n) (inclusief uzelf)"
 msgstr "Researcher(s) carrying out the study (including yourself)"
 
 #: proposals/models.py:369
-#: proposals/templates/proposals/vue_templates/proposal_list.html:163
+#: proposals/templates/proposals/vue_templates/proposal_list.html:160
 msgid "Eindverantwoordelijke onderzoeker"
 msgstr "Researcher with final responsibility"
 
@@ -1712,19 +1712,19 @@ msgstr "Practice"
 msgid "Extern getoetst"
 msgstr "External approval"
 
-#: proposals/models.py:524
+#: proposals/models.py:519
 msgid "Geen beoordeling door METC noodzakelijk"
 msgstr "Assessment by METC not required"
 
-#: proposals/models.py:525
+#: proposals/models.py:520
 msgid "In afwachting beslissing METC"
 msgstr "Pending decision by METC"
 
-#: proposals/models.py:526
+#: proposals/models.py:521
 msgid "Beslissing METC geüpload"
 msgstr "METC decision uploaded"
 
-#: proposals/models.py:530
+#: proposals/models.py:525
 msgid ""
 "Vindt de dataverzameling plaats binnen het UMC Utrecht of andere instelling "
 "waar toetsing door een METC verplicht is gesteld?"
@@ -1732,11 +1732,11 @@ msgstr ""
 "Will the data collection take place at the UMC Utrecht or another "
 "institution for which an assessment by a METC is required?"
 
-#: proposals/models.py:544
+#: proposals/models.py:539
 msgid "Welke instelling?"
 msgstr "Which institution?"
 
-#: proposals/models.py:550
+#: proposals/models.py:545
 msgid ""
 "Is de onderzoeksvraag medisch-wetenschappelijk van aard (zoals gedefinieerd "
 "door de WMO)?"
@@ -1744,7 +1744,7 @@ msgstr ""
 "Is the nature of the research question medical (as defined by the Medical "
 "Research Involving Human Subjects Act (WMO))?"
 
-#: proposals/models.py:552
+#: proposals/models.py:547
 msgid ""
 "De definitie van medisch-wetenschappelijk onderzoek is: Medisch-"
 "wetenschappelijk onderzoek is onderzoek dat als doel heeft het beantwoorden "
@@ -1765,7 +1765,7 @@ msgstr ""
 "Committee on Research Involving Human Subjects, Definition of medical "
 "research, 2005, ccmo.nl)"
 
-#: proposals/models.py:568
+#: proposals/models.py:563
 msgid ""
 "Je onderzoek moet beoordeeld worden door een METC, maar dient nog wel bij de "
 "FETC-GW te worden geregistreerd. Is dit onderzoek al aangemeld bij een METC?"
@@ -1774,15 +1774,15 @@ msgstr ""
 "registered with the FEtC-H. Has an application for this project already been "
 "submitted to an METC?"
 
-#: proposals/models.py:575
+#: proposals/models.py:570
 msgid "Is de METC al tot een beslissing gekomen?"
 msgstr "Has the METC already come to a decision?"
 
-#: proposals/models.py:580
+#: proposals/models.py:575
 msgid "Upload hier de beslissing van het METC (in .pdf of .doc(x)-formaat)"
 msgstr "Please upload the decision of METC  (in .pdf or .doc(x)-format) here"
 
-#: proposals/models.py:618
+#: proposals/models.py:613
 #, python-brace-format
 msgid "WMO {title}, status {status}"
 msgstr "WMO {title}, status {status}"
@@ -3172,42 +3172,42 @@ msgstr "Decide"
 msgid "Naar volgende stap"
 msgstr "To next step"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:75
+#: proposals/templates/proposals/vue_templates/proposal_list.html:73
 msgid "Inzien"
 msgstr "Show"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:83
+#: proposals/templates/proposals/vue_templates/proposal_list.html:80
 msgid "Verberg"
 msgstr "Hide"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:90
+#: proposals/templates/proposals/vue_templates/proposal_list.html:87
 msgid "Soort aanvraag"
 msgstr "Type of application"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:99
+#: proposals/templates/proposals/vue_templates/proposal_list.html:96
 msgid "Besloten op"
 msgstr "Concluded on"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:112
+#: proposals/templates/proposals/vue_templates/proposal_list.html:109
 msgid "Status"
 msgstr "State"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:136
+#: proposals/templates/proposals/vue_templates/proposal_list.html:133
 #: reviews/templates/reviews/vue_templates/decision_list.html:141
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:83
 #: reviews/templates/reviews/vue_templates/review_list.html:126
 msgid "Revisie/amendement van"
 msgstr "Revision/amendment of"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:158
+#: proposals/templates/proposals/vue_templates/proposal_list.html:155
 msgid "Nog niet ingediend"
 msgstr "Not yet submitted"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:177
+#: proposals/templates/proposals/vue_templates/proposal_list.html:174
 msgid "Route:"
 msgstr "Route:"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:184
+#: proposals/templates/proposals/vue_templates/proposal_list.html:181
 #: reviews/templates/reviews/vue_templates/decision_list.html:185
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:128
 #: reviews/templates/reviews/vue_templates/review_list.html:171
@@ -4309,37 +4309,6 @@ msgstr "Pending decisions committee members"
 #: reviews/views.py:90
 msgid "Openstaande besluiten eindverantwoordelijken"
 msgstr "Pending decisions supervisors"
-
-#: src/uil-django-core/uil/rest_client/clients/_base.py:104
-#: src/uil-django-core/uil/rest_client/clients/_base.py:107
-msgid "api:host_unreachable"
-msgstr ""
-
-#: src/uil-django-core/uil/rest_client/fields.py:28
-#, python-format
-msgid "Value %(value)r is not a valid choice."
-msgstr ""
-
-#: src/uil-django-core/uil/rest_client/fields.py:29
-msgid "This field cannot be null."
-msgstr ""
-
-#: src/uil-django-core/uil/rest_client/fields.py:30
-msgid "This field cannot be blank."
-msgstr ""
-
-#: src/uil-django-core/uil/rest_client/fields.py:31
-#, python-format
-msgid "%(model_name)s with this %(field_label)s already exists."
-msgstr ""
-
-#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
-#. Eg: "Title must be unique for pub_date year"
-#: src/uil-django-core/uil/rest_client/fields.py:35
-#, python-format
-msgid ""
-"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
-msgstr ""
 
 #: studies/forms.py:38
 msgid ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-31 14:23+0200\n"
+"POT-Creation-Date: 2022-06-08 15:53+0200\n"
 "PO-Revision-Date: 2020-10-07 11:22+0200\n"
 "Last-Translator: Anna Asbury <anna.asbury@annaasbury.com>\n"
 "Language-Team: \n"
@@ -37,7 +37,7 @@ msgstr " Regulations Linguistics Chamber (LC) "
 
 #: faqs/menus.py:22 main/templates/base/menu.html:134
 #: main/templates/main/index.html:189
-#: proposals/templates/proposals/proposal_pdf.html:395
+#: proposals/templates/proposals/proposal_pdf.html:398
 #: proposals/templates/proposals/study_consent.html:8
 #: proposals/templates/proposals/study_consent.html:68
 msgid "Informed consent formulieren"
@@ -150,11 +150,11 @@ msgstr ""
 msgid "Feedback verstuurd"
 msgstr "Feedback sent"
 
-#: fetc/settings.py:120
+#: fetc/settings.py:121
 msgid "Nederlands"
 msgstr "Dutch"
 
-#: fetc/settings.py:121
+#: fetc/settings.py:122
 msgid "Engels"
 msgstr "English"
 
@@ -232,7 +232,7 @@ msgstr "How many times a week will the intervention session take place?"
 #: interventions/templates/interventions/intervention_form.html:7
 #: interventions/templates/interventions/intervention_form.html:49
 #: proposals/templates/proposals/diff/intervention.html:4
-#: proposals/templates/proposals/proposal_pdf.html:250
+#: proposals/templates/proposals/proposal_pdf.html:253
 #: proposals/templates/proposals/proposal_pdf_empty.html:183
 msgid "Het interventieonderzoek"
 msgstr "Intervention study"
@@ -340,8 +340,8 @@ msgid ""
 "onderzoekers         waarschuwen dat de school om een VOG kan vragen."
 msgstr ""
 "Anybody who works at a school needs to be able to show a Certificate of "
-"Conduct (VOG, see <a href=\"https://www.justis.nl/producten/vog/\" "
-"target=\"_blank\">https://www.justis.nl/producten/vog/</a>). It is the "
+"Conduct (VOG, see <a href=\"https://www.justis.nl/producten/vog/\" target="
+"\"_blank\">https://www.justis.nl/producten/vog/</a>). It is the "
 "responsibility of the school to verify if the employees have such a VOG. The "
 "role of the FEtC-H in this matter is just to inform the researchers that the "
 "school probably will ask about this certificate."
@@ -351,7 +351,7 @@ msgid "Gebruiksersnaam"
 msgstr "Username"
 
 #: main/templates/auth/user_detail.html:30
-#: proposals/templates/proposals/proposal_pdf.html:76
+#: proposals/templates/proposals/proposal_pdf.html:79
 msgid "E-mail"
 msgstr "E-mail"
 
@@ -382,7 +382,7 @@ msgstr "Phase"
 #: main/templates/auth/user_detail.html:55 proposals/api/views.py:23
 #: proposals/api/views.py:88 proposals/api/views.py:118
 #: proposals/api/views.py:168
-#: proposals/templates/proposals/vue_templates/proposal_list.html:157
+#: proposals/templates/proposals/vue_templates/proposal_list.html:150
 #: reviews/api/views.py:49 reviews/api/views.py:280 reviews/api/views.py:342
 #: reviews/templates/reviews/vue_templates/decision_list.html:153
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:95
@@ -747,14 +747,13 @@ msgstr ""
 "    We encountered an error while processing your request.\n"
 "     "
 
-#: main/templates/error/500.html:17      "
+#: main/templates/error/500.html:17
 msgid ""
 "Blijft dit probleem aanhouden? Neem dan contact op met het technisch beheer "
-"van de portal via <a href=\"mailto:portaldev.gw@uu.nl\" "
-"target=\"_blank\">portaldev.gw@uu.nl</a>. Maak hierbij zo veel mogelijk "
-"duidelijk wat je aan het doen was, en op welke pagina."
+"van de portal via <a href=\"mailto:portaldev.gw@uu.nl\" target=\"_blank"
+"\">portaldev.gw@uu.nl</a>. Maak hierbij zo veel mogelijk duidelijk wat je "
+"aan het doen was, en op welke pagina."
 msgstr ""
-"\n"
 "If this problem persists, please contact the technical support staff of the "
 "portal by email at <a href=\"mailto:portaldev.gw@uu.nl\">portaldev.gw@uu.nl</"
 "a>. Try to explain what you were doing and note the page that you were on, "
@@ -815,8 +814,8 @@ msgstr ""
 msgid ""
 "Het reglement van de <a href=\"https://fetc-gw.wp.hum.uu.nl/reglement-"
 "algemene-kamer/\" target=\"blank\">Algemene Kamer (AK)</a> of dat van de <a "
-"href=\"https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/\" "
-"target=\"blank\">Linguïstiek Kamer (LK)</a>."
+"href=\"https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/\" target="
+"\"blank\">Linguïstiek Kamer (LK)</a>."
 msgstr ""
 "The regulations of the <a href=\"https://fetc-gw.wp.hum.uu.nl/en/regulations-"
 "general-chamber-2/\" target=\"blank\">General Chamber</a> or those of the <a "
@@ -826,26 +825,26 @@ msgstr ""
 #: main/templates/main/index.html:78
 msgid ""
 "Gebruik de juiste (meest recente) <a href=\"https://intranet.uu.nl/"
-"documenten-ethische-toetsingscommissie-gw\" "
-"target=\"blank\">voorbeelddocumenten</a> voor de <em>informed consent</em>. "
-"(de laatstse versie is van <u>december 2021</u>)</li>"
+"documenten-ethische-toetsingscommissie-gw\" target=\"blank"
+"\">voorbeelddocumenten</a> voor de <em>informed consent</em>. (de laatstse "
+"versie is van <u>december 2021</u>)</li>"
 msgstr ""
 "Make sure to use the correct (most recent) <a href=\"https://intranet.uu.nl/"
-"en/documents-ethics-assessment-committee-humanities\" "
-"target=\"_blank\">model documents</a> for <em>informed consent</em>. (Latest "
-"version: <u>December 2021</u>)"
+"en/documents-ethics-assessment-committee-humanities\" target=\"_blank"
+"\">model documents</a> for <em>informed consent</em>. (Latest version: "
+"<u>December 2021</u>)"
 
 #: main/templates/main/index.html:82
 msgid ""
 "<li>Voor advies over data management (plannen): <a href=\"mailto:"
 "datamanagement.gw@uu.nl\">datamanagement.gw@uu.nl</a>.</li> <li>Voor advies "
 "over privacy zaken: <a href=\"mailto:privacy.gw@uu.nl\">privacy.gw@uu.nl</a>."
-"</li> <li>Voor vragen over de procedure: <a href=\"mailto:fetc-gw@uu."
-"nl\">Desiree Capel</a>.</li> <li>Voor vragen over de portal zelf: <a "
-"href=\"mailto:portaldev.gw@uu.nl\">portaldev.gw@uu.nl</a>.</li>"
+"</li> <li>Voor vragen over de procedure: <a href=\"mailto:fetc-gw@uu.nl"
+"\">Desiree Capel</a>.</li> <li>Voor vragen over de portal zelf: <a href="
+"\"mailto:portaldev.gw@uu.nl\">portaldev.gw@uu.nl</a>.</li>"
 msgstr ""
-"<li>For advice on data management: <a href=\"mailto:datamanagement.gw@uu."
-"nl\">datamanagement.gw@uu.nl</a>.</li> <li>For issues concerning privacy: <a "
+"<li>For advice on data management: <a href=\"mailto:datamanagement.gw@uu.nl"
+"\">datamanagement.gw@uu.nl</a>.</li> <li>For issues concerning privacy: <a "
 "href=\"mailto:privacy.gw@uu.nl\">privacy.gw@uu.nl</a>.</li> <li>For "
 "questions on FEtC-H procedure: <a href=\"mailto:fetc-gw@uu.nl\">Desiree "
 "Capel</a>.</li> <li>For questions about the functioning of the portal "
@@ -966,14 +965,14 @@ msgstr "Cover image by Simona Evsatieva"
 #, python-format
 msgid ""
 "\n"
-"                        Welkom bij het portal van de FETC-GW. Je kan <a "
-"href=\"%(the_url)s\">hier</a> inloggen met je\n"
+"                        Welkom bij het portal van de FETC-GW. Je kan <a href="
+"\"%(the_url)s\">hier</a> inloggen met je\n"
 "                        Solis-ID.\n"
 "                    "
 msgstr ""
 "\n"
-"\t Welcome to the FEtC-H web portal. You can sign in <a "
-"href=\"%(the_url)s\">here</a> with your Solis-ID.\n"
+"\t Welcome to the FEtC-H web portal. You can sign in <a href=\"%(the_url)s"
+"\">here</a> with your Solis-ID.\n"
 "\t     "
 
 #: main/templates/main/index.html:228
@@ -1097,7 +1096,7 @@ msgid ""
 msgstr "As might happen on forums where the researcher also has an account."
 
 #: observations/models.py:65 observations/models.py:75
-#: observations/models.py:88 proposals/models.py:534 studies/models.py:154
+#: observations/models.py:88 proposals/models.py:539 studies/models.py:154
 #: studies/models.py:188 studies/models.py:321
 msgid "Licht toe"
 msgstr "Explain"
@@ -1164,7 +1163,7 @@ msgstr "How many hours of observation will take place on average per day?"
 #: observations/templates/observations/observation_form.html:7
 #: observations/templates/observations/observation_form.html:44
 #: proposals/templates/proposals/diff/observation.html:4
-#: proposals/templates/proposals/proposal_pdf.html:262
+#: proposals/templates/proposals/proposal_pdf.html:265
 #: proposals/templates/proposals/proposal_pdf_empty.html:226
 msgid "Het observatieonderzoek"
 msgstr "Observational study"
@@ -1221,7 +1220,7 @@ msgstr "Date reviewed"
 #: proposals/api/views.py:31 proposals/api/views.py:73
 #: proposals/api/views.py:92 proposals/api/views.py:130
 #: proposals/api/views.py:151
-#: proposals/templates/proposals/vue_templates/proposal_list.html:112
+#: proposals/templates/proposals/vue_templates/proposal_list.html:105
 msgid "Laatst bijgewerkt"
 msgstr "Last edited"
 
@@ -1655,7 +1654,7 @@ msgid "Uitvoerende(n) (inclusief uzelf)"
 msgstr "Researcher(s) carrying out the study (including yourself)"
 
 #: proposals/models.py:369
-#: proposals/templates/proposals/vue_templates/proposal_list.html:170
+#: proposals/templates/proposals/vue_templates/proposal_list.html:163
 msgid "Eindverantwoordelijke onderzoeker"
 msgstr "Researcher with final responsibility"
 
@@ -1713,19 +1712,19 @@ msgstr "Practice"
 msgid "Extern getoetst"
 msgstr "External approval"
 
-#: proposals/models.py:519
+#: proposals/models.py:524
 msgid "Geen beoordeling door METC noodzakelijk"
 msgstr "Assessment by METC not required"
 
-#: proposals/models.py:520
+#: proposals/models.py:525
 msgid "In afwachting beslissing METC"
 msgstr "Pending decision by METC"
 
-#: proposals/models.py:521
+#: proposals/models.py:526
 msgid "Beslissing METC geüpload"
 msgstr "METC decision uploaded"
 
-#: proposals/models.py:525
+#: proposals/models.py:530
 msgid ""
 "Vindt de dataverzameling plaats binnen het UMC Utrecht of andere instelling "
 "waar toetsing door een METC verplicht is gesteld?"
@@ -1733,11 +1732,11 @@ msgstr ""
 "Will the data collection take place at the UMC Utrecht or another "
 "institution for which an assessment by a METC is required?"
 
-#: proposals/models.py:539
+#: proposals/models.py:544
 msgid "Welke instelling?"
 msgstr "Which institution?"
 
-#: proposals/models.py:545
+#: proposals/models.py:550
 msgid ""
 "Is de onderzoeksvraag medisch-wetenschappelijk van aard (zoals gedefinieerd "
 "door de WMO)?"
@@ -1745,7 +1744,7 @@ msgstr ""
 "Is the nature of the research question medical (as defined by the Medical "
 "Research Involving Human Subjects Act (WMO))?"
 
-#: proposals/models.py:547
+#: proposals/models.py:552
 msgid ""
 "De definitie van medisch-wetenschappelijk onderzoek is: Medisch-"
 "wetenschappelijk onderzoek is onderzoek dat als doel heeft het beantwoorden "
@@ -1766,7 +1765,7 @@ msgstr ""
 "Committee on Research Involving Human Subjects, Definition of medical "
 "research, 2005, ccmo.nl)"
 
-#: proposals/models.py:563
+#: proposals/models.py:568
 msgid ""
 "Je onderzoek moet beoordeeld worden door een METC, maar dient nog wel bij de "
 "FETC-GW te worden geregistreerd. Is dit onderzoek al aangemeld bij een METC?"
@@ -1775,15 +1774,15 @@ msgstr ""
 "registered with the FEtC-H. Has an application for this project already been "
 "submitted to an METC?"
 
-#: proposals/models.py:570
+#: proposals/models.py:575
 msgid "Is de METC al tot een beslissing gekomen?"
 msgstr "Has the METC already come to a decision?"
 
-#: proposals/models.py:575
+#: proposals/models.py:580
 msgid "Upload hier de beslissing van het METC (in .pdf of .doc(x)-formaat)"
 msgstr "Please upload the decision of METC  (in .pdf or .doc(x)-format) here"
 
-#: proposals/models.py:613
+#: proposals/models.py:618
 #, python-brace-format
 msgid "WMO {title}, status {status}"
 msgstr "WMO {title}, status {status}"
@@ -2000,17 +1999,17 @@ msgstr "yes,no,"
 #: proposals/templates/proposals/proposal_diff.html:178
 #: proposals/templates/proposals/proposal_diff.html:205
 #: proposals/templates/proposals/proposal_diff.html:206
-#: proposals/templates/proposals/proposal_pdf.html:90
-#: proposals/templates/proposals/proposal_pdf.html:106
-#: proposals/templates/proposals/proposal_pdf.html:160
+#: proposals/templates/proposals/proposal_pdf.html:93
+#: proposals/templates/proposals/proposal_pdf.html:109
 #: proposals/templates/proposals/proposal_pdf.html:163
-#: proposals/templates/proposals/proposal_pdf.html:182
-#: proposals/templates/proposals/proposal_pdf.html:201
-#: proposals/templates/proposals/proposal_pdf.html:210
-#: proposals/templates/proposals/proposal_pdf.html:294
-#: proposals/templates/proposals/proposal_pdf.html:298
-#: proposals/templates/proposals/proposal_pdf.html:334
-#: proposals/templates/proposals/proposal_pdf.html:408
+#: proposals/templates/proposals/proposal_pdf.html:166
+#: proposals/templates/proposals/proposal_pdf.html:185
+#: proposals/templates/proposals/proposal_pdf.html:204
+#: proposals/templates/proposals/proposal_pdf.html:213
+#: proposals/templates/proposals/proposal_pdf.html:297
+#: proposals/templates/proposals/proposal_pdf.html:301
+#: proposals/templates/proposals/proposal_pdf.html:337
+#: proposals/templates/proposals/proposal_pdf.html:411
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:78
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:88
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:70
@@ -2054,24 +2053,24 @@ msgstr ""
 #: proposals/templates/proposals/pdf/observation_v1.html:53
 #: proposals/templates/proposals/proposal_diff.html:184
 #: proposals/templates/proposals/proposal_diff.html:188
-#: proposals/templates/proposals/proposal_pdf.html:167
-#: proposals/templates/proposals/proposal_pdf.html:401
+#: proposals/templates/proposals/proposal_pdf.html:170
 #: proposals/templates/proposals/proposal_pdf.html:404
-#: proposals/templates/proposals/proposal_pdf.html:416
-#: proposals/templates/proposals/proposal_pdf.html:421
-#: proposals/templates/proposals/proposal_pdf.html:426
-#: proposals/templates/proposals/proposal_pdf.html:432
+#: proposals/templates/proposals/proposal_pdf.html:407
+#: proposals/templates/proposals/proposal_pdf.html:419
+#: proposals/templates/proposals/proposal_pdf.html:424
+#: proposals/templates/proposals/proposal_pdf.html:429
 #: proposals/templates/proposals/proposal_pdf.html:435
-#: proposals/templates/proposals/proposal_pdf.html:449
-#: proposals/templates/proposals/proposal_pdf.html:454
-#: proposals/templates/proposals/proposal_pdf.html:470
+#: proposals/templates/proposals/proposal_pdf.html:438
+#: proposals/templates/proposals/proposal_pdf.html:452
+#: proposals/templates/proposals/proposal_pdf.html:457
+#: proposals/templates/proposals/proposal_pdf.html:473
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:122
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:92
 msgid "Download"
 msgstr "Download"
 
 #: proposals/templates/proposals/diff/sessions.html:7
-#: proposals/templates/proposals/proposal_pdf.html:273
+#: proposals/templates/proposals/proposal_pdf.html:276
 #: proposals/templates/proposals/proposal_pdf_empty.html:276
 #: studies/templates/studies/session_start.html:7
 #: studies/templates/studies/session_start.html:17
@@ -2099,14 +2098,14 @@ msgstr ""
 "application does involve this."
 
 #: proposals/templates/proposals/diff/sessions.html:170
-#: proposals/templates/proposals/proposal_pdf.html:346
+#: proposals/templates/proposals/proposal_pdf.html:349
 #: proposals/templates/proposals/proposal_pdf_empty.html:332
 #: tasks/templates/tasks/task_end.html:7 tasks/templates/tasks/task_end.html:18
 msgid "Overzicht van het takenonderzoek"
 msgstr "Overview of task-based research"
 
 #: proposals/templates/proposals/diff/study.html:9
-#: proposals/templates/proposals/proposal_pdf.html:193
+#: proposals/templates/proposals/proposal_pdf.html:196
 #: proposals/templates/proposals/proposal_pdf_empty.html:142
 #: studies/templates/studies/study_form.html:7
 #: studies/templates/studies/study_form.html:102
@@ -2122,7 +2121,7 @@ msgid "Dit traject is weggehaald uit de revisie"
 msgstr "This trajectory was removed in this revision."
 
 #: proposals/templates/proposals/diff/study.html:131
-#: proposals/templates/proposals/proposal_pdf.html:356
+#: proposals/templates/proposals/proposal_pdf.html:359
 #: proposals/templates/proposals/proposal_pdf_empty.html:340
 #: studies/templates/studies/study_end.html:7
 #: studies/templates/studies/study_end.html:28
@@ -2248,8 +2247,8 @@ msgid ""
 "a> een amendement aan."
 msgstr ""
 "If you have changes to an already approved application that therefore needs "
-"to be re-reviewed, please make an amendment <a "
-"href=\"%(amendment_url)s\">here</a>."
+"to be re-reviewed, please make an amendment <a href=\"%(amendment_url)s"
+"\">here</a>."
 
 #: proposals/templates/proposals/proposal_copy.html:87
 msgid "Kopiëren"
@@ -2277,7 +2276,7 @@ msgstr ""
 "follow with regard to data."
 
 #: proposals/templates/proposals/proposal_data_management.html:24
-#: proposals/templates/proposals/proposal_pdf.html:462
+#: proposals/templates/proposals/proposal_pdf.html:465
 #: reviews/templatetags/documents_list.py:244
 msgid "Data Management Plan"
 msgstr "Data Management Plan"
@@ -2285,14 +2284,14 @@ msgstr "Data Management Plan"
 #: proposals/templates/proposals/proposal_data_management.html:27
 msgid ""
 "Een data management plan is sinds 2020 <a href=\"https://intranet.uu.nl/"
-"actueel/nieuws/nieuw-facultair-datamanagementbeleid\" "
-"target=\"_blank\">verplicht</a> bij de faculteit geesteswetenschappen, zowel "
-"als bij de instanties NWO en ERC als zij subsidie voor een onderzoek bieden."
+"actueel/nieuws/nieuw-facultair-datamanagementbeleid\" target=\"_blank"
+"\">verplicht</a> bij de faculteit geesteswetenschappen, zowel als bij de "
+"instanties NWO en ERC als zij subsidie voor een onderzoek bieden."
 msgstr ""
 "A data management plan is <a href=\"https://intranet.uu.nl/en/current-"
-"affairs/news/new-faculty-data-management-policy\" "
-"target=\"_blank\">required</a> by the Faculty of Humanities from 2020 "
-"onwards as well as by NWO or ERC if you are financed by these organizations. "
+"affairs/news/new-faculty-data-management-policy\" target=\"_blank"
+"\">required</a> by the Faculty of Humanities from 2020 onwards as well as by "
+"NWO or ERC if you are financed by these organizations. "
 
 #: proposals/templates/proposals/proposal_data_management.html:33
 msgid ""
@@ -2306,14 +2305,14 @@ msgid ""
 "gw@uu.nl\" target=\"_blank\">datamanager</a>."
 msgstr ""
 "The faculty provides information on <a href=\"https://intranet.uu.nl/en/"
-"current-affairs/news/new-faculty-data-management-policy\" "
-"target=\"_blank\">data management</a>, as well as on <a href=\"https://www."
-"uu.nl/en/research/research-data-management/guides/data-management-planning\" "
-"target=\"_blank\">how to write a Data Management Plan</a>. You can also have "
-"your plan reviewed, either by <a href=\"https://www.uu.nl/en/research/"
-"research-data-management/tools-services/data-management-plan-review\" "
-"target=\"_blank\">Research Data Management Support</a> or the faculty <a "
-"href=\"mailto:Datamanagement.gw@uu.nl\" target=\"_blank\">data manager</a>. "
+"current-affairs/news/new-faculty-data-management-policy\" target=\"_blank"
+"\">data management</a>, as well as on <a href=\"https://www.uu.nl/en/"
+"research/research-data-management/guides/data-management-planning\" target="
+"\"_blank\">how to write a Data Management Plan</a>. You can also have your "
+"plan reviewed, either by <a href=\"https://www.uu.nl/en/research/research-"
+"data-management/tools-services/data-management-plan-review\" target=\"_blank"
+"\">Research Data Management Support</a> or the faculty <a href=\"mailto:"
+"Datamanagement.gw@uu.nl\" target=\"_blank\">data manager</a>. "
 
 #: proposals/templates/proposals/proposal_data_management.html:38
 msgid ""
@@ -2341,11 +2340,11 @@ msgstr "If you have not already done so, it is highly recommended you attend: "
 
 #: proposals/templates/proposals/proposal_data_management.html:49
 msgid ""
-"<li> de workshop <a href=\"https://www.uu.nl/en/node/75859\" "
-"target=\"_blank\">Quick start to Research Data Management</a> </li>"
+"<li> de workshop <a href=\"https://www.uu.nl/en/node/75859\" target=\"_blank"
+"\">Quick start to Research Data Management</a> </li>"
 msgstr ""
-"<li>the workshop <a href=\"https://www.uu.nl/en/node/75859\" "
-"target=\"_blank\">Quick start to Research Data Management</a></li>"
+"<li>the workshop <a href=\"https://www.uu.nl/en/node/75859\" target=\"_blank"
+"\">Quick start to Research Data Management</a></li>"
 
 #: proposals/templates/proposals/proposal_data_management.html:58
 msgid ""
@@ -2354,9 +2353,9 @@ msgid ""
 "datamanagement.gw@uu.nl\" target=\"_blank\">datamanagement.gw@uu.nl</a>."
 msgstr ""
 "For advice on data management planning you can also contact Frans de Liagre "
-"Böhl at <a href=\"mailto:Datamanagement.gw@uu.nl\" "
-"target=\"_blank\">datamanagement.gw@uu.nl</a>, who is the data manager of "
-"the Faculty of Humanities."
+"Böhl at <a href=\"mailto:Datamanagement.gw@uu.nl\" target=\"_blank"
+"\">datamanagement.gw@uu.nl</a>, who is the data manager of the Faculty of "
+"Humanities."
 
 #: proposals/templates/proposals/proposal_data_management.html:62
 msgid "Privacy: AVG en GDPR"
@@ -2369,11 +2368,11 @@ msgid ""
 "Nederlandse implementatie van het Europese <a href=\"https://gdpr.eu/\" "
 "target=\"_blank\">GDPR</a>."
 msgstr ""
-"When you collect personal data, make sure you comply with the Dutch <a "
-"href=\"https://business.gov.nl/regulation/protection-personal-data/\" "
-"target=\"_blank\">Algemene Verordening Persoonsgegevens</a>, or AVG. This "
-"regulation is in line with European <a href=\"https://gdpr.eu/\" "
-"target=\"_blank\">GDPR privacy legislation</a>."
+"When you collect personal data, make sure you comply with the Dutch <a href="
+"\"https://business.gov.nl/regulation/protection-personal-data/\" target="
+"\"_blank\">Algemene Verordening Persoonsgegevens</a>, or AVG. This "
+"regulation is in line with European <a href=\"https://gdpr.eu/\" target="
+"\"_blank\">GDPR privacy legislation</a>."
 
 #: proposals/templates/proposals/proposal_data_management.html:70
 msgid ""
@@ -2390,11 +2389,11 @@ msgstr ""
 
 #: proposals/templates/proposals/proposal_data_management.html:81
 msgid ""
-"<li> de workshop <a href=\"https://www.uu.nl/en/node/81799\" "
-"target=\"_blank\">Handling personal data in research</a> </li>"
+"<li> de workshop <a href=\"https://www.uu.nl/en/node/81799\" target=\"_blank"
+"\">Handling personal data in research</a> </li>"
 msgstr ""
-"<li>the workshop <a href=\"https://www.uu.nl/en/node/81799\" "
-"target=\"_blank\">Handling personal data in research</a></li>"
+"<li>the workshop <a href=\"https://www.uu.nl/en/node/81799\" target=\"_blank"
+"\">Handling personal data in research</a></li>"
 
 #: proposals/templates/proposals/proposal_data_management.html:89
 msgid ""
@@ -2424,7 +2423,7 @@ msgstr ""
 #: proposals/templates/proposals/proposal_form.html:95
 #: proposals/templates/proposals/proposal_form_pre_approved.html:7
 #: proposals/templates/proposals/proposal_form_pre_approved.html:83
-#: proposals/templates/proposals/proposal_pdf.html:79
+#: proposals/templates/proposals/proposal_pdf.html:82
 #: proposals/templates/proposals/proposal_pdf_empty.html:60
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:60
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:59
@@ -2438,14 +2437,14 @@ msgstr "General information about the application"
 
 #: proposals/templates/proposals/proposal_diff.html:94
 #: proposals/templates/proposals/proposal_diff.html:95
-#: proposals/templates/proposals/proposal_pdf.html:114
+#: proposals/templates/proposals/proposal_pdf.html:117
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:98
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:86
 msgid "onbekend"
 msgstr "unknown"
 
 #: proposals/templates/proposals/proposal_diff.html:130
-#: proposals/templates/proposals/proposal_pdf.html:137
+#: proposals/templates/proposals/proposal_pdf.html:140
 #: proposals/templates/proposals/proposal_pdf_empty.html:101
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:97
 #: proposals/templates/proposals/wmo_form.html:7
@@ -2456,7 +2455,7 @@ msgstr ""
 "Ethical assessment by a Medical Ethical Testing Committee (METC) required?"
 
 #: proposals/templates/proposals/proposal_diff.html:163
-#: proposals/templates/proposals/proposal_pdf.html:157
+#: proposals/templates/proposals/proposal_pdf.html:160
 #: proposals/templates/proposals/proposal_pdf_empty.html:117
 #: proposals/templates/proposals/wmo_application.html:7
 #: proposals/templates/proposals/wmo_application.html:27
@@ -2464,7 +2463,7 @@ msgid "Aanmelding bij de METC"
 msgstr "Registration with the METC"
 
 #: proposals/templates/proposals/proposal_diff.html:196
-#: proposals/templates/proposals/proposal_pdf.html:179
+#: proposals/templates/proposals/proposal_pdf.html:182
 #: proposals/templates/proposals/proposal_pdf_empty.html:131
 #: proposals/templates/proposals/study_start.html:7
 #: proposals/templates/proposals/study_start.html:64
@@ -2515,8 +2514,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Dit formulier is bedoeld voor aanvragen die al goedgekeurd zijn door een "
-"andere commissie. Indien dit niet het geval is, dien je het <a "
-"href=\"%(proposal_url)s\">normale formulier</a> in te vullen."
+"andere commissie. Indien dit niet het geval is, dien je het <a href="
+"\"%(proposal_url)s\">normale formulier</a> in te vullen."
 msgstr ""
 "his form is meant for applications that have already been approved by a "
 "different committee. If this is not the case, you are required to fill in "
@@ -2621,24 +2620,28 @@ msgstr ""
 "            "
 
 #: proposals/templates/proposals/proposal_pdf.html:70
+msgid "Huidige staat van de aanvraag"
+msgstr "Current state of the application"
+
+#: proposals/templates/proposals/proposal_pdf.html:73
 msgid "Indiener"
 msgstr "Applicant"
 
-#: proposals/templates/proposals/proposal_pdf.html:73
+#: proposals/templates/proposals/proposal_pdf.html:76
 #: tasks/templates/tasks/task_list.html:7
 msgid "Naam"
 msgstr "Name"
 
-#: proposals/templates/proposals/proposal_pdf.html:172
+#: proposals/templates/proposals/proposal_pdf.html:175
 msgid "Niet aangeleverd"
 msgstr "Not provided"
 
-#: proposals/templates/proposals/proposal_pdf.html:444
+#: proposals/templates/proposals/proposal_pdf.html:447
 #: proposals/templates/proposals/study_consent.html:122
 msgid "Extra formulieren"
 msgstr "Additional forms"
 
-#: proposals/templates/proposals/proposal_pdf.html:476
+#: proposals/templates/proposals/proposal_pdf.html:479
 #: proposals/templates/proposals/proposal_pdf_empty.html:386
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:129
 #: proposals/templates/proposals/proposal_submit.html:139
@@ -2738,8 +2741,8 @@ msgid ""
 "<em>informed consent</em>."
 msgstr ""
 "Make sure to use the correct (most recent) <a href=\"https://intranet.uu.nl/"
-"en/documents-ethics-assessment-committee-humanities\" "
-"target=\"_blank\">model documents</a> for <em>informed consent</em>."
+"en/documents-ethics-assessment-committee-humanities\" target=\"_blank"
+"\">model documents</a> for <em>informed consent</em>."
 
 #: proposals/templates/proposals/proposal_start.html:40
 #: proposals/templates/proposals/proposal_start_practice.html:42
@@ -2854,31 +2857,30 @@ msgstr ""
 "has     already been approved by a different ethics committee. It is "
 "therefore <em>necessary</em> to be familiar with the FEtC-H regulations. "
 "Please refer to the FEtC-H website for the regulations of <a href=\"https://"
-"fetc-gw.wp.hum.uu.nl/en/regulations-general-chamber-2/\" "
-"target=\"_blank\">the  General Chamber</a> and <a href=\"https://fetc-gw.wp."
-"hum.uu.nl/en/regulations-linguistics-chamber/\" target=\"_blank\">the "
-"Linguistics Chamber</a>. You can save yourself and the committee members a "
-"great deal of time by making sure you are properly informed."
+"fetc-gw.wp.hum.uu.nl/en/regulations-general-chamber-2/\" target=\"_blank"
+"\">the  General Chamber</a> and <a href=\"https://fetc-gw.wp.hum.uu.nl/en/"
+"regulations-linguistics-chamber/\" target=\"_blank\">the Linguistics "
+"Chamber</a>. You can save yourself and the committee members a great deal of "
+"time by making sure you are properly informed."
 
 #: proposals/templates/proposals/proposal_start_pre_approved.html:30
 #, python-format
 msgid ""
 "Gebruik bij het invullen s.v.p. geen afkortingen waar de FETC-GW wellicht "
-"niet mee bekend is. Raadpleeg bij vragen eerst het reglement van de <a "
-"href=\"http://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/\" "
-"target=\"_blank\"> Algemene Kamer (AK)</a> of de <a href=\"http://fetc-gw.wp."
-"hum.uu.nl/reglement-linguistiek-kamer/\" target=\"_blank\">Linguïstiek Kamer "
-"(LK)</a>, en neem eventueel daarna contact op met de secretaris "
-"(%(secretary_name)s, <a href=\"mailto:fetc-gw@uu.nl\">fetc-gw@uu.nl</a>)."
+"niet mee bekend is. Raadpleeg bij vragen eerst het reglement van de <a href="
+"\"http://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/\" target=\"_blank\"> "
+"Algemene Kamer (AK)</a> of de <a href=\"http://fetc-gw.wp.hum.uu.nl/"
+"reglement-linguistiek-kamer/\" target=\"_blank\">Linguïstiek Kamer (LK)</a>, "
+"en neem eventueel daarna contact op met de secretaris (%(secretary_name)s, "
+"<a href=\"mailto:fetc-gw@uu.nl\">fetc-gw@uu.nl</a>)."
 msgstr ""
 "When filling in the forms please avoid using abbreviations the FEtC-Hmight "
 "not be familiar with.If you have questions, first consult the regulations of "
 "the <a href=\"https://fetc-gw.wp.hum.uu.nl/en/regulations-general-chamber-2/"
 "\" target=\"_blank\">General Chamber</a> or the <a href=\"https://fetc-gw.wp."
-"hum.uu.nl/en/regulations-linguistics-chamber/\" "
-"target=\"_blank\">Linguistics Chamber</a>,and if necessary contact the "
-"secretary (%(secretary_name)s,<a href=\"mailto:fetc-gw@uu.nl\">fetc-gw@uu."
-"nl</a>)."
+"hum.uu.nl/en/regulations-linguistics-chamber/\" target=\"_blank"
+"\">Linguistics Chamber</a>,and if necessary contact the secretary "
+"(%(secretary_name)s,<a href=\"mailto:fetc-gw@uu.nl\">fetc-gw@uu.nl</a>)."
 
 #: proposals/templates/proposals/proposal_start_pre_assessment.html:7
 msgid "Toetsing voor subsidieaanvraag"
@@ -3029,17 +3031,16 @@ msgid ""
 "en terug te vinden onder \"Mijn concepten\"."
 msgstr ""
 "You have not yet added a declaration of consent or information letter for "
-"trajectory %(study_order)s. You can add these on <a "
-"href=\"%(consent_link)s\">this page</a>. If these forms are not yet ready, "
-"you can return later; your application has already been saved and can be "
-"found under \"My drafts\"."
+"trajectory %(study_order)s. You can add these on <a href=\"%(consent_link)s"
+"\">this page</a>. If these forms are not yet ready, you can return later; "
+"your application has already been saved and can be found under \"My drafts\"."
 
 #: proposals/templates/proposals/proposal_submit.html:91
 #, python-format
 msgid ""
 "Je hebt aangeven dat je interventie een extra taak heeft, maar nog geen "
-"taakonderzoek toegevoegd voor traject %(study_order)s. Die kan je op <a "
-"href=\"%(study_link)s\">deze pagina</a> alsnog aanmaken."
+"taakonderzoek toegevoegd voor traject %(study_order)s. Die kan je op <a href="
+"\"%(study_link)s\">deze pagina</a> alsnog aanmaken."
 msgstr ""
 "You have indicated that your intervention study contains an extra task, but "
 "the task-based research form is missing for trajectory %(study_order)s.You "
@@ -3121,13 +3122,12 @@ msgstr ""
 #: proposals/templates/proposals/study_consent.html:79
 msgid ""
 "Gebruik de juiste (meest recente) <a href=\"https://intranet.uu.nl/"
-"documenten-ethische-toetsingscommissie-gw\" "
-"target=\"blank\">voorbeelddocumenten</a> voor de <em>informed consent</em>. "
-"</li>"
+"documenten-ethische-toetsingscommissie-gw\" target=\"blank"
+"\">voorbeelddocumenten</a> voor de <em>informed consent</em>. </li>"
 msgstr ""
 "Make sure to use the correct (most recent) <a href=\"https://intranet.uu.nl/"
-"en/documents-ethics-assessment-committee-humanities\" "
-"target=\"_blank\">model documents</a> for <em>informed consent</em>."
+"en/documents-ethics-assessment-committee-humanities\" target=\"_blank"
+"\">model documents</a> for <em>informed consent</em>."
 
 #: proposals/templates/proposals/study_consent.html:89
 msgid ""
@@ -3172,43 +3172,42 @@ msgstr "Decide"
 msgid "Naar volgende stap"
 msgstr "To next step"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:74
-#: proposals/templates/proposals/vue_templates/proposal_list.html:82
+#: proposals/templates/proposals/vue_templates/proposal_list.html:75
 msgid "Inzien"
 msgstr "Show"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:90
+#: proposals/templates/proposals/vue_templates/proposal_list.html:83
 msgid "Verberg"
 msgstr "Hide"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:97
+#: proposals/templates/proposals/vue_templates/proposal_list.html:90
 msgid "Soort aanvraag"
 msgstr "Type of application"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:106
+#: proposals/templates/proposals/vue_templates/proposal_list.html:99
 msgid "Besloten op"
 msgstr "Concluded on"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:119
+#: proposals/templates/proposals/vue_templates/proposal_list.html:112
 msgid "Status"
 msgstr "State"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:143
+#: proposals/templates/proposals/vue_templates/proposal_list.html:136
 #: reviews/templates/reviews/vue_templates/decision_list.html:141
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:83
 #: reviews/templates/reviews/vue_templates/review_list.html:126
 msgid "Revisie/amendement van"
 msgstr "Revision/amendment of"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:165
+#: proposals/templates/proposals/vue_templates/proposal_list.html:158
 msgid "Nog niet ingediend"
 msgstr "Not yet submitted"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:184
+#: proposals/templates/proposals/vue_templates/proposal_list.html:177
 msgid "Route:"
 msgstr "Route:"
 
-#: proposals/templates/proposals/vue_templates/proposal_list.html:191
+#: proposals/templates/proposals/vue_templates/proposal_list.html:184
 #: reviews/templates/reviews/vue_templates/decision_list.html:185
 #: reviews/templates/reviews/vue_templates/decision_list_reviewer.html:128
 #: reviews/templates/reviews/vue_templates/review_list.html:171
@@ -3537,8 +3536,8 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                Klik op <img src=\"%(img_diff)s\" title=\"Toon "
-"verschillen\"> om de verschillen met de voorgaande\n"
+"                Klik op <img src=\"%(img_diff)s\" title=\"Toon verschillen"
+"\"> om de verschillen met de voorgaande\n"
 "                versie te zien (alleen beschikbaar voor revisies/"
 "amendementen).\n"
 "            "
@@ -3598,8 +3597,8 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Klik op <img src=\"%(img_add_reviewers)s\" "
-"title=\"Aanstellen\"> om beoordelaars aan te stellen.\n"
+"                    Klik op <img src=\"%(img_add_reviewers)s\" title="
+"\"Aanstellen\"> om beoordelaars aan te stellen.\n"
 "                "
 msgstr ""
 "\n"
@@ -3611,14 +3610,14 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Klik op <img src=\"%(img_change_chamber)s\" "
-"title=\"Verplaats naar andere kamer\"> om een aanvraag\n"
+"                    Klik op <img src=\"%(img_change_chamber)s\" title="
+"\"Verplaats naar andere kamer\"> om een aanvraag\n"
 "                    te verplaatsen naar een andere kamer.\n"
 "                "
 msgstr ""
 "\n"
-"                    Click on <img src=\"%(img_change_chamber)s\" "
-"title=\"Move to other chamber\"> to move an application \n"
+"                    Click on <img src=\"%(img_change_chamber)s\" title="
+"\"Move to other chamber\"> to move an application \n"
 "                    to a different chamber.\n"
 "                "
 
@@ -3639,14 +3638,14 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Klik op <img src=\"%(img_confirm)s\" "
-"title=\"Bevestigingsbrief\"> om aan te geven dat de\n"
+"                    Klik op <img src=\"%(img_confirm)s\" title="
+"\"Bevestigingsbrief\"> om aan te geven dat de\n"
 "                    bevestigingsbrief is verstuurd.\n"
 "                "
 msgstr ""
 "\n"
-"                    Click on <img src=\"%(img_confirm)s\" "
-"title=\"Confirmation letter\"> to note that the\n"
+"                    Click on <img src=\"%(img_confirm)s\" title="
+"\"Confirmation letter\"> to note that the\n"
 "                    confirmation letter has been sent.\n"
 "                "
 
@@ -3654,14 +3653,14 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Klik op <img src=\"%(img_confirmed)s\" "
-"title=\"Bevestigingsbrief\"> om de opgegeven datum\n"
+"                    Klik op <img src=\"%(img_confirmed)s\" title="
+"\"Bevestigingsbrief\"> om de opgegeven datum\n"
 "                    van de bevestigingsbrief te veranderen.\n"
 "                "
 msgstr ""
 "\n"
-"                    Click on <img src=\"%(img_confirmed)s\" "
-"title=\"Confirmation letter\"> to change the date of \n"
+"                    Click on <img src=\"%(img_confirmed)s\" title="
+"\"Confirmation letter\"> to change the date of \n"
 "                    the confirmation letter.\n"
 "                "
 
@@ -3706,8 +3705,8 @@ msgstr "Assess the application"
 #, python-format
 msgid ""
 "Je kunt nu een go of no-go geven voor de aanvraag <em>%(title)s</em>, "
-"%(refnum)s in %(chamber)s. De aanvraag is <a href=\"%(pdf_url)s\" "
-"target=\"_blank\">hier</a> in te zien (downloadt als PDF)."
+"%(refnum)s in %(chamber)s. De aanvraag is <a href=\"%(pdf_url)s\" target="
+"\"_blank\">hier</a> in te zien (downloadt als PDF)."
 msgstr ""
 "    You can now give a go or no-go for the application <em>%(title)s</em>, "
 "%(refnum)s in %(chamber)s.\n"
@@ -3786,8 +3785,8 @@ msgid ""
 msgstr ""
 "\n"
 "    This is a revision or amendment of a previous application. You can check "
-"the differences compared to the previous application <a "
-"href=\"%(diff_url)s\">here</a>.\n"
+"the differences compared to the previous application <a href=\"%(diff_url)s"
+"\">here</a>.\n"
 "    "
 
 #: reviews/templates/reviews/decision_form.html:93
@@ -3860,8 +3859,8 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Details van besluitvorming bij aanmelding "
-"<em>%(proposal)s</em>\n"
+"                    Details van besluitvorming bij aanmelding <em>"
+"%(proposal)s</em>\n"
 "                "
 msgstr ""
 "\n"
@@ -4310,6 +4309,37 @@ msgstr "Pending decisions committee members"
 #: reviews/views.py:90
 msgid "Openstaande besluiten eindverantwoordelijken"
 msgstr "Pending decisions supervisors"
+
+#: src/uil-django-core/uil/rest_client/clients/_base.py:104
+#: src/uil-django-core/uil/rest_client/clients/_base.py:107
+msgid "api:host_unreachable"
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:28
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:29
+msgid "This field cannot be null."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:30
+msgid "This field cannot be blank."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:31
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: src/uil-django-core/uil/rest_client/fields.py:35
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
 
 #: studies/forms.py:38
 msgid ""
@@ -4852,8 +4882,8 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"                    Deelnemers uit de leeftijdscategorieën "
-"<em>%(age_groups)s</em>\n"
+"                    Deelnemers uit de leeftijdscategorieën <em>"
+"%(age_groups)s</em>\n"
 "                "
 msgstr ""
 "\n"
@@ -5369,4 +5399,3 @@ msgstr "Task edited"
 #: tasks/views/task_views.py:50
 msgid "Taak verwijderd"
 msgstr "Task deleted"
-

--- a/proposals/models.py
+++ b/proposals/models.py
@@ -505,11 +505,6 @@ bij dit onderzoek?'),
 
         return Review.objects.filter(proposal=self).last()
 
-    def get_status_display(self):
-        "Return the proposal's status readably"
-
-        return dict(self.STATUSES)[self.status]
-
     def __str__(self):
         if self.is_practice():
             return '{} ({}) (Practice)'.format(self.title, self.created_by)

--- a/proposals/models.py
+++ b/proposals/models.py
@@ -505,6 +505,11 @@ bij dit onderzoek?'),
 
         return Review.objects.filter(proposal=self).last()
 
+    def get_status_display(self):
+        "Return the proposal's status readably"
+
+        return dict(self.STATUSES)[self.status]
+
     def __str__(self):
         if self.is_practice():
             return '{} ({}) (Practice)'.format(self.title, self.created_by)

--- a/proposals/templates/proposals/proposal_pdf.html
+++ b/proposals/templates/proposals/proposal_pdf.html
@@ -67,6 +67,9 @@ Page <pdf:pagenumber /> of <pdf:pagecount />
             Referentienummer {{ reference_number }}
             {% endblocktrans %}
         </h1>
+	<p>{% trans 'Huidige staat van de aanvraag' %}: <em>{{proposal.get_status_display}}</em>
+	</p>
+	
         <h2>{% trans 'Indiener' %}</h2>
         <table>
             <tr>

--- a/proposals/templates/proposals/vue_templates/proposal_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_list.html
@@ -65,7 +65,7 @@
                 </a>
             </template>
 <template
-                v-if="proposal.status > context.proposal.SUBMITTED_TO_SUPERVISOR"
+                v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
 >
             <a
                 :href="$url('proposals:pdf', [proposal.pk])"

--- a/proposals/templates/proposals/vue_templates/proposal_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_list.html
@@ -64,24 +64,17 @@
                          title="{% trans 'Verwijderen' %}">
                 </a>
             </template>
-
+<template
+                v-if="proposal.status > context.proposal.SUBMITTED_TO_SUPERVISOR"
+>
             <a
                 :href="$url('proposals:pdf', [proposal.pk])"
                 target="_blank"
-                v-if="proposal.pdf"
             >
                 <img src="{{ img_pdf }}"
                      title="{% trans 'Inzien' %}">
             </a>
-            <a
-                v-else
-                :href="$url('proposals:pdf', [proposal.pk])"
-                target="_blank"
-            >
-                <img src="{{ img_pdf }}"
-                         title="{% trans 'Inzien' %}">
-            </a>
-
+</template>
             <a
                 :href="$url('proposals:archive_hide', [proposal.pk])"
                 v-if="proposal.in_archive && context.is_secretary"

--- a/proposals/templates/proposals/vue_templates/proposal_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_list.html
@@ -64,17 +64,14 @@
                          title="{% trans 'Verwijderen' %}">
                 </a>
             </template>
-<template
-                v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
->
             <a
+                v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
                 :href="$url('proposals:pdf', [proposal.pk])"
                 target="_blank"
             >
                 <img src="{{ img_pdf }}"
                      title="{% trans 'Inzien' %}">
             </a>
-</template>
             <a
                 :href="$url('proposals:archive_hide', [proposal.pk])"
                 v-if="proposal.in_archive && context.is_secretary"


### PR DESCRIPTION
This removes the PDF link for draft proposals. Because this does not entirely solve the problem of PDFs looking a little too official, I've added a status line to the top of the proposal PDF template. This should tell anyone viewing the PDF if this proposal was actually accepted.

This also includes a new Proposal method that returns the status as a translated string. Useful for templates and the like. I've named it the same as the equivalent method in Vue.