### PR TITLE
Fix check_field_required bug

### DIFF
--- a/main/templates/base/form_styling.html
+++ b/main/templates/base/form_styling.html
@@ -96,11 +96,13 @@ function check_field_required(input_name, field_name, required_input, app_name, 
     let input = $('input[name=' + input_name + ']');
     let r_input = $('#id_' + required_input);
 
+    let process_identifier = input_name.concat(' ', required_input);
+
     input.change(function() {
         // if a postrequest is in progress, abort that request
-        if (postrequests.has(input_name)) {
-            postrequests.get(input_name).abort();
-            postrequests.delete(input_name);
+        if (postrequests.has(process_identifier)) {
+            postrequests.get(process_identifier).abort();
+            postrequests.delete(process_identifier);
         }
         let checked_inputs = input.filter(':checked').map(function() {
             return this.value;
@@ -126,9 +128,9 @@ function check_field_required(input_name, field_name, required_input, app_name, 
                 r_input.parents('tr').prev().toggle(data.result);
             }
             //when the request is done, mark it undefined
-            postrequests.delete(input_name);
+            postrequests.delete(process_identifier);
         });
-        postrequests.set(input_name, req);
+        postrequests.set(process_identifier, req);
     });
     input.change();
 }


### PR DESCRIPTION
The Map variable would only allow a single process per input_name to be executed, leading to a bug where fields that are checked several times per change (such as 'relation', which is checked for 4 different variables and 'funding which is checked for 2 variables) would only execute the final check and abort the preceding ones, leading to fields not disappearing when they should (see screenshots below).

<img width="1327" alt="Screenshot 2023-02-17 at 16 10 10" src="https://user-images.githubusercontent.com/31687030/219803292-0e85226a-fbca-4e76-b999-755804ee02ae.png">

<img width="1309" alt="Screenshot 2023-02-17 at 16 10 30" src="https://user-images.githubusercontent.com/31687030/219803322-3ffc24b4-0321-4379-87bb-79af0c1a8966.png">

Thus, a unique process name needed to be assigned for each input_name + required_input combination, so that you can have several processes per input change, but rapidly checking and un-checking of a variable is still aborted.

This took much longer to figure out than I care to admit.