### PR TITLE
Use applicant names in Pre-approved and pre-assesment PDF's

### DIFF
--- a/proposals/templates/proposals/proposal_pdf_pre_approved.html
+++ b/proposals/templates/proposals/proposal_pdf_pre_approved.html
@@ -93,10 +93,17 @@ Page <pdf:pagenumber /> of <pdf:pagecount />
             </tr>
             {% if proposal.other_applicants %}
             <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th>
-                <td>{{ proposal.applicants.all|unordered_list }}</td>
+              <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
+                <ul>
+                  {% for applicant in proposal.applicants.all %}
+                    <li>
+                      {{ applicant.get_full_name }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </td>
             </tr>
-            {% endif %}
+          {% endif %}
             <tr>
                 <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th>
                 <td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>

--- a/proposals/templates/proposals/proposal_pdf_pre_assessment.html
+++ b/proposals/templates/proposals/proposal_pdf_pre_assessment.html
@@ -76,9 +76,17 @@ Page <pdf:pagenumber /> of <pdf:pagecount />
             </tr>
             {% if proposal.other_applicants %}
             <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>{{ proposal.applicants.all|unordered_list }}</td>
+              <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
+                <ul>
+                  {% for applicant in proposal.applicants.all %}
+                    <li>
+                      {{ applicant.get_full_name }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </td>
             </tr>
-            {% endif %}
+          {% endif %}
             <tr>
                 <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th><td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>
             </tr>


### PR DESCRIPTION
changed the other applicants if statement in the pre-approved and pre-assesment pdf templates to the one in the normal pdf template. Fixed issue 386.