### PR TITLE
Feature/start date warning

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-27 14:42+0200\n"
+"POT-Creation-Date: 2022-08-12 15:17+0200\n"
 "PO-Revision-Date: 2020-10-07 11:22+0200\n"
 "Last-Translator: Anna Asbury <anna.asbury@annaasbury.com>\n"
 "Language-Team: \n"
@@ -311,8 +311,8 @@ msgid "Geef aan waar de dataverzameling plaatsvindt"
 msgstr "Specify where the data collection will take place"
 
 #: main/models.py:67 observations/models.py:127 proposals/models.py:171
-#: studies/models.py:168 studies/models.py:201 tasks/models.py:147
-#: tasks/models.py:159
+#: studies/models.py:168 studies/models.py:201 tasks/models.py:153
+#: tasks/models.py:165
 msgid "Namelijk"
 msgstr "Please specify"
 
@@ -524,27 +524,27 @@ msgid "Maak een amendement van een al goedgekeurde aanvraag"
 msgstr "Create an amendment to an already approved application"
 
 #: main/templates/base/menu.html:32 proposals/menus.py:56
-#: proposals/views/proposal_views.py:71
+#: proposals/views/proposal_views.py:73
 msgid "Mijn conceptaanvragen"
 msgstr "My draft applications"
 
 #: main/templates/base/menu.html:35 proposals/menus.py:60
-#: proposals/views/proposal_views.py:121
+#: proposals/views/proposal_views.py:123
 msgid "Mijn oefenaanvragen"
 msgstr "My practice applications"
 
 #: main/templates/base/menu.html:38 proposals/menus.py:64
-#: proposals/views/proposal_views.py:83
+#: proposals/views/proposal_views.py:85
 msgid "Mijn ingediende aanvragen"
 msgstr "My submitted applications"
 
 #: main/templates/base/menu.html:41 proposals/menus.py:68
-#: proposals/views/proposal_views.py:95
+#: proposals/views/proposal_views.py:97
 msgid "Mijn afgehandelde aanvragen"
 msgstr "My processed applications"
 
 #: main/templates/base/menu.html:44 proposals/menus.py:72
-#: proposals/views/proposal_views.py:107
+#: proposals/views/proposal_views.py:109
 msgid "Mijn aanvragen als eindverantwoordelijke"
 msgstr "My supervised applications"
 
@@ -1322,7 +1322,8 @@ msgid ""
 "Dit veld is verplicht, maar je kunt later terugkomen om "
 "hem                     verder in te vullen."
 msgstr ""
-"This field is required, but you may choose to come back to this page later to fill it in."
+"This field is required, but you may choose to come back to this page later "
+"to fill it in."
 
 #: proposals/forms.py:220
 msgid ""
@@ -2545,7 +2546,7 @@ msgid "Eén of meerdere trajecten?"
 msgstr "One or more trajectories?"
 
 #: proposals/templates/proposals/proposal_diff.html:225
-#: proposals/templates/proposals/proposal_submit.html:137
+#: proposals/templates/proposals/proposal_submit.html:157
 msgid "Concept-aanmelding versturen"
 msgstr "Submit draft application"
 
@@ -2555,7 +2556,7 @@ msgid "Aantal woorden:"
 msgstr "Number of words:"
 
 #: proposals/templates/proposals/proposal_form.html:92
-#: proposals/templates/proposals/proposal_submit.html:126
+#: proposals/templates/proposals/proposal_submit.html:146
 msgid ""
 "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling "
 "door de FETC-GW worden ingediend."
@@ -2572,6 +2573,14 @@ msgstr ""
 "You are editing a application from a student/PhD candidate under your "
 "supervision. Please note that this form should be filled in as if you were "
 "that student/PhD candidate. "
+
+#: proposals/templates/proposals/proposal_form.html:129
+msgid ""
+"Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag "
+"ligt, kan de FETC geen officiële goedkeuring meer geven."
+msgstr ""
+"If the intended start date lies within two weeks of submission, the FETC-H "
+"will not be able to provide official approval for this proposal."
 
 #: proposals/templates/proposals/proposal_form_pre_approved.html:85
 msgid ""
@@ -2717,7 +2726,7 @@ msgstr "Additional forms"
 #: proposals/templates/proposals/proposal_pdf.html:482
 #: proposals/templates/proposals/proposal_pdf_empty.html:386
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:129
-#: proposals/templates/proposals/proposal_submit.html:139
+#: proposals/templates/proposals/proposal_submit.html:159
 msgid "Aanmelding versturen"
 msgstr "Submit application"
 
@@ -2784,7 +2793,7 @@ msgstr ""
 "    "
 
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:117
-#: proposals/templates/proposals/proposal_submit.html:133
+#: proposals/templates/proposals/proposal_submit.html:153
 msgid "Aanvraag voor voortoetsing versturen"
 msgstr "Submit application for preliminary assessment"
 
@@ -3119,11 +3128,11 @@ msgstr ""
 "the task-based research form is missing for trajectory %(study_order)s.You "
 "can add it on <a href=\"%(study_link)s\">this page</a>."
 
-#: proposals/templates/proposals/proposal_submit.html:105
+#: proposals/templates/proposals/proposal_submit.html:106
 msgid "Er zijn nog errors gevonden op de volgende pagina's:"
 msgstr "Errors were found on the following pages:"
 
-#: proposals/templates/proposals/proposal_submit.html:117
+#: proposals/templates/proposals/proposal_submit.html:119
 msgid ""
 "Dit komt waarschijnlijk doordat je nog niet alle verplichte velden heeft "
 "ingevuld. Je kan je aanmelding pas versturen wanneer deze fouten "
@@ -3132,7 +3141,30 @@ msgstr ""
 "This is probably because you have not yet filled in all required fields. You "
 "can submit your application when these errors have been corrected."
 
-#: proposals/templates/proposals/proposal_submit.html:135
+#: proposals/templates/proposals/proposal_submit.html:127
+msgid "Controleer uw beoogde startdatum"
+msgstr "Check your intended start date"
+
+#: proposals/templates/proposals/proposal_submit.html:129
+msgid ""
+"Omdat de beoogde startdatum binnen twee weken van vandaag ligt, kan de FETC "
+"helaas geen officiële goedkeuring meer geven voor deze aanvraag. Controleer "
+"daarom bij een revisie altijd of de beoogde startdatum nog klopt."
+msgstr ""
+"Because the intended start date of research activities lies within two weeks "
+"of today, the FETC-H will not be able to provide official approval for this proposal. Please "
+"make sure the entered date is still correct."
+
+#: proposals/templates/proposals/proposal_submit.html:133
+#, python-format
+msgid ""
+"De beoogde startdatum vindt u op <a href=\"%(first_page_url)s\">deze pagina</"
+"a>."
+msgstr ""
+"The intended start date can be edited on <a href=\"%(first_page_url)s\">this "
+"page</a>."
+
+#: proposals/templates/proposals/proposal_submit.html:155
 msgid "Terug naar beoordeling >>"
 msgstr "Back to review >>"
 
@@ -3392,40 +3424,40 @@ msgstr ""
 "You must confirm your understanding of the AVG before you can submit your "
 "application."
 
-#: proposals/views/proposal_views.py:38 proposals/views/proposal_views.py:143
+#: proposals/views/proposal_views.py:40 proposals/views/proposal_views.py:145
 msgid "Publiek archief"
 msgstr "Public archive"
 
-#: proposals/views/proposal_views.py:39
+#: proposals/views/proposal_views.py:41
 msgid "Dit overzicht toont alle goedgekeurde aanvragen."
 msgstr "This overview shows all approved applications."
 
-#: proposals/views/proposal_views.py:58
+#: proposals/views/proposal_views.py:60
 msgid "Mijn aanvraag"
 msgstr "My application"
 
-#: proposals/views/proposal_views.py:59
+#: proposals/views/proposal_views.py:61
 msgid "Dit overzicht toont al je aanvragen."
 msgstr "This overview shows all your applications."
 
-#: proposals/views/proposal_views.py:72
+#: proposals/views/proposal_views.py:74
 msgid "Dit overzicht toont al je nog niet ingediende aanvragen."
 msgstr "This overview shows all the applications you have not yet submitted."
 
-#: proposals/views/proposal_views.py:84
+#: proposals/views/proposal_views.py:86
 msgid "Dit overzicht toont al je ingediende aanvragen."
 msgstr "This overview shows all the applications you have submitted."
 
-#: proposals/views/proposal_views.py:96
+#: proposals/views/proposal_views.py:98
 msgid "Dit overzicht toont al je beoordeelde aanvragen."
 msgstr "This overview shows all your applications that have been assessed."
 
-#: proposals/views/proposal_views.py:109
+#: proposals/views/proposal_views.py:111
 msgid ""
 "Dit overzicht toont alle aanvragen waarvan je eindverantwoordelijke bent."
 msgstr "This overview shows all your supervised applications."
 
-#: proposals/views/proposal_views.py:122
+#: proposals/views/proposal_views.py:124
 msgid ""
 "Dit overzicht toont alle oefenaanvragen waar je als student, onderzoeker of "
 "eindverantwoordelijke bij betrokken bent."
@@ -3433,15 +3465,15 @@ msgstr ""
 "This overview shows all practice applications in which you are involved as a "
 "student, researcher or accountable researcher."
 
-#: proposals/views/proposal_views.py:229
+#: proposals/views/proposal_views.py:234
 msgid "Aanvraag verwijderd"
 msgstr "Application deleted"
 
-#: proposals/views/proposal_views.py:340
+#: proposals/views/proposal_views.py:345
 msgid "Wijzigingen opgeslagen"
 msgstr "Changes saved"
 
-#: proposals/views/proposal_views.py:428
+#: proposals/views/proposal_views.py:444
 msgid "Aanvraag gekopieerd"
 msgstr "Application copied"
 
@@ -5227,7 +5259,7 @@ msgstr "All fields can be edited after copying."
 msgid "Te kopiëren sessie"
 msgstr "Session to be copied"
 
-#: tasks/forms.py:101 tasks/models.py:131
+#: tasks/forms.py:101 tasks/models.py:137
 msgid ""
 "Wat is de duur van deze taak van begin tot eind in <strong>minuten</strong>, "
 "dus vanaf het moment dat de taak van start gaat tot en met het einde van de "
@@ -5278,19 +5310,19 @@ msgstr ""
 "task, breaks between tasks, and debriefing? (in case of a lab visit from "
 "entering the lab until leaving)"
 
-#: tasks/models.py:78
+#: tasks/models.py:84
 msgid "Sessie {}"
 msgstr "Session {}"
 
-#: tasks/models.py:92
+#: tasks/models.py:98
 msgid "Vastlegging gedrag"
 msgstr "Registration of behaviour"
 
-#: tasks/models.py:115
+#: tasks/models.py:121
 msgid "Wat is de naam van de taak?"
 msgstr "What is the title of the task?"
 
-#: tasks/models.py:121
+#: tasks/models.py:127
 msgid ""
 "Beschrijf de taak die de deelnemer moet uitvoeren, en leg kort uit hoe deze "
 "taak (en de eventuele manipulaties daarbinnen) aan de beantwoording van jouw "
@@ -5306,7 +5338,7 @@ msgstr ""
 "participant. The committee members need to be in the clear on your exact "
 "plans."
 
-#: tasks/models.py:143
+#: tasks/models.py:149
 msgid ""
 "Hoe wordt het gedrag of de toestand van de deelnemer bij deze taak "
 "vastgelegd?"
@@ -5314,11 +5346,11 @@ msgstr ""
 "How will the behaviour or the state of the participant be recorded in this "
 "task?"
 
-#: tasks/models.py:154
+#: tasks/models.py:160
 msgid "Kies het soort meting"
 msgstr "Select the type of measurement"
 
-#: tasks/models.py:165
+#: tasks/models.py:171
 msgid ""
 "Krijgt de deelnemer tijdens of na deze taak feedback op hun gedrag of "
 "toestand?"
@@ -5326,11 +5358,11 @@ msgstr ""
 "Will the participant receive feedback on their behaviour or state during or "
 "after this task?"
 
-#: tasks/models.py:172
+#: tasks/models.py:178
 msgid "Beschrijf hoe de feedback wordt gegeven."
 msgstr "Describe how the feedback will be given."
 
-#: tasks/models.py:196
+#: tasks/models.py:202
 msgid "Taak {} in sessie {}"
 msgstr "Task {} in session {}"
 

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -4,169 +4,170 @@
 {% load i18n %}
 
 {% block header_title %}
-    {% trans "Algemene informatie over de aanvraag" %} - {{ block.super }}
+{% trans "Algemene informatie over de aanvraag" %} - {{ block.super }}
 {% endblock %}
 
 {% block html_head %}
-    <script>
-        $(function () {
-            check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
-            depends_on_value('other_applicants', 'True', 'applicants');
-            depends_on_value('other_stakeholders', 'True', 'stakeholders');
-            check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
-            check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
+<script>
+$(function () {
+  check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
+  depends_on_value('other_applicants', 'True', 'applicants');
+  depends_on_value('other_stakeholders', 'True', 'stakeholders');
+  check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
+  check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
 
-            // Add datepicker for date_start, set locale to current language
-            $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
+  // Add datepicker for date_start, set locale to current language
+  $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
 
-            var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
-            $("#id_date_start").datepicker({
-                dateFormat: date_format,
-                minDate: 'now',
-            })
+  var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
+  $("#id_date_start").datepicker({
+    dateFormat: date_format,
+    minDate: 'now',
+  })
 
-            // AJAX applicants
-            $('select#id_applicants').select2({
-                ajax: {
-                    url: '{% url 'main:user_search' %}',
-                    dataType: 'json',
-                    data: function (params) {
-                        return {
-                            q: params.term || '*',
-                            page: params.page || 1
-                        }
-                    },
-                    delay: 1500,
-                    error: function (err) {
-                        console.log(err)
-                    },
-                    cache: true
-                }
-            });
+  // AJAX applicants
+  $('select#id_applicants').select2({
+    ajax: {
+      url: '{% url 'main:user_search' %}',
+      dataType: 'json',
+      data: function (params) {
+        return {
+          q: params.term || '*',
+          page: params.page || 1
+        }
+      },
+      delay: 1500,
+      error: function (err) {
+        console.log(err)
+      },
+      cache: true
+    }
+  });
 
-            // AJAX supervisors
-            $('select#id_supervisor').select2({
-                ajax: {
-                    url: '{% url 'main:user_search' %}',
-                    dataType: 'json',
-                    data: function (params) {
-                        return {
-                            q: params.term || '*',
-                            page: params.page || 1
-                        }
-                    },
-                    delay: 1500,
-                    error: function (err) {
-                        console.log(err)
-                    },
-                    cache: true
-                }
-            });
+  // AJAX supervisors
+  $('select#id_supervisor').select2({
+    ajax: {
+      url: '{% url 'main:user_search' %}',
+      dataType: 'json',
+      data: function (params) {
+        return {
+          q: params.term || '*',
+          page: params.page || 1
+        }
+      },
+      delay: 1500,
+      error: function (err) {
+        console.log(err)
+      },
+      cache: true
+    }
+  });
 
-            // Add a running word count to the summary
-            var summary = $("#id_summary");
-            if (summary.length) {
-                summary.after("<span id='wordcount' />");
-                summary[0].addEventListener("input", function () {
-                    var wordCount = 0;
-                    if (this.value.trim()) {
-                        wordCount = this.value.match(/\S+/g).length;
-                    }
-                    $("#wordcount").text(" {% trans 'Aantal woorden:' %} " + wordCount);
-                }, false);
-            }
-        });
-    </script>
+  // Add a running word count to the summary
+  var summary = $("#id_summary");
+  if (summary.length) {
+    summary.after("<span id='wordcount' />");
+    summary[0].addEventListener("input", function () {
+      var wordCount = 0;
+      if (this.value.trim()) {
+        wordCount = this.value.match(/\S+/g).length;
+      }
+      $("#wordcount").text(" {% trans 'Aantal woorden:' %} " + wordCount);
+    }, false);
+  }
+});
+</script>
 {% endblock %}
 
 {% block content %}
-    <div class="uu-inner-container">
-        <div class="col-12">
-            {% if not create %}
-                {% with nav_items=proposal.available_urls active=1 %}
-                    {% include 'base/navigation.html' %}
-                {% endwith %}
-            {% endif %}
-            {% if is_practice %}
-            <div class="info">
-                {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
-            </div>
-            {% endif %}
-            <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
-            {% if not create and is_supervisor %}
-                {% blocktrans trimmed %}
-                    Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je het
-                    formulier
-                    invult alsof jij die student/PhD kandidaat bent.
-                {% endblocktrans %}
-                <br/>
-                <br/>
-		{% endif %}
-            <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-                <table>{{ form.as_table }}</table>
-                {% include "base/form_buttons.html" %}
-            </form>
-        </div>
+<div class="uu-inner-container">
+  <div class="col-12">
+    {% if not create %}
+    {% with nav_items=proposal.available_urls active=1 %}
+    {% include 'base/navigation.html' %}
+    {% endwith %}
+    {% endif %}
+    {% if is_practice %}
+    <div class="info">
+      {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
     </div>
-    <!-- Code for intended start date warning -->
-    <style>
-     .red {
-	 color: red;
-     }
-     #date_start_warning {
-	 margin-top: 0.5rem;
-	 margin-bottom: 0.5rem;
-	 line-height: 1.5;
-     }
-    </style>
-    <script>
-     /* Find date start input */
-     let date_start_input = $("#id_date_start")
+    {% endif %}
+    <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
+    {% if not create and is_supervisor %}
+    {% blocktrans trimmed %}
+    Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je het
+    formulier
+    invult alsof jij die student/PhD kandidaat bent.
+    {% endblocktrans %}
+    <br/>
+    <br/>
+    {% endif %}
+    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+      <table>{{ form.as_table }}</table>
+      {% include "base/form_buttons.html" %}
+    </form>
+  </div>
+</div>
+<!-- Code for intended start date warning -->
+<style>
+.red {
+  color: red;
+}
+#date_start_warning {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+</style>
+<script>
+/* Find date start input */
+let date_start_input = $("#id_date_start")
 
-     /* Insert warning element */
-     date_start_input.after(`
+/* Insert warning element */
+date_start_input.after(`
 <p id="date_start_warning">
     {% trans "Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
-     `)
+`)
 
-     /* Re-select warning paragraph */
-     const date_start_warning = $("#date_start_warning")
+/* Re-select warning paragraph */
+const date_start_warning = $("#date_start_warning")
 
-     /* Define checker function */
-     function checkDateStart()
-     {
-	 let date_value = date_start_input.val();
-	 if (date_value=="") {
-	     return true
-	 }
-	 let parsed_date = new Date(date_value);
-	 let today = new Date();
-	 let date_difference = parsed_date - today;
-	 const two_weeks_ms = 1000*60*60*24*14;
-	 return date_difference>two_weeks_ms;
-     }
+/* Define checker function */
+function checkDateStart()
+{
+  let date_value = date_start_input.val();
+  if (date_value=="") {
+    return true
+  }
+  let parsed_date = new Date(date_value);
+  let today = new Date();
+  let date_difference = parsed_date - today;
+  const two_weeks_ms = 1000*60*60*24*14;
+  return date_difference>two_weeks_ms;
+}
 
-     /* Define warning update function */
-     function updateWarning()
-     {
-	 if (checkDateStart())
-	 {
-	     date_start_warning.removeClass("red");
-	 } else {
-	     date_start_warning.addClass("red");
-	 }
-     }
-     
-     /* Listen for changing of start date */
-     date_start_input.on('change', () =>{
-	 updateWarning();
-     });
+/* Define warning update function */
+function updateWarning()
+{
+  date_start_warning.addClass("red");
+  if (checkDateStart())
+  {
+    date_start_warning.removeClass("red");
+  } else {
+    date_start_warning.addClass("red");
+  }
+}
 
-     /* Give the update function a warmup run */
-     updateWarning();
-     
-    </script>
-    
-    
+/* Listen for changing of start date */
+date_start_input.on('change', () =>{
+  updateWarning();
+});
+
+/* Give the update function a warmup run */
+updateWarning();
+
+</script>
+
+
 {% endblock %}

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -114,8 +114,6 @@ $(function () {
   color: red;
 }
 #date_start_warning {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
   line-height: 1.5;
 }
 </style>
@@ -125,7 +123,7 @@ let date_start_input = $("#id_date_start")
 
 /* Insert warning element */
 date_start_input.after(`
-<p id="date_start_warning">
+<p id="date_start_warning" class="mb-2 mt-2">
     {% trans "Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
 `)

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -101,11 +101,66 @@
                 {% endblocktrans %}
                 <br/>
                 <br/>
-            {% endif %}
+		{% endif %}
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% include "base/form_buttons.html" %}
             </form>
         </div>
     </div>
+    <!-- Code for intended start date warning -->
+    <style>
+     .red {
+	 color: red;
+     }
+     #date_start_warning {
+	 margin-top: 0.5rem;
+	 margin-bottom: 0.5rem;
+	 line-height: 1.5;
+     }
+    </style>
+    <script>
+     /* Find date start input */
+     let date_start_input = $("#id_date_start")
+
+     /* Insert warning element */
+     date_start_input.after(`
+<p id="date_start_warning">
+    {% trans "Attentie: Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven!"%}
+</p>
+     `)
+
+     /* Re-select warning paragraph */
+     const date_start_warning = $("#date_start_warning")
+
+     /* Define checker function */
+     function checkDateStart()
+     {
+	 let date_value = date_start_input.val();
+	 let parsed_date = new Date(date_value);
+	 const today = new Date();
+	 let date_difference = parsed_date - today;
+	 const two_weeks_ms = 1000*60*60*24*14;
+	 return date_difference>two_weeks_ms;
+     }
+
+     /* Define warning update function */
+     function updateWarning()
+     {
+	 if (checkDateStart())
+	 {
+	     date_start_warning.removeClass("red");
+	 } else {
+	     date_start_warning.addClass("red");
+	 }
+     }
+     
+     /* Listen for changing of start date */
+     date_start_input.on('change', () =>{
+	 updateWarning();
+	 });
+     
+    </script>
+    
+    
 {% endblock %}

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -126,7 +126,7 @@
      /* Insert warning element */
      date_start_input.after(`
 <p id="date_start_warning">
-    {% trans "Attentie: Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
+    {% trans "Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
      `)
 
@@ -137,6 +137,9 @@
      function checkDateStart()
      {
 	 let date_value = date_start_input.val();
+	 if (date_value=="") {
+	     return true
+	 }
 	 let parsed_date = new Date(date_value);
 	 let today = new Date();
 	 let date_difference = parsed_date - today;

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -110,9 +110,6 @@ $(function () {
 </div>
 <!-- Code for intended start date warning -->
 <style>
-.red {
-  color: red;
-}
 #date_start_warning {
   line-height: 1.5;
 }

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -4,159 +4,159 @@
 {% load i18n %}
 
 {% block header_title %}
-{% trans "Algemene informatie over de aanvraag" %} - {{ block.super }}
+  {% trans "Algemene informatie over de aanvraag" %} - {{ block.super }}
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function () {
-  check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
-  depends_on_value('other_applicants', 'True', 'applicants');
-  depends_on_value('other_stakeholders', 'True', 'stakeholders');
-  check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
-  check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
+  <script>
+  $(function () {
+    check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
+    depends_on_value('other_applicants', 'True', 'applicants');
+    depends_on_value('other_stakeholders', 'True', 'stakeholders');
+    check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
+    check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
 
-  // Add datepicker for date_start, set locale to current language
-  $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
+    // Add datepicker for date_start, set locale to current language
+    $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
 
-  var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
-  $("#id_date_start").datepicker({
-    dateFormat: date_format,
-    minDate: 'now',
-  })
+    var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
+    $("#id_date_start").datepicker({
+      dateFormat: date_format,
+      minDate: 'now',
+    })
 
-  // AJAX applicants
-  $('select#id_applicants').select2({
-    ajax: {
-      url: '{% url 'main:user_search' %}',
-      dataType: 'json',
-      data: function (params) {
-        return {
-          q: params.term || '*',
-          page: params.page || 1
-        }
-      },
-      delay: 1500,
-      error: function (err) {
-        console.log(err)
-      },
-      cache: true
-    }
-  });
-
-  // AJAX supervisors
-  $('select#id_supervisor').select2({
-    ajax: {
-      url: '{% url 'main:user_search' %}',
-      dataType: 'json',
-      data: function (params) {
-        return {
-          q: params.term || '*',
-          page: params.page || 1
-        }
-      },
-      delay: 1500,
-      error: function (err) {
-        console.log(err)
-      },
-      cache: true
-    }
-  });
-
-  // Add a running word count to the summary
-  var summary = $("#id_summary");
-  if (summary.length) {
-    summary.after("<span id='wordcount' />");
-    summary[0].addEventListener("input", function () {
-      var wordCount = 0;
-      if (this.value.trim()) {
-        wordCount = this.value.match(/\S+/g).length;
+    // AJAX applicants
+    $('select#id_applicants').select2({
+      ajax: {
+        url: '{% url 'main:user_search' %}',
+        dataType: 'json',
+        data: function (params) {
+          return {
+            q: params.term || '*',
+            page: params.page || 1
+          }
+        },
+        delay: 1500,
+        error: function (err) {
+          console.log(err)
+        },
+        cache: true
       }
-      $("#wordcount").text(" {% trans 'Aantal woorden:' %} " + wordCount);
-    }, false);
-  }
-});
-</script>
+    });
+
+    // AJAX supervisors
+    $('select#id_supervisor').select2({
+      ajax: {
+        url: '{% url 'main:user_search' %}',
+        dataType: 'json',
+        data: function (params) {
+          return {
+            q: params.term || '*',
+            page: params.page || 1
+          }
+        },
+        delay: 1500,
+        error: function (err) {
+          console.log(err)
+        },
+        cache: true
+      }
+    });
+
+    // Add a running word count to the summary
+    var summary = $("#id_summary");
+    if (summary.length) {
+      summary.after("<span id='wordcount' />");
+      summary[0].addEventListener("input", function () {
+        var wordCount = 0;
+        if (this.value.trim()) {
+          wordCount = this.value.match(/\S+/g).length;
+        }
+        $("#wordcount").text(" {% trans 'Aantal woorden:' %} " + wordCount);
+      }, false);
+    }
+  });
+  </script>
 {% endblock %}
 
 {% block content %}
-<div class="uu-inner-container">
-  <div class="col-12">
-    {% if not create %}
-    {% with nav_items=proposal.available_urls active=1 %}
-    {% include 'base/navigation.html' %}
-    {% endwith %}
-    {% endif %}
-    {% if is_practice %}
-    <div class="info">
-      {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+  <div class="uu-inner-container">
+    <div class="col-12">
+      {% if not create %}
+        {% with nav_items=proposal.available_urls active=1 %}
+          {% include 'base/navigation.html' %}
+        {% endwith %}
+      {% endif %}
+      {% if is_practice %}
+        <div class="info">
+          {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+        </div>
+      {% endif %}
+      <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
+      {% if not create and is_supervisor %}
+        {% blocktrans trimmed %}
+          Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je het
+          formulier
+          invult alsof jij die student/PhD kandidaat bent.
+        {% endblocktrans %}
+        <br/>
+        <br/>
+      {% endif %}
+      <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+        <table>{{ form.as_table }}</table>
+        {% include "base/form_buttons.html" %}
+      </form>
     </div>
-    {% endif %}
-    <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
-    {% if not create and is_supervisor %}
-    {% blocktrans trimmed %}
-    Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je het
-    formulier
-    invult alsof jij die student/PhD kandidaat bent.
-    {% endblocktrans %}
-    <br/>
-    <br/>
-    {% endif %}
-    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-      <table>{{ form.as_table }}</table>
-      {% include "base/form_buttons.html" %}
-    </form>
   </div>
-</div>
-<!-- Code for intended start date warning -->
-<style>
-#date_start_warning {
-  line-height: 1.5;
-}
-</style>
-<script>
-/* Find date start input */
-let date_start_input = $("#id_date_start")
+  <!-- Code for intended start date warning -->
+  <style>
+  #date_start_warning {
+    line-height: 1.5;
+  }
+  </style>
+  <script>
+  /* Find date start input */
+  let date_start_input = $("#id_date_start")
 
-/* Insert warning element */
-date_start_input.after(`
+  /* Insert warning element */
+  date_start_input.after(`
 <p id="date_start_warning" class="mb-2 mt-2">
     {% trans "Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
-`)
+  `)
 
-/* Re-select warning paragraph */
-const date_start_warning = $("#date_start_warning")
+  /* Re-select warning paragraph */
+  const date_start_warning = $("#date_start_warning")
 
-/* Define checker function */
-function checkDateStart()
-{
-  let date_value = date_start_input.val();
-  if (date_value=="") {
-    return true
+  /* Define checker function */
+  function checkDateStart()
+  {
+    let date_value = date_start_input.val();
+    if (date_value=="") {
+      return true
+    }
+    let parsed_date = new Date(date_value);
+    let today = new Date();
+    let date_difference = parsed_date - today;
+    const two_weeks_ms = 1000*60*60*24*14;
+    return date_difference>two_weeks_ms;
   }
-  let parsed_date = new Date(date_value);
-  let today = new Date();
-  let date_difference = parsed_date - today;
-  const two_weeks_ms = 1000*60*60*24*14;
-  return date_difference>two_weeks_ms;
-}
 
-/* Define warning update function */
-function updateWarning()
-{
-  date_start_warning.toggleClass("text-danger", checkDateStart()==false);
-}
+  /* Define warning update function */
+  function updateWarning()
+  {
+    date_start_warning.toggleClass("text-danger", checkDateStart()==false);
+  }
 
-/* Listen for changing of start date */
-date_start_input.on('change', () =>{
+  /* Listen for changing of start date */
+  date_start_input.on('change', () =>{
+    updateWarning();
+  });
+
+  /* Give the update function a warmup run */
   updateWarning();
-});
 
-/* Give the update function a warmup run */
-updateWarning();
-
-</script>
+  </script>
 
 
 {% endblock %}

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -148,13 +148,7 @@ function checkDateStart()
 /* Define warning update function */
 function updateWarning()
 {
-  date_start_warning.addClass("red");
-  if (checkDateStart())
-  {
-    date_start_warning.removeClass("red");
-  } else {
-    date_start_warning.addClass("red");
-  }
+  date_start_warning.toggleClass("text-danger", checkDateStart()==false);
 }
 
 /* Listen for changing of start date */

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -126,7 +126,7 @@
      /* Insert warning element */
      date_start_input.after(`
 <p id="date_start_warning">
-    {% trans "Attentie: Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven!"%}
+    {% trans "Attentie: Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
      `)
 
@@ -138,7 +138,7 @@
      {
 	 let date_value = date_start_input.val();
 	 let parsed_date = new Date(date_value);
-	 const today = new Date();
+	 let today = new Date();
 	 let date_difference = parsed_date - today;
 	 const two_weeks_ms = 1000*60*60*24*14;
 	 return date_difference>two_weeks_ms;
@@ -158,7 +158,10 @@
      /* Listen for changing of start date */
      date_start_input.on('change', () =>{
 	 updateWarning();
-	 });
+     });
+
+     /* Give the update function a warmup run */
+     updateWarning();
      
     </script>
     

--- a/proposals/templates/proposals/proposal_submit.html
+++ b/proposals/templates/proposals/proposal_submit.html
@@ -127,7 +127,7 @@
 		  <h5>{% trans "Controleer uw beoogde startdatum" %}</h5>
 		  <p>
 		    {% blocktrans trimmed %}
-		    Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC helaas geen officiële goedkeuring meer geven. Controleer daarom bij een revisie altijd of deze nog klopt!
+		    Omdat de beoogde startdatum binnen twee weken van vandaag ligt, kan de FETC helaas geen officiële goedkeuring meer geven voor deze aanvraag. Controleer daarom bij een revisie altijd of de beoogde startdatum nog klopt.
 		    {% endblocktrans %}
 		    {% url "proposals:update" proposal.pk as first_page_url %}
 		    {% blocktrans trimmed %}

--- a/proposals/templates/proposals/proposal_submit.html
+++ b/proposals/templates/proposals/proposal_submit.html
@@ -101,10 +101,12 @@
             <form action="" method="post" enctype="multipart/form-data">
 
             {% if troublesome_pages %}
-                <div class="warning">
+            <div class="warning">
+	      <h5>
                     {% blocktrans trimmed %}
                         Er zijn nog errors gevonden op de volgende pagina's:
                     {% endblocktrans %}
+		    </h5>
                     <ul>
                         {% for error_page in troublesome_pages %}
                             <li>
@@ -119,7 +121,25 @@
                         aanmelding pas versturen wanneer deze fouten gecorrigeerd zijn.
                     {% endblocktrans %}
                 </div>
-            {% endif %}{% csrf_token %}
+		{% endif %}
+		{% if start_date_warning %}
+		<div class="warning">
+		  <h5>{% trans "Controleer uw beoogde startdatum" %}</h5>
+		  <p>
+		    {% blocktrans trimmed %}
+		    Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC helaas geen officiële goedkeuring meer geven. Controleer daarom bij een revisie altijd of deze nog klopt!
+		    {% endblocktrans %}
+		    {% url "proposals:update" proposal.pk as first_page_url %}
+		    {% blocktrans trimmed %}
+		    De beoogde startdatum vindt u op
+		    <a href="{{first_page_url}}">deze pagina</a>.
+		    {% endblocktrans %}
+		  </p>
+		</div>		
+		{% endif %}
+
+
+		{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% if is_practice %}
                 <div class="info">

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -187,6 +187,9 @@ class HideFromArchiveView(GroupRequiredMixin, generic.RedirectView):
 ##########################
 
 class ProposalCreate(ProposalMixin, AllowErrorsOnBackbuttonMixin, CreateView):
+
+    # Note: template_name is auto-generated to proposal_form.html
+    
     def get_initial(self):
         """Sets initial applicant to current User"""
         initial = super(ProposalCreate, self).get_initial()

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 
+import datetime
+
 from braces.views import GroupRequiredMixin, LoginRequiredMixin, \
     UserFormKwargsMixin
 from django.conf import settings
@@ -359,8 +361,19 @@ class ProposalSubmit(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateV
         context['troublesome_pages'] = get_form_errors(self.get_object())
         context['pagenr'] = self._get_page_number()
         context['is_supervisor_edit_phase'] = self.is_supervisor_edit_phase()
+        context['start_date_warning'] = self.check_start_date()
 
         return context
+
+    def check_start_date(self):
+        """
+        Return true if the proposal's intended start date lies within
+        two weeks of today.
+        """
+        start_date = self.object.date_start
+        two_weeks = datetime.timedelta(days=14)
+        two_weeks_from_now = datetime.date.today() + two_weeks
+        return start_date < two_weeks_from_now
 
     def is_supervisor_edit_phase(self):
         if self.object.status == self.object.SUBMITTED_TO_SUPERVISOR:

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -373,7 +373,7 @@ class ProposalSubmit(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateV
         start_date = self.object.date_start
         two_weeks = datetime.timedelta(days=14)
         two_weeks_from_now = datetime.date.today() + two_weeks
-        return start_date < two_weeks_from_now
+        return start_date <= two_weeks_from_now
 
     def is_supervisor_edit_phase(self):
         if self.object.status == self.object.SUBMITTED_TO_SUPERVISOR:


### PR DESCRIPTION
This fix for #352 seems like a good candidate to go straight to acceptation. It doesn't touch anything critical, but the wording could use a good look-over by @djhcapel.

Current state: Intended start date warning is always shown in the form. When input is actually within two weeks of today, the warning turns red. On the submission page the warning is only shown when relevant, with a link back to the first page.