### PR TITLE
chore: update to DSC 2.0.10

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ django-user-agents
 pillow>=6.0
 pygments
 requests
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v2.0.9#egg=uil-django-core
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v2.0.10#egg=uil-django-core
 -e git+https://github.com/UiL-OTS-labs/python-docx2txt#egg=docx2txt
 python-magic
 pdftotext

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/UiL-OTS-labs/python-docx2txt#egg=docx2txt
     # via -r requirements.in
--e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v2.0.9#egg=uil-django-core
+-e git+https://github.com/UiL-OTS-labs/django-shared-core.git@v2.0.10#egg=uil-django-core
     # via -r requirements.in
 alabaster==0.7.12
     # via sphinx


### PR DESCRIPTION
DSC 2.0.10 fixes a small issue with help-text tooltips being placed on the wrong elements. 

Normally I'd not update the old unsupported version anymore, but this was affecting a required change that cannot wait till DSC 3