### PR TITLE
Add CI check for missing migrations

### DIFF
--- a/.github/workflows/check-missing-migrations.yml
+++ b/.github/workflows/check-missing-migrations.yml
@@ -1,0 +1,24 @@
+name: Check for missing migrations
+
+on:
+  pull_request:
+jobs:
+  run-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libldap2-dev libsasl2-dev libssl-dev gettext poppler-utils poppler-data libpoppler-cpp-dev
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Check for missing migrations
+        run: |
+          python manage.py makemigrations --check --dry-run

--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -2,9 +2,9 @@ name: Django Tests
 
 on:
   push:
-    branches: [ develop, ]
+    branches: [ develop, acceptation ]
   pull_request:
-    branches: [ develop, master, ]
+    branches: [ develop, acceptation, master, ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a Actions workflow that tests if the code in _any_ PR is missing a migration. It also fixes the tests-workflow to also run on the acceptation branch, we forgot to add that branch to the workflow when we created it.

The missing migration workflow works by simply running ``manage.py makemigrations`` with the ``check`` argument, this causes it to return an error code if there is indeed a missing migration causing the workflow to fail.

I considered adding it to the existing tests-workflow; however, as that workflow runs for both PR's and pushes in a specific subset of branches, I decided to create a new one that only runs on PR's (with no branch restrictions) 

As a fun bonus: we actually are missing a migration in develop! I thought I had to write a fake change to test it, but apparently not. 