### PR TITLE
style: Indent templates with djhtml

### DIFF
--- a/feedback/templates/feedback/feedback_list.html
+++ b/feedback/templates/feedback/feedback_list.html
@@ -25,12 +25,12 @@
                 </thead>
                 <tbody>
                     {% for feedback in feedback_list %}
-                    <tr>
-                        <td data-order="{{ feedback.date_created|date:'c' }}">{{ feedback.date_created|date:"j M Y, G:i" }}</td>
-                        <td>{{ feedback.url }}</td>
-                        <td>{{ feedback.comment }}</td>
-                        <td>{{ feedback.submitter.get_full_name }}</td>
-                    </tr>
+                        <tr>
+                            <td data-order="{{ feedback.date_created|date:'c' }}">{{ feedback.date_created|date:"j M Y, G:i" }}</td>
+                            <td>{{ feedback.url }}</td>
+                            <td>{{ feedback.comment }}</td>
+                            <td>{{ feedback.submitter.get_full_name }}</td>
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/feedback/templates/feedback/feedback_thanks.html
+++ b/feedback/templates/feedback/feedback_thanks.html
@@ -15,7 +15,7 @@
             </h2>
             <p>
                 {% blocktrans with url=feedback.url %}
-                Klik <a href="{{ url }}">hier</a> om terug te keren naar pagina waar je gebleven was.
+                    Klik <a href="{{ url }}">hier</a> om terug te keren naar pagina waar je gebleven was.
                 {% endblocktrans %}
             </p>
         </div>

--- a/interventions/templates/interventions/intervention_form.html
+++ b/interventions/templates/interventions/intervention_form.html
@@ -58,10 +58,10 @@
                             <label for="id_extra_info"></label>
                         </th>
                         <td id="id_extra_info">
-                          {% blocktrans trimmed %}
-			  Als je dit nog niet gedaan hebt, zul je op de vorige pagina naast "interventie"
-			  ook "takenonderzoek" moeten aanvinken, om je aanvraag volledig in te vullen.
-			  {% endblocktrans %}
+                            {% blocktrans trimmed %}
+                                Als je dit nog niet gedaan hebt, zul je op de vorige pagina naast "interventie"
+                                ook "takenonderzoek" moeten aanvinken, om je aanvraag volledig in te vullen.
+                            {% endblocktrans %}
                         </td>
                     </tr>
                 </table>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-23 13:58+0200\n"
+"POT-Creation-Date: 2023-11-01 16:53+0100\n"
 "PO-Revision-Date: 2020-10-07 11:22+0200\n"
 "Last-Translator: Anna Asbury <anna.asbury@annaasbury.com>\n"
 "Language-Team: \n"
@@ -153,7 +153,6 @@ msgstr "You can leave feedback on the FEtC-H portal here."
 #: observations/templates/observations/observation_update_attachments.html:39
 #: proposals/templates/proposals/proposal_confirmation.html:36
 #: proposals/templates/proposals/proposal_diff.html:294
-#: proposals/templates/proposals/proposal_diff.html:294
 #: proposals/templates/proposals/proposal_update_attachments.html:26
 #: reviews/templates/reviews/change_chamber_form.html:19
 #: reviews/templates/reviews/decision_form.html:90
@@ -187,10 +186,15 @@ msgid "Bedankt voor je feedback!"
 msgstr "Thanks for your feedback!"
 
 #: feedback/templates/feedback/feedback_thanks.html:17
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                Klik <a href=\"%(url)s\">hier</a> om terug te keren naar "
+#| "pagina waar je gebleven was.\n"
+#| "                "
 msgid ""
 "\n"
-"                Klik <a href=\"%(url)s\">hier</a> om terug te keren naar "
+"                    Klik <a href=\"%(url)s\">hier</a> om terug te keren naar "
 "pagina waar je gebleven was.\n"
 "                "
 msgstr ""
@@ -202,11 +206,11 @@ msgstr ""
 msgid "Feedback verstuurd"
 msgstr "Feedback sent"
 
-#: fetc/settings.py:132
+#: fetc/settings.py:133
 msgid "Nederlands"
 msgstr "Dutch"
 
-#: fetc/settings.py:133
+#: fetc/settings.py:134
 msgid "Engels"
 msgstr "English"
 
@@ -333,26 +337,24 @@ msgid "Dit veld is verplicht."
 msgstr "This field is required."
 
 #: main/menus.py:6 main/templates/base/menu.html:7
-#: main/templates/main/index.html:7 main/templates/main/index.html:24
+#: main/templates/main/index.html:7 main/templates/main/index.html:56
 #: main/templates/main/landing.html:34
 msgid "Startpagina"
 msgstr "Start page"
 
 #: main/menus.py:11
-#: main/menus.py:11
 msgid "Log in"
 msgstr "Log in"
 
 #: main/menus.py:16 main/templates/base/login_header.html:7
-#: main/menus.py:16 main/templates/base/login_header.html:7
 msgid "Log uit"
 msgstr "Log out"
 
-#: main/models.py:10 main/utils.py:13
+#: main/models.py:10 main/utils.py:15
 msgid "ja"
 msgstr "yes"
 
-#: main/models.py:11 main/utils.py:13
+#: main/models.py:11 main/utils.py:15
 msgid "nee"
 msgstr "no"
 
@@ -364,7 +366,7 @@ msgstr "uncertain"
 msgid "Geef aan waar de dataverzameling plaatsvindt"
 msgstr "Specify where the data collection will take place"
 
-#: main/models.py:68 observations/models.py:129 proposals/models.py:255
+#: main/models.py:70 observations/models.py:129 proposals/models.py:255
 #: studies/models.py:208 studies/models.py:244 tasks/models.py:157
 #: tasks/models.py:169
 msgid "Namelijk"
@@ -463,7 +465,6 @@ msgstr "My decision"
 
 #: main/templates/auth/user_detail.html:58 reviews/api/views.py:332
 #: reviews/models.py:57
-#: reviews/models.py:57
 #: reviews/templates/reviews/vue_templates/decision_list.html:133
 #: reviews/templates/reviews/vue_templates/review_list.html:131
 msgid "Afhandeling"
@@ -474,7 +475,6 @@ msgstr "Conclusion"
 msgid "Acties"
 msgstr "Actions"
 
-#: main/templates/auth/user_detail.html:75 reviews/models.py:135
 #: main/templates/auth/user_detail.html:75 reviews/models.py:135
 msgid ", met revisie"
 msgstr ", with revision"
@@ -587,30 +587,25 @@ msgstr "Create an amendment to an already approved application"
 
 #: main/templates/base/menu.html:32 proposals/menus.py:56
 #: proposals/views/proposal_views.py:76
-#: proposals/views/proposal_views.py:76
 msgid "Mijn conceptaanvragen"
 msgstr "My draft applications"
 
 #: main/templates/base/menu.html:35 proposals/menus.py:60
-#: proposals/views/proposal_views.py:126
 #: proposals/views/proposal_views.py:126
 msgid "Mijn oefenaanvragen"
 msgstr "My practice applications"
 
 #: main/templates/base/menu.html:38 proposals/menus.py:64
 #: proposals/views/proposal_views.py:88
-#: proposals/views/proposal_views.py:88
 msgid "Mijn ingediende aanvragen"
 msgstr "My submitted applications"
 
 #: main/templates/base/menu.html:41 proposals/menus.py:68
 #: proposals/views/proposal_views.py:100
-#: proposals/views/proposal_views.py:100
 msgid "Mijn afgehandelde aanvragen"
 msgstr "My processed applications"
 
 #: main/templates/base/menu.html:44 proposals/menus.py:72
-#: proposals/views/proposal_views.py:112
 #: proposals/views/proposal_views.py:112
 msgid "Mijn aanvragen als eindverantwoordelijke"
 msgstr "My supervised applications"
@@ -619,8 +614,8 @@ msgstr "My supervised applications"
 msgid "Al mijn aanvragen"
 msgstr "All my applications"
 
-#: main/templates/base/menu.html:52 proposals/menus.py:108
-#: proposals/views/proposal_views.py:149
+#: main/templates/base/menu.html:52 proposals/menus.py:110
+#: proposals/views/proposal_views.py:153
 msgid "Archief"
 msgstr "Archive"
 
@@ -695,8 +690,6 @@ msgid "FETC-GW-website"
 msgstr "FEtC-H website"
 
 #: main/templates/base/menu.html:152 main/templates/main/landing.html:77
-#: main/templates/registration/login.html:15
-#: main/templates/registration/login.html:32
 #: main/templates/registration/login.html:15
 #: main/templates/registration/login.html:32
 msgid "Inloggen"
@@ -1107,7 +1100,6 @@ msgstr ""
 "the secretary of the FEtC-H."
 
 #: main/templates/main/landing.html:86 main/templates/main/landing.html:93
-#: main/templates/main/landing.html:86 main/templates/main/landing.html:93
 msgid "Log in met je Solis-ID"
 msgstr "Log in with your Solis-ID"
 
@@ -1123,22 +1115,18 @@ msgstr ""
 "Click <a href=\"%(landing_url)s\">here</a> to return to the start page."
 
 #: main/templates/registration/login.html:23
-#: main/templates/registration/login.html:23
 msgid ""
 "Gebruikersnaam of wachtwoord incorrect. Probeer het alstublieft opnieuw."
 msgstr "Username or password incorrect. Please try again."
 
 #: main/templates/registration/login.html:27
-#: main/templates/registration/login.html:27
 msgid "Je kan hier inloggen met je Solis-ID en wachtwoord."
 msgstr "You can log in here with your Solis-ID and password."
 
 #: main/templates/registration/login.html:30
-#: main/templates/registration/login.html:30
 msgid "Gebruikersnaam"
 msgstr "Username"
 
-#: main/templates/registration/login.html:31
 #: main/templates/registration/login.html:31
 msgid "Wachtwoord"
 msgstr "Password"
@@ -1215,7 +1203,6 @@ msgid ""
 msgstr "As might happen on forums where the researcher also has an account."
 
 #: observations/models.py:65 observations/models.py:75
-#: observations/models.py:88 proposals/models.py:745 studies/models.py:172
 #: observations/models.py:88 proposals/models.py:745 studies/models.py:172
 #: studies/models.py:228 studies/models.py:358
 msgid "Licht toe"
@@ -1371,7 +1358,6 @@ msgid "Datum ingediend bij eindverantwoordelijke"
 msgstr "Date sent to supervisor"
 
 #: proposals/forms.py:42 proposals/models.py:221
-#: proposals/forms.py:42 proposals/models.py:221
 msgid ""
 "Zijn er nog andere onderzoekers bij deze aanvraag betrokken die "
 "<strong>niet</strong> geaffilieerd zijn aan een van de onderzoeksinstituten "
@@ -1441,11 +1427,9 @@ msgid "Ik maak een oefenaanvraag aan"
 msgstr "I am creating a practice application"
 
 #: proposals/forms.py:276 proposals/models.py:536
-#: proposals/forms.py:276 proposals/models.py:536
 msgid "Te kopiëren aanvraag"
 msgstr "Application to be copied"
 
-#: proposals/forms.py:278 proposals/models.py:538
 #: proposals/forms.py:278 proposals/models.py:538
 msgid "Dit veld toont enkel aanvragen waar je zelf een medeuitvoerende bent."
 msgstr "This field shows only applications in which you are involved."
@@ -1599,53 +1583,43 @@ msgid "Bekijk alle goedgekeurde aanvragen van de Linguïstiek Kamer"
 msgstr "View all approved applications of the Linguistics Chamber"
 
 #: proposals/mixins.py:20
-#: proposals/mixins.py:20
 #, python-format
 msgid "Aanvraag %(title)s bewerkt"
 msgstr "Application %(title)s edited"
 
 #: proposals/models.py:143
-#: proposals/models.py:143
 msgid "Concept"
 msgstr "Draft"
 
-#: proposals/models.py:146
 #: proposals/models.py:146
 msgid "Opgestuurd ter beoordeling door eindverantwoordelijke"
 msgstr "Sent for assessment by the researcher with final responsibility"
 
 #: proposals/models.py:147
-#: proposals/models.py:147
 msgid "Opgestuurd ter beoordeling door FETC-GW"
 msgstr "Sent for assessment by FEtC-H"
 
-#: proposals/models.py:149 proposals/models.py:150
 #: proposals/models.py:149 proposals/models.py:150
 msgid "Aanvraag is beoordeeld door FETC-GW"
 msgstr "Application has been assessed by FEtC-H"
 
 #: proposals/models.py:156
-#: proposals/models.py:156
 msgid "in het kader van een cursus"
 msgstr "in the context of a course"
 
-#: proposals/models.py:157
 #: proposals/models.py:157
 msgid "om de portal te exploreren"
 msgstr "to explore the portal"
 
 # Not actually used in the interface
 #: proposals/models.py:169
-#: proposals/models.py:169
 msgid "Door welke comissie dient deze aanvraag te worden beoordeeld?"
 msgstr "Which chamber should be reviewing this application?"
 
 #: proposals/models.py:178
-#: proposals/models.py:178
 msgid "Aan welk onderzoeksinstituut ben je verbonden?"
 msgstr "To which research institute are you affiliated?"
 
-#: proposals/models.py:184
 #: proposals/models.py:184
 msgid ""
 "Wat is de beoogde startdatum van het onderzoek waarvoor deze aanvraag wordt "
@@ -1654,7 +1628,6 @@ msgstr ""
 "What is the desired starting date of the actual research for which this "
 "application is being submitted?"
 
-#: proposals/models.py:185
 #: proposals/models.py:185
 msgid ""
 "NB: Voor een aanvraag van een onderzoek dat al gestart is voordat de FETC-GW "
@@ -1666,7 +1639,6 @@ msgstr ""
 "only provides a post-hoc advice."
 
 #: proposals/models.py:194
-#: proposals/models.py:194
 msgid ""
 "Wat is de titel van je aanvraag? Deze titel zal worden gebruikt in alle "
 "formele correspondentie."
@@ -1674,7 +1646,6 @@ msgstr ""
 "What is the title of your application? This title will be used in all formal "
 "correspondence."
 
-#: proposals/models.py:199
 #: proposals/models.py:199
 msgid ""
 "De titel die je hier opgeeft is zichtbaar voor de FETC-GW-leden en, wanneer "
@@ -1688,7 +1659,6 @@ msgstr ""
 "submitted."
 
 #: proposals/models.py:207
-#: proposals/models.py:207
 msgid ""
 "Geef een duidelijke, bondige beschrijving van de onderzoeksvraag of -vragen. "
 "Gebruik maximaal 200 woorden."
@@ -1696,7 +1666,6 @@ msgstr ""
 "Give a clear, concise description of the research question or questions. Use "
 "a maximum of 200 words."
 
-#: proposals/models.py:215
 #: proposals/models.py:215
 msgid ""
 "Zijn er nog andere onderzoekers bij deze aanvraag betrokken die geaffilieerd "
@@ -1706,11 +1675,9 @@ msgstr ""
 "ILS?"
 
 #: proposals/models.py:229
-#: proposals/models.py:229
 msgid "Andere betrokkenen"
 msgstr "Other people involved"
 
-#: proposals/models.py:234
 #: proposals/models.py:234
 msgid ""
 "Worden de informed consent formulieren nog vertaald naar een andere taal dan "
@@ -1720,22 +1687,18 @@ msgstr ""
 "or English?"
 
 #: proposals/models.py:241
-#: proposals/models.py:241
 msgid "Andere talen:"
 msgstr "Other languages:"
 
-#: proposals/models.py:250
 #: proposals/models.py:250
 msgid "Hoe wordt dit onderzoek gefinancierd?"
 msgstr "How is this study funded?"
 
 #: proposals/models.py:261
-#: proposals/models.py:261
 msgid ""
 "Wat is de naam van het gefinancierde project en wat is het projectnummer?"
 msgstr "What is the name of the funded project and what is the project number?"
 
-#: proposals/models.py:265
 #: proposals/models.py:265
 msgid ""
 "De titel die je hier opgeeft zal in de formele toestemmingsbrief gebruikt "
@@ -1743,11 +1706,9 @@ msgid ""
 msgstr "This title will be used in the formal letter of approval."
 
 #: proposals/models.py:271
-#: proposals/models.py:271
 msgid "Ruimte voor eventuele opmerkingen. Gebruik maximaal 1000 woorden."
 msgstr "Space for possible comments. Use a maximum of a 1000 words."
 
-#: proposals/models.py:277
 #: proposals/models.py:277
 msgid ""
 "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één van de "
@@ -1772,7 +1733,6 @@ msgstr ""
 "facilities you intend to use (database, lab, Zep software)"
 
 #: proposals/models.py:297
-#: proposals/models.py:297
 msgid ""
 "Als de deelnemers van je onderzoek moeten worden misleid, kan           je "
 "ervoor kiezen je applicatie pas later op te laten nemen in het           "
@@ -1785,17 +1745,14 @@ msgstr ""
 "a temporary embargo?"
 
 #: proposals/models.py:308
-#: proposals/models.py:308
 msgid ""
 "Vanaf welke datum mag je onderzoek wel in het archief worden weergegeven?"
 msgstr "From which date may your application be displayed in the archive?"
 
 #: proposals/models.py:318
-#: proposals/models.py:318
 msgid "Upload hier je aanvraag (in .pdf of .doc(x)-formaat)"
 msgstr "Upload your application here (in .pdf or .doc(x)-format)"
 
-#: proposals/models.py:326
 #: proposals/models.py:326
 msgid ""
 "Heb je formele toestemming van een ethische toetsingcommissie, uitgezonderd "
@@ -1805,11 +1762,9 @@ msgstr ""
 "committee?"
 
 #: proposals/models.py:334
-#: proposals/models.py:334
 msgid "Welk instituut heeft de aanvraag goedgekeurd?"
 msgstr "Which institute approved the application?"
 
-#: proposals/models.py:342
 #: proposals/models.py:342
 msgid ""
 "Upload hier je formele toestemmingsbrief van dit instituut (in .pdf of ."
@@ -1819,16 +1774,13 @@ msgstr ""
 "or .doc(x)-format)"
 
 #: proposals/models.py:350
-#: proposals/models.py:350
 msgid "Ik vul de portal in in het kader van een cursus"
 msgstr "I am using this portal in the context of a course"
 
 #: proposals/models.py:355
-#: proposals/models.py:355
 msgid "Ik vul de portal in om de portal te exploreren"
 msgstr "I am using this portal to explore the portal"
 
-#: proposals/models.py:367
 #: proposals/models.py:367
 msgid ""
 "Kan voor alle deelnemersgroepen dezelfde informatiebrief en         "
@@ -1836,7 +1788,6 @@ msgid ""
 msgstr ""
 "Can the same informed consent documents be used for all participant groups?"
 
-#: proposals/models.py:369
 #: proposals/models.py:369
 msgid ""
 "Daar waar de verschillen klein en qua belasting of risico irrelevant zijn is "
@@ -1862,11 +1813,9 @@ msgstr ""
 "they constitute separate trajectories."
 
 #: proposals/models.py:385
-#: proposals/models.py:385
 msgid "Hoeveel verschillende trajecten zijn er?"
 msgstr "How many different trajectories are there?"
 
-#: proposals/models.py:403
 #: proposals/models.py:403
 msgid ""
 "Ik heb kennis genomen van het bovenstaande en begrijp mijn "
@@ -1875,7 +1824,6 @@ msgstr ""
 "I have read the information above and have considered my responsibilities "
 "with regard to the AVG."
 
-#: proposals/models.py:410
 #: proposals/models.py:410
 msgid ""
 "Als je een Data Management Plan hebt voor deze aanvraag, kan je kiezen om "
@@ -1887,11 +1835,9 @@ msgstr ""
 "proposals."
 
 #: proposals/models.py:422 reviews/models.py:184
-#: proposals/models.py:422 reviews/models.py:184
 msgid "Ruimte voor eventuele opmerkingen"
 msgstr "Space for possible comments"
 
-#: proposals/models.py:434
 #: proposals/models.py:434
 msgid "Datum bevestigingsbrief verstuurd"
 msgstr "Date confirmation sent"
@@ -1901,11 +1847,9 @@ msgid "Is er een revisie geweest na het indienen van deze aanvraag?"
 msgstr "Has this proposal been amended after it was submitted?"
 
 #: proposals/models.py:444
-#: proposals/models.py:444
 msgid "Leg uit"
 msgstr "Explain why"
 
-#: proposals/models.py:450
 #: proposals/models.py:450
 msgid ""
 "Wat zijn de belangrijkste ethische kwesties in dit onderzoek en beschrijf "
@@ -1916,26 +1860,21 @@ msgstr ""
 "words."
 
 #: proposals/models.py:464
-#: proposals/models.py:464
 msgid "In welke hoedanigheid ben je betrokken bij dit onderzoek?"
 msgstr "In what capacity are you involved in this application?"
 
-#: proposals/models.py:472
 #: proposals/models.py:472
 msgid "Wat is je studierichting?"
 msgstr "What is your course of study?"
 
 #: proposals/models.py:479
-#: proposals/models.py:479
 msgid "In welke context doe je dit onderzoek?"
 msgstr "In what capacity are you involved in this application?"
 
 #: proposals/models.py:486
-#: proposals/models.py:486
 msgid "Namelijk:"
 msgstr "Please specify:"
 
-#: proposals/models.py:493
 #: proposals/models.py:493
 msgid ""
 "Studenten (die mensgebonden onderzoek uitvoeren binnen hun studieprogramma) "
@@ -1951,7 +1890,6 @@ msgstr ""
 "what the reason is:"
 
 #: proposals/models.py:510
-#: proposals/models.py:510
 msgid ""
 "Uitvoerenden, inclusief uzelf. Let op! De andere onderzoekers moeten         "
 "ten minste één keer zijn ingelogd op dit portaal om ze te kunnen selecteren."
@@ -1961,13 +1899,11 @@ msgstr ""
 "be selectable here."
 
 #: proposals/models.py:517
-#: proposals/models.py:517
 #: proposals/templates/proposals/vue_templates/proposal_archive_list.html:115
 #: proposals/templates/proposals/vue_templates/proposal_list.html:166
 msgid "Eindverantwoordelijke onderzoeker"
 msgstr "Researcher with final responsibility"
 
-#: proposals/models.py:520
 #: proposals/models.py:520
 msgid ""
 "Aan het einde van de procedure kan je deze aanvraag ter\n"
@@ -1991,7 +1927,6 @@ msgstr ""
 "but remember to come back and fill in this field before submitting."
 
 #: proposals/models.py:545
-#: proposals/models.py:545
 msgid ""
 "Is deze aanvraag een revisie van of amendement op een ingediende aanvraag?"
 msgstr ""
@@ -1999,11 +1934,9 @@ msgstr ""
 "application?"
 
 #: proposals/models.py:617
-#: proposals/models.py:617
 msgid "Amendement"
 msgstr "Amendment"
 
-#: proposals/models.py:617 reviews/api/views.py:39 reviews/api/views.py:328
 #: proposals/models.py:617 reviews/api/views.py:39 reviews/api/views.py:328
 #: reviews/templates/reviews/committee_members_workload.html:36
 #: reviews/templates/reviews/committee_members_workload.html:82
@@ -2012,41 +1945,33 @@ msgid "Revisie"
 msgstr "Revision"
 
 #: proposals/models.py:623
-#: proposals/models.py:623
 msgid "Normaal"
 msgstr "Normal"
 
-#: proposals/models.py:628
 #: proposals/models.py:628
 msgid "Voortoetsing"
 msgstr "Preliminary assessment"
 
 #: proposals/models.py:630
-#: proposals/models.py:630
 msgid "Oefening"
 msgstr "Practice"
 
-#: proposals/models.py:632
 #: proposals/models.py:632
 msgid "Extern getoetst"
 msgstr "External approval"
 
 #: proposals/models.py:730
-#: proposals/models.py:730
 msgid "Geen beoordeling door METC noodzakelijk"
 msgstr "Assessment by METC not required"
 
-#: proposals/models.py:731
 #: proposals/models.py:731
 msgid "In afwachting beslissing METC"
 msgstr "Pending decision by METC"
 
 #: proposals/models.py:732
-#: proposals/models.py:732
 msgid "Beslissing METC geüpload"
 msgstr "METC decision uploaded"
 
-#: proposals/models.py:736
 #: proposals/models.py:736
 msgid ""
 "Vindt de dataverzameling plaats binnen het UMC Utrecht of andere instelling "
@@ -2056,11 +1981,9 @@ msgstr ""
 "institution for which an assessment by a METC is required?"
 
 #: proposals/models.py:750
-#: proposals/models.py:750
 msgid "Welke instelling?"
 msgstr "Which institution?"
 
-#: proposals/models.py:756
 #: proposals/models.py:756
 msgid ""
 "Is de onderzoeksvraag medisch-wetenschappelijk van aard (zoals gedefinieerd "
@@ -2069,7 +1992,6 @@ msgstr ""
 "Is the nature of the research question medical (as defined by the Medical "
 "Research Involving Human Subjects Act (WMO))?"
 
-#: proposals/models.py:758
 #: proposals/models.py:758
 msgid ""
 "De definitie van medisch-wetenschappelijk onderzoek is: Medisch-"
@@ -2092,7 +2014,6 @@ msgstr ""
 "research, 2005, ccmo.nl)"
 
 #: proposals/models.py:774
-#: proposals/models.py:774
 msgid ""
 "Je onderzoek moet beoordeeld worden door een METC, maar dient nog wel bij de "
 "FETC-GW te worden geregistreerd. Is dit onderzoek al aangemeld bij een METC?"
@@ -2102,16 +2023,13 @@ msgstr ""
 "submitted to an METC?"
 
 #: proposals/models.py:781
-#: proposals/models.py:781
 msgid "Is de METC al tot een beslissing gekomen?"
 msgstr "Has the METC already come to a decision?"
 
 #: proposals/models.py:786
-#: proposals/models.py:786
 msgid "Upload hier de beslissing van het METC (in .pdf of .doc(x)-formaat)"
 msgstr "Please upload the decision of METC  (in .pdf or .doc(x)-format) here"
 
-#: proposals/models.py:824
 #: proposals/models.py:824
 #, python-brace-format
 msgid "WMO {title}, status {status}"
@@ -2123,14 +2041,26 @@ msgid "Vergelijk documenten"
 msgstr "Compare documents"
 
 #: proposals/templates/proposals/compare_documents.html:51
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                Hier kan je twee versies van een document vergelijken. "
+#| "Standaard\n"
+#| "                geeft hij een <i>gecombineerde</i> versie weer, waarbij "
+#| "tekst\n"
+#| "                die verwijderd is in het rood is gemarkeerd en nieuwe "
+#| "tekst\n"
+#| "                in het groen is gemarkeerd.\n"
+#| "                "
 msgid ""
 "\n"
-"                Hier kan je twee versies van een document vergelijken. "
+"                    Hier kan je twee versies van een document vergelijken. "
 "Standaard\n"
-"                geeft hij een <i>gecombineerde</i> versie weer, waarbij "
+"                    geeft hij een <i>gecombineerde</i> versie weer, waarbij "
 "tekst\n"
-"                die verwijderd is in het rood is gemarkeerd en nieuwe tekst\n"
-"                in het groen is gemarkeerd.\n"
+"                    die verwijderd is in het rood is gemarkeerd en nieuwe "
+"tekst\n"
+"                    in het groen is gemarkeerd.\n"
 "                "
 msgstr ""
 "\n"
@@ -2141,10 +2071,18 @@ msgstr ""
 "                "
 
 #: proposals/templates/proposals/compare_documents.html:59
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                Je kan ook de bestanden naast elkaar bekijken, met "
+#| "dezelfde\n"
+#| "                markeringen. Klik hiervoor op 'Bekijk apart'.\n"
+#| "                "
 msgid ""
 "\n"
-"                Je kan ook de bestanden naast elkaar bekijken, met dezelfde\n"
-"                markeringen. Klik hiervoor op 'Bekijk apart'.\n"
+"                    Je kan ook de bestanden naast elkaar bekijken, met "
+"dezelfde\n"
+"                    markeringen. Klik hiervoor op 'Bekijk apart'.\n"
 "                "
 msgstr ""
 "\n"
@@ -2218,10 +2156,6 @@ msgstr ""
 #: proposals/templates/proposals/proposal_diff.html:211
 #: proposals/templates/proposals/proposal_diff.html:244
 #: proposals/templates/proposals/proposal_diff.html:268
-#: proposals/templates/proposals/proposal_diff.html:178
-#: proposals/templates/proposals/proposal_diff.html:211
-#: proposals/templates/proposals/proposal_diff.html:244
-#: proposals/templates/proposals/proposal_diff.html:268
 msgid "Originele aanvraag"
 msgstr "Original application"
 
@@ -2237,10 +2171,6 @@ msgstr "Original application"
 #: proposals/templates/proposals/diff/study.html:152
 #: proposals/templates/proposals/diff/study.html:216
 #: proposals/templates/proposals/proposal_diff.html:54
-#: proposals/templates/proposals/proposal_diff.html:179
-#: proposals/templates/proposals/proposal_diff.html:212
-#: proposals/templates/proposals/proposal_diff.html:245
-#: proposals/templates/proposals/proposal_diff.html:269
 #: proposals/templates/proposals/proposal_diff.html:179
 #: proposals/templates/proposals/proposal_diff.html:212
 #: proposals/templates/proposals/proposal_diff.html:245
@@ -2341,16 +2271,6 @@ msgstr "yes,no,"
 #: proposals/templates/proposals/proposal_diff.html:250
 #: proposals/templates/proposals/proposal_diff.html:273
 #: proposals/templates/proposals/proposal_diff.html:274
-#: proposals/templates/proposals/proposal_diff.html:121
-#: proposals/templates/proposals/proposal_diff.html:122
-#: proposals/templates/proposals/proposal_diff.html:216
-#: proposals/templates/proposals/proposal_diff.html:217
-#: proposals/templates/proposals/proposal_diff.html:221
-#: proposals/templates/proposals/proposal_diff.html:222
-#: proposals/templates/proposals/proposal_diff.html:249
-#: proposals/templates/proposals/proposal_diff.html:250
-#: proposals/templates/proposals/proposal_diff.html:273
-#: proposals/templates/proposals/proposal_diff.html:274
 #: proposals/templates/proposals/proposal_pdf.html:109
 #: proposals/templates/proposals/proposal_pdf.html:125
 #: proposals/templates/proposals/proposal_pdf.html:182
@@ -2406,8 +2326,6 @@ msgstr ""
 #: proposals/templates/proposals/diff/study.html:247
 #: proposals/templates/proposals/diff/study.html:253
 #: proposals/templates/proposals/pdf/observation_v1.html:53
-#: proposals/templates/proposals/proposal_diff.html:228
-#: proposals/templates/proposals/proposal_diff.html:232
 #: proposals/templates/proposals/proposal_diff.html:228
 #: proposals/templates/proposals/proposal_diff.html:232
 #: proposals/templates/proposals/proposal_pdf.html:189
@@ -2814,8 +2732,6 @@ msgstr "General information about the application"
 
 #: proposals/templates/proposals/proposal_diff.html:133
 #: proposals/templates/proposals/proposal_diff.html:134
-#: proposals/templates/proposals/proposal_diff.html:133
-#: proposals/templates/proposals/proposal_diff.html:134
 #: proposals/templates/proposals/proposal_pdf.html:133
 #: proposals/templates/proposals/proposal_pdf.html:520
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:119
@@ -2823,7 +2739,6 @@ msgstr "General information about the application"
 msgid "onbekend"
 msgstr "unknown"
 
-#: proposals/templates/proposals/proposal_diff.html:174
 #: proposals/templates/proposals/proposal_diff.html:174
 #: proposals/templates/proposals/proposal_pdf.html:159
 #: proposals/templates/proposals/proposal_pdf_empty.html:104
@@ -2836,7 +2751,6 @@ msgstr ""
 "Ethical assessment by a Medical Ethical Testing Committee (METC) required?"
 
 #: proposals/templates/proposals/proposal_diff.html:207
-#: proposals/templates/proposals/proposal_diff.html:207
 #: proposals/templates/proposals/proposal_pdf.html:179
 #: proposals/templates/proposals/proposal_pdf_empty.html:120
 #: proposals/templates/proposals/wmo_application.html:7
@@ -2844,7 +2758,6 @@ msgstr ""
 msgid "Aanmelding bij de METC"
 msgstr "Registration with the METC"
 
-#: proposals/templates/proposals/proposal_diff.html:240
 #: proposals/templates/proposals/proposal_diff.html:240
 #: proposals/templates/proposals/proposal_pdf.html:201
 #: proposals/templates/proposals/proposal_pdf_empty.html:134
@@ -2854,7 +2767,6 @@ msgstr "Registration with the METC"
 msgid "Eén of meerdere trajecten?"
 msgstr "One or more trajectories?"
 
-#: proposals/templates/proposals/proposal_diff.html:264
 #: proposals/templates/proposals/proposal_diff.html:264
 #: proposals/templates/proposals/proposal_submit.html:179
 msgid "Concept-aanmelding versturen"
@@ -3044,11 +2956,17 @@ msgid "Aanmelding versturen"
 msgstr "Submit application"
 
 #: proposals/templates/proposals/proposal_pdf_empty.html:42
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "    FETC-GW - <em>naam aanvraag</em> (referentienummer "
+#| "<em>referentienummer</em>)\n"
+#| "    "
 msgid ""
 "\n"
-"    FETC-GW - <em>naam aanvraag</em> (referentienummer <em>referentienummer</"
-"em>)\n"
-"    "
+"            FETC-GW - <em>naam aanvraag</em> (referentienummer "
+"<em>referentienummer</em>)\n"
+"        "
 msgstr ""
 "\n"
 "    FEtC-H - <em>application name</em> (reference number <em>reference "
@@ -3056,10 +2974,15 @@ msgstr ""
 "    "
 
 #: proposals/templates/proposals/proposal_pdf_empty.html:56
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            Referentienummer <em>referentienummer</em>\n"
+#| "            "
 msgid ""
 "\n"
-"            Referentienummer <em>referentienummer</em>\n"
-"            "
+"                    Referentienummer <em>referentienummer</em>\n"
+"                "
 msgstr ""
 "\n"
 "            Reference number <em>reference number</em>\n"
@@ -3080,12 +3003,18 @@ msgid "Taak"
 msgstr "Task"
 
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:42
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    FETC-GW - Aanvraag elders al goedgekeurde aanvraag <em>%(title)s</em> "
+#| "(referentienummer %(reference_number)s, ingediend door %(submitter)s)\n"
+#| "    "
 msgid ""
 "\n"
-"    FETC-GW - Aanvraag elders al goedgekeurde aanvraag <em>%(title)s</em> "
-"(referentienummer %(reference_number)s, ingediend door %(submitter)s)\n"
-"    "
+"            FETC-GW - Aanvraag elders al goedgekeurde aanvraag "
+"<em>%(title)s</em> (referentienummer %(reference_number)s, ingediend door "
+"%(submitter)s)\n"
+"        "
 msgstr ""
 "\n"
 "    FEtC-H - Application for preapproved assessment <em>%(title)s</em> "
@@ -3094,23 +3023,32 @@ msgstr ""
 
 #: proposals/templates/proposals/proposal_pdf_pre_approved.html:56
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:55
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "            Referentienummer %(reference_number)s\n"
+#| "            "
 msgid ""
 "\n"
-"            Referentienummer %(reference_number)s\n"
-"            "
+"                    Referentienummer %(reference_number)s\n"
+"                "
 msgstr ""
 "\n"
 "            Reference number %(reference_number)s\n"
 "            "
 
 #: proposals/templates/proposals/proposal_pdf_pre_assessment.html:41
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    FETC-GW - Aanvraag voor voortoetsing <em>%(title)s</em> "
+#| "(referentienummer %(reference_number)s, ingediend door %(submitter)s)\n"
+#| "    "
 msgid ""
 "\n"
-"    FETC-GW - Aanvraag voor voortoetsing <em>%(title)s</em> "
+"            FETC-GW - Aanvraag voor voortoetsing <em>%(title)s</em> "
 "(referentienummer %(reference_number)s, ingediend door %(submitter)s)\n"
-"    "
+"        "
 msgstr ""
 "\n"
 "    FEtC-H - Application for preliminary assessment <em>%(title)s</em> "
@@ -3790,11 +3728,9 @@ msgid "Versturen"
 msgstr "Submit"
 
 #: proposals/utils/proposal_utils.py:416
-#: proposals/utils/proposal_utils.py:416
 msgid "FETC-GW: gereviseerde aanvraag gebruikt labfaciliteiten"
 msgstr "FEtC-H: A revised application uses lab facilities"
 
-#: proposals/utils/proposal_utils.py:418
 #: proposals/utils/proposal_utils.py:418
 msgid "FETC-GW: nieuwe aanvraag gebruikt labfaciliteiten"
 msgstr "FEtC-H: New application uses lab facilities"
@@ -3845,47 +3781,38 @@ msgstr ""
 "application."
 
 #: proposals/views/proposal_views.py:43
-#: proposals/views/proposal_views.py:43
 msgid "Publiek archief"
 msgstr "Public archive"
 
-#: proposals/views/proposal_views.py:44
 #: proposals/views/proposal_views.py:44
 msgid "Dit overzicht toont alle goedgekeurde aanvragen."
 msgstr "This overview shows all approved applications."
 
 #: proposals/views/proposal_views.py:63
-#: proposals/views/proposal_views.py:63
 msgid "Mijn aanvraag"
 msgstr "My application"
 
-#: proposals/views/proposal_views.py:64
 #: proposals/views/proposal_views.py:64
 msgid "Dit overzicht toont al je aanvragen."
 msgstr "This overview shows all your applications."
 
 #: proposals/views/proposal_views.py:77
-#: proposals/views/proposal_views.py:77
 msgid "Dit overzicht toont al je nog niet ingediende aanvragen."
 msgstr "This overview shows all the applications you have not yet submitted."
 
-#: proposals/views/proposal_views.py:89
 #: proposals/views/proposal_views.py:89
 msgid "Dit overzicht toont al je ingediende aanvragen."
 msgstr "This overview shows all the applications you have submitted."
 
 #: proposals/views/proposal_views.py:101
-#: proposals/views/proposal_views.py:101
 msgid "Dit overzicht toont al je beoordeelde aanvragen."
 msgstr "This overview shows all your applications that have been assessed."
 
-#: proposals/views/proposal_views.py:114
 #: proposals/views/proposal_views.py:114
 msgid ""
 "Dit overzicht toont alle aanvragen waarvan je eindverantwoordelijke bent."
 msgstr "This overview shows all your supervised applications."
 
-#: proposals/views/proposal_views.py:127
 #: proposals/views/proposal_views.py:127
 msgid ""
 "Dit overzicht toont alle oefenaanvragen waar je als student, onderzoeker of "
@@ -3894,15 +3821,15 @@ msgstr ""
 "This overview shows all practice applications in which you are involved as a "
 "student, researcher or accountable researcher."
 
-#: proposals/views/proposal_views.py:242
+#: proposals/views/proposal_views.py:246
 msgid "Aanvraag verwijderd"
 msgstr "Application deleted"
 
-#: proposals/views/proposal_views.py:380
+#: proposals/views/proposal_views.py:384
 msgid "Wijzigingen opgeslagen"
 msgstr "Changes saved"
 
-#: proposals/views/proposal_views.py:481
+#: proposals/views/proposal_views.py:485
 msgid "Aanvraag gekopieerd"
 msgstr "Application copied"
 
@@ -4056,32 +3983,26 @@ msgid "Niet verder in behandeling genomen"
 msgstr "Not to be assessed further"
 
 #: reviews/models.py:51 reviews/models.py:178
-#: reviews/models.py:51 reviews/models.py:178
 #: reviews/templates/reviews/review_table.html:9
 msgid "Beslissing"
 msgstr "Decision"
 
 #: reviews/models.py:126
-#: reviews/models.py:126
 msgid "Onbekend"
 msgstr "Unknown"
 
-#: reviews/models.py:143
 #: reviews/models.py:143
 msgid "nog geen route"
 msgstr "no route assigned"
 
 #: reviews/models.py:172
-#: reviews/models.py:172
 msgid "goedgekeurd"
 msgstr "endorsed"
 
 #: reviews/models.py:173
-#: reviews/models.py:173
 msgid "niet goedgekeurd"
 msgstr "not endorsed"
 
-#: reviews/models.py:174
 #: reviews/models.py:174
 msgid "revisie noodzakelijk"
 msgstr "revision necessary"
@@ -4585,11 +4506,16 @@ msgid "Dit is een beslissing van een eindverantwoordelijke"
 msgstr "This is a supervisor review"
 
 #: reviews/templates/reviews/review_detail_sidebar.html:107
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                Deze aanvraag heeft een revisie gehad tijdens het "
+#| "beslisproces.\n"
+#| "            "
 msgid ""
 "\n"
-"                Deze aanvraag heeft een revisie gehad tijdens het "
-"beslisproces.\n"
-"            "
+"            Deze aanvraag heeft een revisie gehad tijdens het beslisproces.\n"
+"        "
 msgstr ""
 "\n"
 "        A revision was made to this application after it was submitted to "
@@ -4597,10 +4523,15 @@ msgstr ""
 "    "
 
 #: reviews/templates/reviews/review_detail_sidebar.html:111
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                    Er zijn de volgende opmerkingen bijgevoegd:<br/>\n"
+#| "                "
 msgid ""
 "\n"
-"                    Er zijn de volgende opmerkingen bijgevoegd:<br/>\n"
-"                "
+"                Er zijn de volgende opmerkingen bijgevoegd:<br/>\n"
+"            "
 msgstr ""
 "\n"
 "            The following comments have been provided:<br/>\n"
@@ -4771,26 +4702,21 @@ msgid "Plaats aanvraag in het archief."
 msgstr "Add this application to the archive"
 
 #: reviews/utils/review_utils.py:54
-#: reviews/utils/review_utils.py:54
 msgid "FETC-GW {}: bevestiging indienen concept-aanmelding"
 msgstr "FEtC-H {}: confirmation of draft application submission"
 
-#: reviews/utils/review_utils.py:74
 #: reviews/utils/review_utils.py:74
 msgid "FETC-GW {}: beoordelen als eindverantwoordelijke"
 msgstr "FEtC-H {}: assess as researcher with final responsibility"
 
 #: reviews/utils/review_utils.py:124
-#: reviews/utils/review_utils.py:124
 msgid "FETC-GW {}: aanmelding ontvangen"
 msgstr "FEtC-H {}: application received"
 
 #: reviews/utils/review_utils.py:218
-#: reviews/utils/review_utils.py:218
 msgid "FETC-GW {}: nieuwe aanvraag voor voortoetsing"
 msgstr "FEtC-H {}: new application for preliminary assessment"
 
-#: reviews/utils/review_utils.py:232
 #: reviews/utils/review_utils.py:232
 msgid "FETC-GW {}: bevestiging indienen aanvraag voor voortoetsing"
 msgstr ""
@@ -4798,21 +4724,17 @@ msgstr ""
 "assessment"
 
 #: reviews/utils/review_utils.py:281
-#: reviews/utils/review_utils.py:281
 msgid "FETC-GW {}: nieuwe aanvraag ingediend"
 msgstr "FEtC-H {}: new application submitted"
 
-#: reviews/utils/review_utils.py:296
 #: reviews/utils/review_utils.py:296
 msgid "FETC-GW {}: nieuwe beoordeling toegevoegd"
 msgstr "FEtC-H {}: new decision added"
 
 #: reviews/utils/review_utils.py:312
-#: reviews/utils/review_utils.py:312
 msgid "FETC-GW {}: eindverantwoordelijke heeft je aanvraag beoordeeld"
 msgstr "FEtC-H {}: a supervisor has reviewed your application"
 
-#: reviews/utils/review_utils.py:338
 #: reviews/utils/review_utils.py:338
 msgid "De aanvraag bevat het gebruik van wilsonbekwame volwassenen."
 msgstr ""
@@ -4820,11 +4742,9 @@ msgstr ""
 "consent."
 
 #: reviews/utils/review_utils.py:341
-#: reviews/utils/review_utils.py:341
 msgid "De aanvraag bevat het gebruik van misleiding."
 msgstr "The application contains the use of misrepresentation."
 
-#: reviews/utils/review_utils.py:344
 #: reviews/utils/review_utils.py:344
 msgid ""
 "Er bestaat een hiërarchische relatie tussen de onderzoeker(s) en deelnemer(s)"
@@ -4832,11 +4752,9 @@ msgstr ""
 "A hierarchal relationship between researcher(s) and participant(s) exists."
 
 #: reviews/utils/review_utils.py:347
-#: reviews/utils/review_utils.py:347
 msgid "Het onderzoek verzamelt bijzondere persoonsgegevens."
 msgstr "This study collects special or sensitive personal details."
 
-#: reviews/utils/review_utils.py:350
 #: reviews/utils/review_utils.py:350
 msgid ""
 "Het onderzoek selecteert deelnemers op bijzondere kenmerken die wellicht "
@@ -4845,7 +4763,6 @@ msgstr ""
 "The study selects participants based on particular characteristics which "
 "might entail increased vulnerability."
 
-#: reviews/utils/review_utils.py:356
 #: reviews/utils/review_utils.py:356
 msgid ""
 "De onderzoeker geeft aan dat (of twijfelt erover of) het onderzoek op "
@@ -4857,7 +4774,6 @@ msgstr ""
 "informed consent it might raise questions."
 
 #: reviews/utils/review_utils.py:360
-#: reviews/utils/review_utils.py:360
 msgid ""
 "De onderzoeker geeft aan dat (of twijfelt erover of) de risico's op "
 "psychische of fysieke schade bij deelname aan het onderzoek meer dan "
@@ -4867,7 +4783,6 @@ msgstr ""
 "psychological or physical harm in participating in the study are more than "
 "minimal."
 
-#: reviews/utils/review_utils.py:367
 #: reviews/utils/review_utils.py:367
 #, python-brace-format
 msgid ""
@@ -4880,14 +4795,12 @@ msgstr ""
 "({max_d} minutes) for the age group {ag}."
 
 #: reviews/utils/review_utils.py:384
-#: reviews/utils/review_utils.py:384
 #, python-brace-format
 msgid "Het onderzoek observeert deelnemers in de volgende setting: {s}"
 msgstr ""
 "The application contains sessions with participants in the following "
 "setting: {s}"
 
-#: reviews/utils/review_utils.py:388
 #: reviews/utils/review_utils.py:388
 msgid ""
 "Het onderzoek observeert deelnemers in een niet-publieke ruimte en werkt met "
@@ -4896,7 +4809,6 @@ msgstr ""
 "The study observes participants in a non-public space and works with "
 "retrospective informed consent."
 
-#: reviews/utils/review_utils.py:390
 #: reviews/utils/review_utils.py:390
 msgid ""
 "De onderzoeker begeeft zich \"under cover\" in een beheerde niet-publieke "
@@ -4908,11 +4820,9 @@ msgstr ""
 "and/or collects data which can be traced back to individuals."
 
 #: reviews/utils/review_utils.py:395
-#: reviews/utils/review_utils.py:395
 msgid "De aanvraag bevat het gebruik van {}"
 msgstr "The application makes use of {}"
 
-#: reviews/utils/review_utils.py:416
 #: reviews/utils/review_utils.py:416
 msgid ""
 "De aanvraag bevat psychofysiologische metingen bij kinderen onder de {} jaar."
@@ -4931,6 +4841,37 @@ msgstr "Pending decisions committee members"
 #: reviews/views.py:200
 msgid "Openstaande besluiten eindverantwoordelijken"
 msgstr "Pending decisions supervisors"
+
+#: src/uil-django-core/uil/rest_client/clients/_base.py:104
+#: src/uil-django-core/uil/rest_client/clients/_base.py:107
+msgid "api:host_unreachable"
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:28
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:29
+msgid "This field cannot be null."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:30
+msgid "This field cannot be blank."
+msgstr ""
+
+#: src/uil-django-core/uil/rest_client/fields.py:31
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: src/uil-django-core/uil/rest_client/fields.py:35
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
 
 #: studies/forms.py:41
 msgid ""
@@ -5348,9 +5289,16 @@ msgstr ""
 "pdf or .doc(x)-format)"
 
 #: studies/templates/studies/session_start.html:21
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                In de volgende vragen gaan we nader in op wat je in jouw "
+#| "onderzoek van je deelnemers zal verlangen. Daarbij gelden de volgende "
+#| "definities:\n"
+#| "                "
 msgid ""
 "\n"
-"                In de volgende vragen gaan we nader in op wat je in jouw "
+"                    In de volgende vragen gaan we nader in op wat je in jouw "
 "onderzoek van je deelnemers zal verlangen. Daarbij gelden de volgende "
 "definities:\n"
 "                "
@@ -5361,17 +5309,30 @@ msgstr ""
 "    "
 
 #: studies/templates/studies/session_start.html:26
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                <strong>Sessie:</strong> Het geheel van de voor je "
+#| "onderzoek benodigde betrokkenheid die je op één dag van een deelnemer "
+#| "vraagt. Bij een labonderzoek is dat bijvoorbeeld alles wat er van "
+#| "onderzoekswege gebeurt vanaf het moment dat je de deelnemer ontvangt tot "
+#| "het moment dat je afscheid neemt, inclusief de benodigde pauzes. En bij "
+#| "een internet-vragenlijst is dat alles wat er van onderzoekswege gebeurt "
+#| "vanaf het welkomstscherm tot de afronding van de (reeks) vragenlijst(en), "
+#| "wederom inclusief benodigde pauzes. Bij veldwerk is dat de tijd dat je "
+#| "met de deelnemer in interactie bent op één dag.\n"
+#| "                "
 msgid ""
 "\n"
-"                <strong>Sessie:</strong> Het geheel van de voor je onderzoek "
-"benodigde betrokkenheid die je op één dag van een deelnemer vraagt. Bij een "
-"labonderzoek is dat bijvoorbeeld alles wat er van onderzoekswege gebeurt "
-"vanaf het moment dat je de deelnemer ontvangt tot het moment dat je afscheid "
-"neemt, inclusief de benodigde pauzes. En bij een internet-vragenlijst is dat "
-"alles wat er van onderzoekswege gebeurt vanaf het welkomstscherm tot de "
-"afronding van de (reeks) vragenlijst(en), wederom inclusief benodigde "
-"pauzes. Bij veldwerk is dat de tijd dat je met de deelnemer in interactie "
-"bent op één dag.\n"
+"                    <strong>Sessie:</strong> Het geheel van de voor je "
+"onderzoek benodigde betrokkenheid die je op één dag van een deelnemer "
+"vraagt. Bij een labonderzoek is dat bijvoorbeeld alles wat er van "
+"onderzoekswege gebeurt vanaf het moment dat je de deelnemer ontvangt tot het "
+"moment dat je afscheid neemt, inclusief de benodigde pauzes. En bij een "
+"internet-vragenlijst is dat alles wat er van onderzoekswege gebeurt vanaf "
+"het welkomstscherm tot de afronding van de (reeks) vragenlijst(en), wederom "
+"inclusief benodigde pauzes. Bij veldwerk is dat de tijd dat je met de "
+"deelnemer in interactie bent op één dag.\n"
 "                "
 msgstr ""
 "\n"
@@ -5387,21 +5348,38 @@ msgstr ""
 "    "
 
 #: studies/templates/studies/session_start.html:31
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                <strong>Taak:</strong> Een coherente verzameling "
+#| "handelingen die je via een gesproken of geschreven taak-instructie aan de "
+#| "deelnemer oplegt, en ook als zodanig als 'taak' in een artikel zou "
+#| "beschrijven (bijvoorbeeld: \"Beluister de volgende 200 zinnetjes en druk "
+#| "op een knop als je een fout ontdekt\", \"Vul persoonlijkheidsvragenlijst "
+#| "X in\", \"Speel 10 minuten met je kind zoals je dat thuis doet\", “houd 1 "
+#| "week een dagboek bij van jouw media-gebruik”, “wil je je gender "
+#| "identiteit beschrijven”, “maak foto’s van plekken in jouw leefomgeving "
+#| "die je bedreigend en inspirerend vindt”, “zoek en deel met ons 10 foto’s "
+#| "uit jouw prive-archief om je levensverhaal te kunnen vertellen”). Indien "
+#| "de specifieke opdracht aan de deelnemer per item varieert (bijvoorbeeld: "
+#| "\"bij een Nederlandse zin beoordeel je de betekenis, bij een Engelse zin "
+#| "de grammatica\"), beschouw dit dan gewoon als één taak.\n"
+#| "                "
 msgid ""
 "\n"
-"                <strong>Taak:</strong> Een coherente verzameling handelingen "
-"die je via een gesproken of geschreven taak-instructie aan de deelnemer "
-"oplegt, en ook als zodanig als 'taak' in een artikel zou beschrijven "
-"(bijvoorbeeld: \"Beluister de volgende 200 zinnetjes en druk op een knop als "
-"je een fout ontdekt\", \"Vul persoonlijkheidsvragenlijst X in\", \"Speel 10 "
-"minuten met je kind zoals je dat thuis doet\", “houd 1 week een dagboek bij "
-"van jouw media-gebruik”, “wil je je gender identiteit beschrijven”, “maak "
-"foto’s van plekken in jouw leefomgeving die je bedreigend en inspirerend "
-"vindt”, “zoek en deel met ons 10 foto’s uit jouw prive-archief om je "
-"levensverhaal te kunnen vertellen”). Indien de specifieke opdracht aan de "
-"deelnemer per item varieert (bijvoorbeeld: \"bij een Nederlandse zin "
-"beoordeel je de betekenis, bij een Engelse zin de grammatica\"), beschouw "
-"dit dan gewoon als één taak.\n"
+"                    <strong>Taak:</strong> Een coherente verzameling "
+"handelingen die je via een gesproken of geschreven taak-instructie aan de "
+"deelnemer oplegt, en ook als zodanig als 'taak' in een artikel zou "
+"beschrijven (bijvoorbeeld: \"Beluister de volgende 200 zinnetjes en druk op "
+"een knop als je een fout ontdekt\", \"Vul persoonlijkheidsvragenlijst X "
+"in\", \"Speel 10 minuten met je kind zoals je dat thuis doet\", “houd 1 week "
+"een dagboek bij van jouw media-gebruik”, “wil je je gender identiteit "
+"beschrijven”, “maak foto’s van plekken in jouw leefomgeving die je "
+"bedreigend en inspirerend vindt”, “zoek en deel met ons 10 foto’s uit jouw "
+"prive-archief om je levensverhaal te kunnen vertellen”). Indien de "
+"specifieke opdracht aan de deelnemer per item varieert (bijvoorbeeld: \"bij "
+"een Nederlandse zin beoordeel je de betekenis, bij een Engelse zin de "
+"grammatica\"), beschouw dit dan gewoon als één taak.\n"
 "                "
 msgstr ""
 "\n"
@@ -5736,22 +5714,30 @@ msgstr ""
 "            "
 
 #: studies/templates/studies/study_title.html:6
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Traject %(order)s (<em>%(name)s</em>)\n"
+#| "    "
 msgid ""
 "\n"
-"    Traject %(order)s (<em>%(name)s</em>)\n"
-"    "
+"                Traject %(order)s (<em>%(name)s</em>)\n"
+"            "
 msgstr ""
 "\n"
 "    Trajectory %(order)s (<em>%(name)s</em>)\n"
 "    "
 
 #: studies/templates/studies/study_title.html:10
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Traject %(order)s\n"
+#| "    "
 msgid ""
 "\n"
-"    Traject %(order)s\n"
-"    "
+"                Traject %(order)s\n"
+"            "
 msgstr ""
 "\n"
 "    Trajectory %(order)s\n"
@@ -5972,33 +5958,46 @@ msgid "Taak {} in sessie {}"
 msgstr "Task {} in session {}"
 
 #: tasks/templates/tasks/session_title.html:6
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Traject %(study_order)s (<em>%(study_name)s</em>), sessie %(order)s\n"
+#| "    "
 msgid ""
 "\n"
-"    Traject %(study_order)s (<em>%(study_name)s</em>), sessie %(order)s\n"
-"    "
+"                Traject %(study_order)s (<em>%(study_name)s</em>), sessie "
+"%(order)s\n"
+"            "
 msgstr ""
 "\n"
 "    Trajectory %(study_order)s (<em>%(study_name)s</em>), session %(order)s\n"
 "    "
 
 #: tasks/templates/tasks/session_title.html:12
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Traject %(study_order)s (<em>%(study_name)s</em>)\n"
+#| "    "
 msgid ""
 "\n"
-"    Traject %(study_order)s (<em>%(study_name)s</em>)\n"
-"    "
+"                Traject %(study_order)s (<em>%(study_name)s</em>)\n"
+"            "
 msgstr ""
 "\n"
 "    Trajectory %(study_order)s (<em>%(study_name)s</em>)\n"
 "    "
 
 #: tasks/templates/tasks/session_title.html:18
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Sessie %(order)s\n"
+#| "    "
 msgid ""
 "\n"
-"    Sessie %(order)s\n"
-"    "
+"                Sessie %(order)s\n"
+"            "
 msgstr ""
 "\n"
 "    Session %(order)s\n"
@@ -6032,12 +6031,17 @@ msgid ""
 msgstr "We will ask the same questions for each task on the next few pages."
 
 #: tasks/templates/tasks/task_title.html:6
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Traject %(study_order)s (<em>%(study_name)s</em>), sessie "
+#| "%(session_order)s, taak %(order)s\n"
+#| "    "
 msgid ""
 "\n"
-"    Traject %(study_order)s (<em>%(study_name)s</em>), sessie "
+"                Traject %(study_order)s (<em>%(study_name)s</em>), sessie "
 "%(session_order)s, taak %(order)s\n"
-"    "
+"            "
 msgstr ""
 "\n"
 "    Trajectory %(study_order)s (<em>%(study_name)s</em>), session "
@@ -6045,11 +6049,15 @@ msgstr ""
 "    "
 
 #: tasks/templates/tasks/task_title.html:12
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "    Sessie %(session_order)s, taak %(order)s\n"
+#| "    "
 msgid ""
 "\n"
-"    Sessie %(session_order)s, taak %(order)s\n"
-"    "
+"                Sessie %(session_order)s, taak %(order)s\n"
+"            "
 msgstr ""
 "\n"
 "    Session %(session_order)s, task %(order)s\n"

--- a/main/templates/auth/user_detail.html
+++ b/main/templates/auth/user_detail.html
@@ -47,70 +47,70 @@
 
             <table class="dt" data-language="{% datatables_lang %}">
                 <thead>
-                <tr>
-                    <th>{% trans "Referentienummer" %}</th>
-                    <th>{% trans "Eindverantwoordelijke" %}</th>
-                    <th>{% trans "Titel aanvraag" %}</th>
-                    <th>{% trans "Fase" %}</th>
-                    <th>{% trans "Datum ingediend" %}</th>
-                    <th>{% trans "Gewenste einddatum" %}</th>
-                    <th>{% trans "Mijn besluit" %}</th>
-                    <th>{% trans "Afhandeling" %}</th>
-                    <th>{% trans "Acties" %}</th>
-                </tr>
+                    <tr>
+                        <th>{% trans "Referentienummer" %}</th>
+                        <th>{% trans "Eindverantwoordelijke" %}</th>
+                        <th>{% trans "Titel aanvraag" %}</th>
+                        <th>{% trans "Fase" %}</th>
+                        <th>{% trans "Datum ingediend" %}</th>
+                        <th>{% trans "Gewenste einddatum" %}</th>
+                        <th>{% trans "Mijn besluit" %}</th>
+                        <th>{% trans "Afhandeling" %}</th>
+                        <th>{% trans "Acties" %}</th>
+                    </tr>
                 </thead>
                 <tbody>
-                {% for review in reviews %}
-                    <tr>
-                        <td>{{ review.proposal.reference_number }}</td>
-                        <td>{{ review.accountable_user.get_full_name }}</td>
-                        <td>{{ review.proposal.title }}</td>
-                        <td>{{ review.get_stage_display }}</td>
-                        <td data-order="{{ review.date_start|date:'c' }}">{{ review.date_start|date:"j M Y" }}</td>
-                        <td data-order="{{ review.date_start|date:'c' }}">{{ review.date_should_end|date:"j M Y" }}</td>
-                        <td>{{ decision.get_go_display|default:"" }}</td>
-                        <td>
-                            {% if review.stage == review.CLOSED %}
-                                {% if review.proposal.has_minor_revision %}
-                                    {{ review.get_continuation_display }}{% trans ', met revisie' %}
-                                {% else %}
-                                    {{ review.get_continuation_display }}
+                    {% for review in reviews %}
+                        <tr>
+                            <td>{{ review.proposal.reference_number }}</td>
+                            <td>{{ review.accountable_user.get_full_name }}</td>
+                            <td>{{ review.proposal.title }}</td>
+                            <td>{{ review.get_stage_display }}</td>
+                            <td data-order="{{ review.date_start|date:'c' }}">{{ review.date_start|date:"j M Y" }}</td>
+                            <td data-order="{{ review.date_start|date:'c' }}">{{ review.date_should_end|date:"j M Y" }}</td>
+                            <td>{{ decision.get_go_display|default:"" }}</td>
+                            <td>
+                                {% if review.stage == review.CLOSED %}
+                                    {% if review.proposal.has_minor_revision %}
+                                        {{ review.get_continuation_display }}{% trans ', met revisie' %}
+                                    {% else %}
+                                        {{ review.get_continuation_display }}
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <a href="{% url 'proposals:pdf' review.proposal.pk %}" target="_blank"><img
+                            </td>
+                            <td>
+                                <a href="{% url 'proposals:pdf' review.proposal.pk %}" target="_blank"><img
                                     src="{% static 'main/images/page_white_acrobat.png' %}"
                                     title="{% trans 'Aanvraag inzien' %}"></a>
-                            <a href="{% url 'reviews:detail' review.pk %}"><img
+                                <a href="{% url 'reviews:detail' review.pk %}"><img
                                     src="{% static 'main/images/zoom.png' %}" title="{% trans 'Details' %}"></a>
-                            {% if user|is_secretary and review.stage == review.ASSIGNMENT %}
-                                <a href="{% url 'reviews:assign' review.pk %}"><img
+                                {% if user|is_secretary and review.stage == review.ASSIGNMENT %}
+                                    <a href="{% url 'reviews:assign' review.pk %}"><img
                                         src="{% static 'reviews/images/user_add.png' %}"
                                         title="{% trans 'Aanstellen' %}"></a>
-                            {% elif user|is_secretary and review.stage == review.CLOSING %}
-                                <a href="{% url 'reviews:close' review.pk %}"><img
+                                {% elif user|is_secretary and review.stage == review.CLOSING %}
+                                    <a href="{% url 'reviews:close' review.pk %}"><img
                                         src="{% static 'reviews/images/accept.png' %}" title="{% trans 'Afsluiten' %}"></a>
-                            {% elif user|is_secretary and review.stage == review.CLOSED %}
-                                {% if review.continuation == review.GO or review.continuation == review.GO_POST_HOC %}
-                                    <a href="{% url 'proposals:archive_export' review.proposal.pk %}">
-                                        <img src="{% static 'reviews/images/website.png' %}"
-                                             title="{% trans 'Website export tekst' %}">
-                                    </a>
-                                    <a href="{% url 'proposals:confirmation' review.proposal.pk %}">
-                                        {% if not review.proposal.date_confirmed %}
-                                            <img src="{% static 'reviews/images/report_go.png' %}"
-                                                 title="{% trans 'Bevestigingsbrief versturen' %}">
-                                        {% else %}
-                                            <img src="{% static 'reviews/images/tick.png' %}"
-                                                 title="{% trans 'Bevestigingsbrief verstuurd' %}">
-                                        {% endif %}
-                                    </a>
+                                {% elif user|is_secretary and review.stage == review.CLOSED %}
+                                    {% if review.continuation == review.GO or review.continuation == review.GO_POST_HOC %}
+                                        <a href="{% url 'proposals:archive_export' review.proposal.pk %}">
+                                            <img src="{% static 'reviews/images/website.png' %}"
+                                                 title="{% trans 'Website export tekst' %}">
+                                        </a>
+                                        <a href="{% url 'proposals:confirmation' review.proposal.pk %}">
+                                            {% if not review.proposal.date_confirmed %}
+                                                <img src="{% static 'reviews/images/report_go.png' %}"
+                                                     title="{% trans 'Bevestigingsbrief versturen' %}">
+                                            {% else %}
+                                                <img src="{% static 'reviews/images/tick.png' %}"
+                                                     title="{% trans 'Bevestigingsbrief verstuurd' %}">
+                                            {% endif %}
+                                        </a>
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
+                            </td>
+                        </tr>
+                    {% endfor %}
                 </tbody>
             </table>
         </div>

--- a/main/templates/base/form_styling.html
+++ b/main/templates/base/form_styling.html
@@ -2,217 +2,217 @@
 
 <script>
 
-function warning_on_value(a, a_value, b)
-{
-    let input_a = $('input[name=' + a + ']');
-    input_a.change(function() {
-        var check = input_a.filter(':checked').val() === a_value;
+    function warning_on_value(a, a_value, b)
+    {
+        let input_a = $('input[name=' + a + ']');
+        input_a.change(function() {
+            var check = input_a.filter(':checked').val() === a_value;
 
-        $('#' + b).toggle(check);
-    });
-    input_a.change();
-}
+            $('#' + b).toggle(check);
+        });
+        input_a.change();
+    }
 
 //checks whether field 'a' has 'a_value', and if so, toggles field 'b'
-function depends_on_value(a, a_value, b)
-{
-    let input_a = $('input[name=' + a + ']');
-    let input_b = $('#id_' + b);
-    input_a.change(function() {
-        let check = input_a.filter(':checked').val() === a_value;
+    function depends_on_value(a, a_value, b)
+    {
+        let input_a = $('input[name=' + a + ']');
+        let input_b = $('#id_' + b);
+        input_a.change(function() {
+            let check = input_a.filter(':checked').val() === a_value;
 
         // Only if we don't want to show the field
-        if(!check) {
+            if(!check) {
             // clear the checkbox values for dependent fields to ensure secondary
             // dependencies disappear
-            let b_checkboxes = input_b.find('[type=checkbox]');
-            b_checkboxes.each(function() {
-                this.checked = false;
-            });
-            b_checkboxes.trigger('change');
-        }
-
-        input_b.parents('tr').toggle(check);
-    });
-    input_a.change();
-}
-
-function depends_on_hidden_value(a, a_value, b, header=false)
-{
-    let input_a = $('input[name=' + a + ']');
-    let input_b = $('#id_' + b);
-
-    input_a.change(function() {
-        let values = a_value;
-        if(!Array.isArray(values))
-        {
-            values = [a_value]
-        }
-        let check = false
-
-        values.forEach(function (val) {
-            if( input_a.val() === val )
-                check = true;
-        })
-
-        if(header)
-        {
-            input_b.parents('tr').prev().toggle(check);
-        }
-
-        input_b.parents('tr').toggle(check);
-    });
-    input_a.change();
-}
-
-function depends_on_list_value(a, a_value, b)
-{
-    let input_a = $('input[name=' + a + ']');
-    input_a.change(function() {
-        let values = input_a.filter(':checked').map(function() {
-            return this.value;
-        }).get();
-        $('#id_' + b).parent().parent().toggle(intersect(values, a_value).length > 0);
-    });
-    input_a.change();
-}
-
-function intersect(a, b)
-{
-    return a.filter(function (e) {
-        if (b.indexOf(e) !== -1) return true;
-    });
-}
-
-var postrequests = new Map(); //var to denote if a request is in progress
-
-// Checks whether a field is required given the selected inputs
-function check_field_required(input_name, field_name, required_input, app_name, model_name, header=false)
-{
-    // model_name is the name of the model as it is stored in the database (without punctuation)
-    // input_name is the name of the model as it is stored in the form (potentially with punctuation)
-    model_name = typeof model_name !== 'undefined' ? model_name : input_name;
-
-    let input = $('input[name=' + input_name + ']');
-    let r_input = $('#id_' + required_input);
-
-    let process_identifier = input_name.concat(' ', required_input);
-
-    input.change(function() {
-        // if a postrequest is in progress, abort that request
-        if (postrequests.has(process_identifier)) {
-            postrequests.get(process_identifier).abort();
-            postrequests.delete(process_identifier);
-        }
-        let checked_inputs = input.filter(':checked').map(function() {
-            return this.value;
-        }).get();
-
-        let url = "{% url 'main:check_requires' %}";
-        let params = {'value': checked_inputs, 'app': app_name, 'model': model_name, 'field': field_name};
-        let req = $.post(url, params, function(data) {
-            r_input.parents('tr').toggle(data.result);
-
-            // If we don't want to show the field, unselect all selected checkboxes of that field (if any)
-            if (data.result === false) {
-                let r_input_checkboxes = r_input.find('[type=checkbox]');
-                r_input_checkboxes.each(function() {
+                let b_checkboxes = input_b.find('[type=checkbox]');
+                b_checkboxes.each(function() {
                     this.checked = false;
                 });
-                r_input_checkboxes.trigger('change');
+                b_checkboxes.trigger('change');
             }
 
-            // Remove header if present
+            input_b.parents('tr').toggle(check);
+        });
+        input_a.change();
+    }
+
+    function depends_on_hidden_value(a, a_value, b, header=false)
+    {
+        let input_a = $('input[name=' + a + ']');
+        let input_b = $('#id_' + b);
+
+        input_a.change(function() {
+            let values = a_value;
+            if(!Array.isArray(values))
+            {
+                values = [a_value]
+            }
+            let check = false
+
+            values.forEach(function (val) {
+                if( input_a.val() === val )
+                    check = true;
+            })
+
             if(header)
             {
-                r_input.parents('tr').prev().toggle(data.result);
+                input_b.parents('tr').prev().toggle(check);
             }
-            //when the request is done, mark it undefined
-            postrequests.delete(process_identifier);
+
+            input_b.parents('tr').toggle(check);
         });
-        postrequests.set(process_identifier, req);
-    });
-    input.change();
-}
+        input_a.change();
+    }
+
+    function depends_on_list_value(a, a_value, b)
+    {
+        let input_a = $('input[name=' + a + ']');
+        input_a.change(function() {
+            let values = input_a.filter(':checked').map(function() {
+                return this.value;
+            }).get();
+            $('#id_' + b).parent().parent().toggle(intersect(values, a_value).length > 0);
+        });
+        input_a.change();
+    }
+
+    function intersect(a, b)
+    {
+        return a.filter(function (e) {
+            if (b.indexOf(e) !== -1) return true;
+        });
+    }
+
+    var postrequests = new Map(); //var to denote if a request is in progress
+
+// Checks whether a field is required given the selected inputs
+    function check_field_required(input_name, field_name, required_input, app_name, model_name, header=false)
+    {
+    // model_name is the name of the model as it is stored in the database (without punctuation)
+    // input_name is the name of the model as it is stored in the form (potentially with punctuation)
+        model_name = typeof model_name !== 'undefined' ? model_name : input_name;
+
+        let input = $('input[name=' + input_name + ']');
+        let r_input = $('#id_' + required_input);
+
+        let process_identifier = input_name.concat(' ', required_input);
+
+        input.change(function() {
+        // if a postrequest is in progress, abort that request
+            if (postrequests.has(process_identifier)) {
+                postrequests.get(process_identifier).abort();
+                postrequests.delete(process_identifier);
+            }
+            let checked_inputs = input.filter(':checked').map(function() {
+                return this.value;
+            }).get();
+
+            let url = "{% url 'main:check_requires' %}";
+            let params = {'value': checked_inputs, 'app': app_name, 'model': model_name, 'field': field_name};
+            let req = $.post(url, params, function(data) {
+                r_input.parents('tr').toggle(data.result);
+
+            // If we don't want to show the field, unselect all selected checkboxes of that field (if any)
+                if (data.result === false) {
+                    let r_input_checkboxes = r_input.find('[type=checkbox]');
+                    r_input_checkboxes.each(function() {
+                        this.checked = false;
+                    });
+                    r_input_checkboxes.trigger('change');
+                }
+
+            // Remove header if present
+                if(header)
+                {
+                    r_input.parents('tr').prev().toggle(data.result);
+                }
+            //when the request is done, mark it undefined
+                postrequests.delete(process_identifier);
+            });
+            postrequests.set(process_identifier, req);
+        });
+        input.change();
+    }
 
 // Adds a title row to a form field
-function add_title(field, title)
-{
-    var insert = $('<tr>').append($('<th>').append($('<strong>').text(title))).append($('<td>'));
-    $('#id_' + field).parents('tr').before(insert);
-}
+    function add_title(field, title)
+    {
+        var insert = $('<tr>').append($('<th>').append($('<strong>').text(title))).append($('<td>'));
+        $('#id_' + field).parents('tr').before(insert);
+    }
 
-$(function() {
+    $(function() {
     // Will put help texts as a tooltip on an information image
-    $("[id^=id]").each(function() {
-        var help = $(this).nextAll('.helptext');
-        if (help.html())
-        {
-            var label = $("th label[for^='" + $(this).attr('id') + "']").first();
-            label.after(` <img src="{% static 'main/images/information.png' %}">`);
-            label.next().qtip({
-                content: {
-                    text: help.html(),
-                },
-                hide: {
-                    fixed: true,
-                    delay: 500,
-                },
-            });
-            help.remove();
-        }
-    });
+        $("[id^=id]").each(function() {
+            var help = $(this).nextAll('.helptext');
+            if (help.html())
+            {
+                var label = $("th label[for^='" + $(this).attr('id') + "']").first();
+                label.after(` <img src="{% static 'main/images/information.png' %}">`);
+                label.next().qtip({
+                    content: {
+                        text: help.html(),
+                    },
+                    hide: {
+                        fixed: true,
+                        delay: 500,
+                    },
+                });
+                help.remove();
+            }
+        });
 
     // Will remove labels off table headers for checkbox/radio fields
-    $('input[type="radio"], input[type="checkbox"]').parents('tr').find('th label').contents().unwrap();
+        $('input[type="radio"], input[type="checkbox"]').parents('tr').find('th label').contents().unwrap();
 
     // Will automatically create tabindices
-    $('select[name!=language], input[type!=hidden], textarea, .pure-button').each(function(index) {
-        $(this).attr('tabindex', index + 1)
-    });
+        $('select[name!=language], input[type!=hidden], textarea, .pure-button').each(function(index) {
+            $(this).attr('tabindex', index + 1)
+        });
 
     // Will set a custom width for the language element
-    $('select[name="language"] + .select2-container').width('110px');
+        $('select[name="language"] + .select2-container').width('110px');
 
     // Will make each textarea auto-resize.
     // Copied from: http://stackoverflow.com/a/25621277
-    function h(e) {
-        $(e).css({'height': 'auto', 'overflow-y': 'hidden'}).height(e.scrollHeight);
-    }
-    $('textarea').each(function() {
-        h(this);
-    }).on('input', function() {
-        h(this);
-    });
+        function h(e) {
+            $(e).css({'height': 'auto', 'overflow-y': 'hidden'}).height(e.scrollHeight);
+        }
+        $('textarea').each(function() {
+            h(this);
+        }).on('input', function() {
+            h(this);
+        });
 
     // Prevents the backspace key from navigating back.
     // Copied from: http://stackoverflow.com/a/2768256
-    $(document).unbind('keydown').bind('keydown', function (event) {
-        var doPrevent = false;
-        if (event.keyCode === 8) {
-            var d = event.srcElement || event.target;
-            if ((d.tagName.toUpperCase() === 'INPUT' &&
-                 (
-                     d.type.toUpperCase() === 'TEXT' ||
-                     d.type.toUpperCase() === 'PASSWORD' ||
-                     d.type.toUpperCase() === 'FILE' ||
-                     d.type.toUpperCase() === 'SEARCH' ||
-                     d.type.toUpperCase() === 'EMAIL' ||
-                     d.type.toUpperCase() === 'URL' ||
-                     d.type.toUpperCase() === 'NUMBER' ||
-                     d.type.toUpperCase() === 'DATE' )
-                 ) ||
-                 d.tagName.toUpperCase() === 'TEXTAREA') {
-                doPrevent = d.readOnly || d.disabled;
+        $(document).unbind('keydown').bind('keydown', function (event) {
+            var doPrevent = false;
+            if (event.keyCode === 8) {
+                var d = event.srcElement || event.target;
+                if ((d.tagName.toUpperCase() === 'INPUT' &&
+                    (
+                        d.type.toUpperCase() === 'TEXT' ||
+                        d.type.toUpperCase() === 'PASSWORD' ||
+                        d.type.toUpperCase() === 'FILE' ||
+                        d.type.toUpperCase() === 'SEARCH' ||
+                        d.type.toUpperCase() === 'EMAIL' ||
+                        d.type.toUpperCase() === 'URL' ||
+                        d.type.toUpperCase() === 'NUMBER' ||
+                        d.type.toUpperCase() === 'DATE' )
+                ) ||
+                    d.tagName.toUpperCase() === 'TEXTAREA') {
+                        doPrevent = d.readOnly || d.disabled;
+                    }
+                else {
+                    doPrevent = true;
+                }
             }
-            else {
-                doPrevent = true;
-            }
-        }
 
-        if (doPrevent) {
-            event.preventDefault();
-        }
+            if (doPrevent) {
+                event.preventDefault();
+            }
+        });
     });
-});
 </script>

--- a/main/templates/base/login_header.html
+++ b/main/templates/base/login_header.html
@@ -6,6 +6,6 @@
         {% transformat "Welkom {}" user.get_full_name %}
         <a href="{% url 'logout' %}">({% trans 'Log uit' %})</a>
     {% endwith %}
-    {% else %}
+{% else %}
     &nbsp; {# UI requires a line here #}
 {% endif %}

--- a/main/templates/base/menu.html
+++ b/main/templates/base/menu.html
@@ -7,150 +7,150 @@
             <a class="pure-menu-link" href="{% url 'main:home' %}">{% trans "Startpagina" %}</a>
         </li>
         {% if user.is_authenticated %}
-        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{% trans "Mijn aanvragen" %}</a>
-            <ul class="pure-menu-children">
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:start' %}">{% trans "Nieuwe aanvraag starten" %}</a>
+            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                <a href="#" class="pure-menu-link">{% trans "Mijn aanvragen" %}</a>
+                <ul class="pure-menu-children">
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:start' %}">{% trans "Nieuwe aanvraag starten" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:copy' %}">{% trans "Nieuwe studie starten op basis van een kopie van een oude studie" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:start_pre' %}">{% trans "Nieuwe voortoetsing aanvraag starten" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:start_pre_approved' %}">{% trans "Nieuwe aanvraag starten (die al goedgekeurd is door een andere ethische toetsingscommissie)" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:copy_revision' %}">{% trans "Maak een revisie van een bestaande aanvraag" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:copy_amendment' %}">{% trans "Maak een amendement van een al goedgekeurde aanvraag" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_concepts' %}">{% trans "Mijn conceptaanvragen" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_practice' %}">{% trans "Mijn oefenaanvragen" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_submitted' %}">{% trans "Mijn ingediende aanvragen" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_completed' %}">{% trans "Mijn afgehandelde aanvragen" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_supervised' %}">{% trans "Mijn aanvragen als eindverantwoordelijke" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:my_archive' %}">{% trans "Al mijn aanvragen" %}</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                <a href="#" class="pure-menu-link">{% trans "Archief" %}</a>
+                <ul class="pure-menu-children">
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:archive' 'AK' %}">{% trans "Alle aanvragen bekijken van de Algemene Kamer" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'proposals:archive' 'LK' %}">{% trans "Alle aanvragen bekijken van de Linguïstiek Kamer" %}</a>
+                    </li>
+                    {% if user|is_secretary %}
+                        <li class="pure-menu-item">
+                            <a class="pure-menu-link" href="{% url 'proposals:archive_export' %}">{% trans "Site-export" %}</a>
+                        </li>
+                    {% endif %}
+                </ul>
+            </li>
+            {% if user|in_general_chamber %}
+                <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                    <a href="#" class="pure-menu-link">{% trans "Algemene Kamer" %}</a>
+                    <ul class="pure-menu-children">
+                        <li class="pure-menu-item">
+                            <a class="pure-menu-link" href="{% url 'reviews:my_open' 'AK' %}">{% trans "Mijn openstaande besluiten" %}</a>
+                        </li>
+                        <li class="pure-menu-item">
+                            <a class="pure-menu-link" href="{% url 'reviews:my_archive' 'AK' %}">{% trans "Al mijn besluiten" %}</a>
+                        </li>
+                        {% if user|is_secretary %}
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:open' 'AK' %}">{% trans "Alle openstaande besluiten commissieleden" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:open_supervisors' 'AK' %}">{% trans "Alle openstaande besluiten eindverantwoordelijken" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:to_conclude' 'AK' %}">{% trans "Nog af te handelen aanvragen" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:archive' 'AK' %}">{% trans "Alle ingezonden aanvragen" %}</a>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:copy' %}">{% trans "Nieuwe studie starten op basis van een kopie van een oude studie" %}</a>
+            {% endif %}
+            {% if user|in_linguistics_chamber %}
+                <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                    <a href="#" class="pure-menu-link">{% trans "Linguïstiek Kamer" %}</a>
+                    <ul class="pure-menu-children">
+                        <li class="pure-menu-item">
+                            <a class="pure-menu-link" href="{% url 'reviews:my_open' 'LK' %}">{% trans "Mijn openstaande besluiten" %}</a>
+                        </li>
+                        <li class="pure-menu-item">
+                            <a class="pure-menu-link" href="{% url 'reviews:my_archive' 'LK' %}">{% trans "Al mijn besluiten" %}</a>
+                        </li>
+                        {% if user|is_secretary %}
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:open' 'LK' %}">{% trans "Alle openstaande besluiten commissieleden" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:open_supervisors' 'LK' %}">{% trans "Alle openstaande besluiten eindverantwoordelijken" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:to_conclude' 'LK' %}">{% trans "Nog af te handelen aanvragen" %}</a>
+                            </li>
+                            <li class="pure-menu-item">
+                                <a class="pure-menu-link" href="{% url 'reviews:archive' 'LK' %}">{% trans "Alle ingezonden aanvragen" %}</a>
+                            </li>
+                        {% endif %}
+                    </ul>
                 </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:start_pre' %}">{% trans "Nieuwe voortoetsing aanvraag starten" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:start_pre_approved' %}">{% trans "Nieuwe aanvraag starten (die al goedgekeurd is door een andere ethische toetsingscommissie)" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:copy_revision' %}">{% trans "Maak een revisie van een bestaande aanvraag" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:copy_amendment' %}">{% trans "Maak een amendement van een al goedgekeurde aanvraag" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_concepts' %}">{% trans "Mijn conceptaanvragen" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_practice' %}">{% trans "Mijn oefenaanvragen" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_submitted' %}">{% trans "Mijn ingediende aanvragen" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_completed' %}">{% trans "Mijn afgehandelde aanvragen" %}</a>
-                </li>
-                 <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_supervised' %}">{% trans "Mijn aanvragen als eindverantwoordelijke" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:my_archive' %}">{% trans "Al mijn aanvragen" %}</a>
-                </li>
-            </ul>
-        </li>
-        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{% trans "Archief" %}</a>
-            <ul class="pure-menu-children">
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:archive' 'AK' %}">{% trans "Alle aanvragen bekijken van de Algemene Kamer" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:archive' 'LK' %}">{% trans "Alle aanvragen bekijken van de Linguïstiek Kamer" %}</a>
-                </li>
-                {% if user|is_secretary %}
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'proposals:archive_export' %}">{% trans "Site-export" %}</a>
-                </li>
-                {% endif %}
-            </ul>
-        </li>
-        {% if user|in_general_chamber %}
-        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{% trans "Algemene Kamer" %}</a>
-            <ul class="pure-menu-children">
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:my_open' 'AK' %}">{% trans "Mijn openstaande besluiten" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:my_archive' 'AK' %}">{% trans "Al mijn besluiten" %}</a>
-                </li>
-                {% if user|is_secretary %}
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:open' 'AK' %}">{% trans "Alle openstaande besluiten commissieleden" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:open_supervisors' 'AK' %}">{% trans "Alle openstaande besluiten eindverantwoordelijken" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:to_conclude' 'AK' %}">{% trans "Nog af te handelen aanvragen" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:archive' 'AK' %}">{% trans "Alle ingezonden aanvragen" %}</a>
-                </li>
-                {% endif %}
-            </ul>
-        </li>
-        {% endif %}
-        {% if user|in_linguistics_chamber %}
-        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{% trans "Linguïstiek Kamer" %}</a>
-            <ul class="pure-menu-children">
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:my_open' 'LK' %}">{% trans "Mijn openstaande besluiten" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:my_archive' 'LK' %}">{% trans "Al mijn besluiten" %}</a>
-                </li>
-                {% if user|is_secretary %}
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:open' 'LK' %}">{% trans "Alle openstaande besluiten commissieleden" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:open_supervisors' 'LK' %}">{% trans "Alle openstaande besluiten eindverantwoordelijken" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:to_conclude' 'LK' %}">{% trans "Nog af te handelen aanvragen" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'reviews:archive' 'LK' %}">{% trans "Alle ingezonden aanvragen" %}</a>
-                </li>
-                {% endif %}
-            </ul>
-        </li>
-        {% endif %}
-        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{% trans "Help" %}</a>
-            <ul class="pure-menu-children">
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl/" target="_blank">{% trans "FETC-GW website" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/" target="_blank">{% trans "Reglement Algemene Kamer (AK)" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/" target="_blank">{% trans " Reglement Linguïstiek Kamer (LK) " %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw" target="_blank">{% trans "Informed consent formulieren" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'faqs:list' %}">{% trans "FAQs" %}</a>
-                </li>
-                <li class="pure-menu-item">
-                    <a class="pure-menu-link" href="{% url 'feedback:create' %}">{% trans "Feedback" %}</a>
-                </li>
-            </ul>
-        </li>
-        <li class="pure-menu-item">
-            <a class="pure-menu-link" href="{% url 'logout' %}"><em>{% trans "Uitloggen" %}</em></a>
-        </li>
+            {% endif %}
+            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                <a href="#" class="pure-menu-link">{% trans "Help" %}</a>
+                <ul class="pure-menu-children">
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl/" target="_blank">{% trans "FETC-GW website" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/" target="_blank">{% trans "Reglement Algemene Kamer (AK)" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/" target="_blank">{% trans " Reglement Linguïstiek Kamer (LK) " %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw" target="_blank">{% trans "Informed consent formulieren" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'faqs:list' %}">{% trans "FAQs" %}</a>
+                    </li>
+                    <li class="pure-menu-item">
+                        <a class="pure-menu-link" href="{% url 'feedback:create' %}">{% trans "Feedback" %}</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="pure-menu-item">
+                <a class="pure-menu-link" href="{% url 'logout' %}"><em>{% trans "Uitloggen" %}</em></a>
+            </li>
         {% else %}
-        <li class="pure-menu-item">
-            <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl" target="_blank">{% trans "FETC-GW-website" %}</a>
-        </li>
-        <li class="pure-menu-item">
-            <a class="pure-menu-link" href="{% url 'login' %}"><em>{% trans "Inloggen" %}</em></a>
-        </li>
+            <li class="pure-menu-item">
+                <a class="pure-menu-link" href="http://fetc-gw.wp.hum.uu.nl" target="_blank">{% trans "FETC-GW-website" %}</a>
+            </li>
+            <li class="pure-menu-item">
+                <a class="pure-menu-link" href="{% url 'login' %}"><em>{% trans "Inloggen" %}</em></a>
+            </li>
         {% endif %}
 
         <li class="pure-menu-item">

--- a/main/templates/base/navigation.html
+++ b/main/templates/base/navigation.html
@@ -12,10 +12,10 @@
                 <li>
                     {% counter main_counter store %}
                     <div
-                            class="navigation-content
-                            {% if not item.url %}inactive{% endif %}
-                            {% if main_counter == active %}active{% endif %}
-                        "
+                        class="navigation-content
+                               {% if not item.url %}inactive{% endif %}
+                               {% if main_counter == active %}active{% endif %}
+                              "
                     >
                         {% if item.url %}
                             <a class="js-submit-redirect" href="{{ item.url }}">

--- a/main/templates/base/sidebar.html
+++ b/main/templates/base/sidebar.html
@@ -5,23 +5,23 @@
 <link rel="stylesheet" type="text/css" href="{% static 'main/progress.css' %}">
 
 <script>
-$(function() {
+    $(function() {
     // Add dividers
-    $('.progress li:even').prepend('<div class="item">');
+        $('.progress li:even').prepend('<div class="item">');
 
     // Set current item and remove previous URLs
-    $('a[href="{{request.path}}"]').prev().addClass('current');
+        $('a[href="{{request.path}}"]').prev().addClass('current');
 
     // Sidebar functionality
-    $('.progress').sidebar({side: 'right'});
-    $('.open-progress').click(function() {
-        $('.progress').show();
-        $('.progress').trigger('sidebar:open');
+        $('.progress').sidebar({side: 'right'});
+        $('.open-progress').click(function() {
+            $('.progress').show();
+            $('.progress').trigger('sidebar:open');
+        });
+        $('.close-progress').click(function() {
+            $('.progress').trigger('sidebar:close');
+        });
     });
-    $('.close-progress').click(function() {
-        $('.progress').trigger('sidebar:close');
-    });
-});
 </script>
 
 <button class="pure-button open-progress show-xs">{% trans "Toon voortgang" %}</button>
@@ -30,41 +30,41 @@ $(function() {
     <button class="pure-button close-progress">{% trans "Sluiten" %}</button>
     <h2>{% trans "Voortgang" %}</h2>
     <ul>
-    {% for item in nav_items %}
-        {% if not item.is_title %}
-        <li>
-            {% if item.url %}
-            <a class="sideBarLink js-submit-redirect {% if item.is_title %}title{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
-            {% else %}
-            <span class="{% if item.is_title %}title{% endif %}">{{ item.title }}</span>
-            {% endif %}
-        </li>
-        <li><div class="divider"></div></li>
-        {% for child in item.children %}
-            <li>
-                {% if child.url %}
-                <a class="ml-3 js-submit-redirect sideBarLink {% if child.is_title %}title{% endif %}" href="{{ child.url }}">{{ child.title }}</a>
-                {% else %}
-                <span class="ml-3 {% if child.is_title %}title{% endif %}">{{ child.title }}</span>
-                {% endif %}
-            </li>
-            <li><div class="divider"></div></li>
-            {% for subchild in child.children %}
+        {% for item in nav_items %}
+            {% if not item.is_title %}
                 <li>
-                    {% if subchild.url %}
-                    <a class="ml-5 js-submit-redirect sideBarLink" href="{{ subchild.url }}">{{ subchild.title }}</a>
+                    {% if item.url %}
+                        <a class="sideBarLink js-submit-redirect {% if item.is_title %}title{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
                     {% else %}
-                    <span class="ml-5">{{ subchild.title }}</span>
+                        <span class="{% if item.is_title %}title{% endif %}">{{ item.title }}</span>
                     {% endif %}
                 </li>
                 <li><div class="divider"></div></li>
-            {% endfor %}
+                {% for child in item.children %}
+                    <li>
+                        {% if child.url %}
+                            <a class="ml-3 js-submit-redirect sideBarLink {% if child.is_title %}title{% endif %}" href="{{ child.url }}">{{ child.title }}</a>
+                        {% else %}
+                            <span class="ml-3 {% if child.is_title %}title{% endif %}">{{ child.title }}</span>
+                        {% endif %}
+                    </li>
+                    <li><div class="divider"></div></li>
+                    {% for subchild in child.children %}
+                        <li>
+                            {% if subchild.url %}
+                                <a class="ml-5 js-submit-redirect sideBarLink" href="{{ subchild.url }}">{{ subchild.title }}</a>
+                            {% else %}
+                                <span class="ml-5">{{ subchild.title }}</span>
+                            {% endif %}
+                        </li>
+                        <li><div class="divider"></div></li>
+                    {% endfor %}
+                {% endfor %}
+            {% else %}
+                </ul>
+                <strong>{{ item.title }}</strong>
+                <ul>
+            {% endif %}
         {% endfor %}
-        {% else %}
-    </ul>
-        <strong>{{ item.title }}</strong>
-    <ul>
-        {% endif %}
-    {% endfor %}
     </ul>
 </div>

--- a/main/templates/error/400.html
+++ b/main/templates/error/400.html
@@ -10,9 +10,9 @@
                 {% trans 'Server error' %}
             </h2>
             <p>
-            {% blocktrans trimmed %}
-                Er is een fout opgetreden tijdens het opvragen van deze pagina.
-            {% endblocktrans %}
+                {% blocktrans trimmed %}
+                    Er is een fout opgetreden tijdens het opvragen van deze pagina.
+                {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans trimmed %}

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -102,127 +102,127 @@
                         {% blocktrans trimmed %}
                             Gebruik de juiste (meest recente) <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw" target="blank">voorbeelddocumenten</a> voor de <em>informed consent</em>. (de laatstse versie is van <u>december 2021</u>)</li>
                         {% endblocktrans %}
-                </li>
-                {% blocktrans trimmed %}
-                    <li>Voor advies over data management (plannen): <a href="mailto:datamanagement.gw@uu.nl">datamanagement.gw@uu.nl</a>.</li>
-                    <li>Voor advies over privacy zaken: <a href="mailto:privacy.gw@uu.nl">privacy.gw@uu.nl</a>.</li>
-                    <li>Voor vragen over de procedure: <a href="mailto:fetc-gw@uu.nl">Desiree Capel</a>.</li>
-                    <li>Voor vragen over de portal zelf: <a href="mailto:portalsupport.gw@uu.nl">portalsupport.gw@uu.nl</a>.</li>
-                {% endblocktrans %}
-            </ul>
+                    </li>
+                    {% blocktrans trimmed %}
+                        <li>Voor advies over data management (plannen): <a href="mailto:datamanagement.gw@uu.nl">datamanagement.gw@uu.nl</a>.</li>
+                        <li>Voor advies over privacy zaken: <a href="mailto:privacy.gw@uu.nl">privacy.gw@uu.nl</a>.</li>
+                        <li>Voor vragen over de procedure: <a href="mailto:fetc-gw@uu.nl">Desiree Capel</a>.</li>
+                        <li>Voor vragen over de portal zelf: <a href="mailto:portalsupport.gw@uu.nl">portalsupport.gw@uu.nl</a>.</li>
+                    {% endblocktrans %}
+                </ul>
 
-            <p>
-                {% blocktrans trimmed %}
-                    In deze portal kan je het volgende doen:
-                {% endblocktrans %}
-            </p>
+                <p>
+                    {% blocktrans trimmed %}
+                        In deze portal kan je het volgende doen:
+                    {% endblocktrans %}
+                </p>
+            </div>
         </div>
-</div>
-    <div class="uu-inner-container">
-        <div class="col-md-6 col-12">
-            <h5>
-                {% trans "Dien een nieuwe aanvraag in" %}
-            </h5>
+        <div class="uu-inner-container">
+            <div class="col-md-6 col-12">
+                <h5>
+                    {% trans "Dien een nieuwe aanvraag in" %}
+                </h5>
             {#                {% trans '(check de meest recente voorbeelddocumenten op <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw" target="_blank">intranet</a>)' %}#}
-            <ul class="startpage-ul">
-                <li>
-                    <a href="{% url 'proposals:start' %}">{% trans "die volledig nieuw is in deze portal;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:copy' %}">{% trans "op basis van een kopie van een oude aanvraag;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:start_pre' %}">{% trans "voor (al dan niet goedgekeurde) subsidieaanvragen;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:start_pre_approved' %}">{% trans "die al goedgekeurd is door een andere ethische toetsingscomissie." %}</a>
-                </li>
-            </ul>
-        </div>
-        <div class="col-md-6 col-12">
-            <h5>
-                {% trans "Een aanvraag reviseren" %}
-            </h5>
+                <ul class="startpage-ul">
+                    <li>
+                        <a href="{% url 'proposals:start' %}">{% trans "die volledig nieuw is in deze portal;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:copy' %}">{% trans "op basis van een kopie van een oude aanvraag;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:start_pre' %}">{% trans "voor (al dan niet goedgekeurde) subsidieaanvragen;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:start_pre_approved' %}">{% trans "die al goedgekeurd is door een andere ethische toetsingscomissie." %}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-md-6 col-12">
+                <h5>
+                    {% trans "Een aanvraag reviseren" %}
+                </h5>
             {#                {% trans '(check de meest recente voorbeelddocumenten op <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw" target="_blank">intranet</a>)' %}#}
-            <ul class="startpage-ul">
-                <li>
-                    <a href="{% url 'proposals:copy_revision' %}">{% trans "als een revisie, gebaseerd op opmerkingen van de FETC-GW;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:copy_amendment' %}">{% trans "als amendement, wanneer de aanvraag al goedgekeurd is door de FETC-GW." %}</a>
-                </li>
-            </ul>
+                <ul class="startpage-ul">
+                    <li>
+                        <a href="{% url 'proposals:copy_revision' %}">{% trans "als een revisie, gebaseerd op opmerkingen van de FETC-GW;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:copy_amendment' %}">{% trans "als amendement, wanneer de aanvraag al goedgekeurd is door de FETC-GW." %}</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-    <div class="uu-inner-container mt-2 mb-2">
-        <div class="col-md-6 col-12">
-            <h6>
-                {% trans "Bekijk" %}
-            </h6>
-            <ul class="startpage-ul">
-                <li>
-                    <a href="{% url 'proposals:my_concepts' %}">{% trans "mijn conceptaanvragen;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:my_practice' %}">{% trans "mijn oefenaanvragen;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:my_submitted' %}">{% trans "mijn ingediende aanvragen;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:my_completed' %}">{% trans "mijn afgehandelde aanvragen;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:my_supervised' %}">{% trans "mijn aanvragen als eindverantwoordelijke;" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:my_archive' %}">{% trans "al mijn aanvragen." %}</a>
-                </li>
-            </ul>
-            <h6 class="mt-2 d-inline-block">
-                {% trans 'FETC-GW archief' %}
-            </h6>
-            <ul class="startpage-ul">
-                <li>
-                    <a href="{% url 'proposals:archive' 'AK' %}">{% trans "Alle goedgekeurde aanvragen bekijken van de Algemene Kamer" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'proposals:archive' 'LK' %}">{% trans "Alle goedgekeurde aanvragen bekijken van de Linguïstiek Kamer" %}</a>
-                </li>
-            </ul>
+        <div class="uu-inner-container mt-2 mb-2">
+            <div class="col-md-6 col-12">
+                <h6>
+                    {% trans "Bekijk" %}
+                </h6>
+                <ul class="startpage-ul">
+                    <li>
+                        <a href="{% url 'proposals:my_concepts' %}">{% trans "mijn conceptaanvragen;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:my_practice' %}">{% trans "mijn oefenaanvragen;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:my_submitted' %}">{% trans "mijn ingediende aanvragen;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:my_completed' %}">{% trans "mijn afgehandelde aanvragen;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:my_supervised' %}">{% trans "mijn aanvragen als eindverantwoordelijke;" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:my_archive' %}">{% trans "al mijn aanvragen." %}</a>
+                    </li>
+                </ul>
+                <h6 class="mt-2 d-inline-block">
+                    {% trans 'FETC-GW archief' %}
+                </h6>
+                <ul class="startpage-ul">
+                    <li>
+                        <a href="{% url 'proposals:archive' 'AK' %}">{% trans "Alle goedgekeurde aanvragen bekijken van de Algemene Kamer" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'proposals:archive' 'LK' %}">{% trans "Alle goedgekeurde aanvragen bekijken van de Linguïstiek Kamer" %}</a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="col-md-6 col-12">
+                <h6>
+                    Help
+                </h6>
+                <ul class="startpage-ul">
+                    <li>
+                        <a href="http://fetc-gw.wp.hum.uu.nl/" target="_blank">{% trans "FETC-GW website" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% trans "https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/" %}"
+                           target="_blank">{% trans "Reglement van de FETC-GW" %}</a>
+                    </li>
+                    <li>
+                        <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw"
+                           target="_blank">{% trans "Informed consent formulieren" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'faqs:list' %}">{% trans "Veelgestelde vragen m.b.t. dit portal" %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'feedback:create' %}">{% trans "Feedback op dit portal geven" %}</a>
+                    </li>
+                </ul>
+
+
+            </div>
+
+            <hr> </hr>
+
+
+            <div class="col-12 mt-4">            <p>{% trans "Bannerfoto door Kim O'leary" %}</p></div>
+
         </div>
-
-        <div class="col-md-6 col-12">
-            <h6>
-                Help
-            </h6>
-            <ul class="startpage-ul">
-                <li>
-                    <a href="http://fetc-gw.wp.hum.uu.nl/" target="_blank">{% trans "FETC-GW website" %}</a>
-                </li>
-                <li>
-                    <a href="{% trans "https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/" %}"
-                       target="_blank">{% trans "Reglement van de FETC-GW" %}</a>
-                </li>
-                <li>
-                    <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw"
-                       target="_blank">{% trans "Informed consent formulieren" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'faqs:list' %}">{% trans "Veelgestelde vragen m.b.t. dit portal" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'feedback:create' %}">{% trans "Feedback op dit portal geven" %}</a>
-                </li>
-            </ul>
-
-
-        </div>
-
-        <hr> </hr>
-
-
-        <div class="col-12 mt-4">            <p>{% trans "Bannerfoto door Kim O'leary" %}</p></div>
-
-    </div>
 {% endblock %}

--- a/main/templates/main/setting_checks.html
+++ b/main/templates/main/setting_checks.html
@@ -1,15 +1,15 @@
 {% load static %}
 
 <script>
-$(function() {
-    check_field_required('setting', 'needs_details', 'setting_details', 'main');
-    check_field_required('setting', 'needs_supervision', 'supervision', 'main');
-    depends_on_value('supervision', 'False', 'leader_has_coc');
+    $(function() {
+        check_field_required('setting', 'needs_details', 'setting_details', 'main');
+        check_field_required('setting', 'needs_supervision', 'supervision', 'main');
+        depends_on_value('supervision', 'False', 'leader_has_coc');
 
-    $('input[name="leader_has_coc"]').change(function() {
-        if ($(this).val() === 'False') {
-            $(this).parents('tr').find('img').qtip('show');
-        }
+        $('input[name="leader_has_coc"]').change(function() {
+            if ($(this).val() === 'False') {
+                $(this).parents('tr').find('img').qtip('show');
+            }
+        });
     });
-});
 </script>

--- a/main/templates/registration/logged_out.html
+++ b/main/templates/registration/logged_out.html
@@ -15,12 +15,12 @@
                 <li>
                     {% url 'main:landing' as landing_url %}
                     {% blocktrans trimmed %}
-                    Klik  <a href="{{ landing_url }}">hier</a> om naar de startpagina te gaan.
+                        Klik  <a href="{{ landing_url }}">hier</a> om naar de startpagina te gaan.
                     {% endblocktrans %}
                 </li>
                 <li>
                     {% blocktrans trimmed %}
-                    Klik <a href="http://fetc-gw.wp.hum.uu.nl">hier</a> om terug te keren naar de FETC-GW-website.
+                        Klik <a href="http://fetc-gw.wp.hum.uu.nl">hier</a> om terug te keren naar de FETC-GW-website.
                     {% endblocktrans %}
                 </li>
             </ul>

--- a/observations/templates/observations/observation_form.html
+++ b/observations/templates/observations/observation_form.html
@@ -10,28 +10,28 @@
 
 {% block html_head %}
     <script>
-$(function() {
-    depends_on_value('is_nonpublic_space', 'True', 'has_advanced_consent');
-    depends_on_value('needs_approval', 'True', 'approval_institution');
-    depends_on_value('needs_approval', 'True', 'approval_document');
-    check_field_required('registrations', 'needs_details', 'registrations_details', 'observations', 'Registration');
+        $(function() {
+            depends_on_value('is_nonpublic_space', 'True', 'has_advanced_consent');
+            depends_on_value('needs_approval', 'True', 'approval_institution');
+            depends_on_value('needs_approval', 'True', 'approval_document');
+            check_field_required('registrations', 'needs_details', 'registrations_details', 'observations', 'Registration');
 
-    check_field_required('setting', 'is_school', 'needs_approval', 'main', 'Setting', true);
+            check_field_required('setting', 'is_school', 'needs_approval', 'main', 'Setting', true);
 
-    depends_on_value('is_anonymous', 'True', 'is_anonymous_details');
-    depends_on_value('is_in_target_group', 'True', 'is_in_target_group_details');
-    depends_on_value('is_nonpublic_space', 'True', 'is_nonpublic_space_details');
+            depends_on_value('is_anonymous', 'True', 'is_anonymous_details');
+            depends_on_value('is_in_target_group', 'True', 'is_in_target_group_details');
+            depends_on_value('is_nonpublic_space', 'True', 'is_nonpublic_space_details');
 
-    depends_on_value('has_advanced_consent', 'False', 'has_advanced_consent_details');
+            depends_on_value('has_advanced_consent', 'False', 'has_advanced_consent_details');
 
-    add_title('setting', "{% trans 'Setting' %}");
-    add_title('details_who', "{% trans 'Details observatie' %}");
-    add_title('is_anonymous', "{% trans 'Anonimiteit' %}");
-    add_title('needs_approval', "{% trans 'Toestemming' %}");
-    add_title('registrations', "{% trans 'Registratie gedrag' %}");
-});
-</script>
-{% include "main/setting_checks.html" %}
+            add_title('setting', "{% trans 'Setting' %}");
+            add_title('details_who', "{% trans 'Details observatie' %}");
+            add_title('is_anonymous', "{% trans 'Anonimiteit' %}");
+            add_title('needs_approval', "{% trans 'Toestemming' %}");
+            add_title('registrations', "{% trans 'Registratie gedrag' %}");
+        });
+    </script>
+    {% include "main/setting_checks.html" %}
 {% endblock %}
 
 {% block content %}
@@ -47,7 +47,7 @@ $(function() {
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% with proposal=observation.study.proposal %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/observations/templates/observations/observation_update_attachments.html
+++ b/observations/templates/observations/observation_update_attachments.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function() {
-    depends_on_hidden_value('passive_consent', 'True', 'passive_consent_details');
-    depends_on_hidden_value('passive_consent', 'True', 'director_consent_declaration');
-    depends_on_hidden_value('passive_consent', 'True', 'director_consent_information');
-    depends_on_hidden_value('passive_consent', 'True', 'parents_information');
-    depends_on_hidden_value('passive_consent', 'False', 'informed_consent');
-    depends_on_hidden_value('passive_consent', 'False', 'briefing');
-});
-</script>
+    <script>
+        $(function() {
+            depends_on_hidden_value('passive_consent', 'True', 'passive_consent_details');
+            depends_on_hidden_value('passive_consent', 'True', 'director_consent_declaration');
+            depends_on_hidden_value('passive_consent', 'True', 'director_consent_information');
+            depends_on_hidden_value('passive_consent', 'True', 'parents_information');
+            depends_on_hidden_value('passive_consent', 'False', 'informed_consent');
+            depends_on_hidden_value('passive_consent', 'False', 'briefing');
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -28,8 +28,8 @@ $(function() {
             </h2>
             <p>
                 {% blocktrans trimmed with title=study.proposal.title ref_number=study.proposal.reference_number order=study.order %}
-                Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
-                (referentienummer <em>{{ ref_number }}</em>), traject {{ order }}.
+                    Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
+                    (referentienummer <em>{{ ref_number }}</em>), traject {{ order }}.
                 {% endblocktrans %}
             </p>
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}

--- a/proposals/templates/easy_pdf/base.html
+++ b/proposals/templates/easy_pdf/base.html
@@ -1,59 +1,59 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <title>{{ title|default:"" }}</title>
+    <head>
+        <title>{{ title|default:"" }}</title>
 
-    {% block style_base %}
+        {% block style_base %}
         {% comment %}
             See DEFAULT_CSS in https://github.com/chrisglass/xhtml2pdf/blob/master/xhtml2pdf/default.py
             for base style.
         {% endcomment %}
 
-        {% block layout_style %}
-            <style type="text/css">
-                @page {
-                    size: {{ pagesize|default:"A4" }};
-                    margin-left: 2.5cm;
-                    margin-right: 2.5cm;
-                    margin-top: 2.5cm;
-                    margin-bottom: 2cm;
+            {% block layout_style %}
+                <style type="text/css">
+                    @page {
+                        size: {{ pagesize|default:"A4" }};
+                        margin-left: 2.5cm;
+                        margin-right: 2.5cm;
+                        margin-top: 2.5cm;
+                        margin-bottom: 2cm;
 
-                    @frame header {
-                        -pdf-frame-content: page-header;
-                        margin-top: 0.7cm;
-                        margin-right: 2mm;
-                        margin-bottom: 0cm;
-                        margin-left: 1.2cm;
+                        @frame header {
+                            -pdf-frame-content: page-header;
+                            margin-top: 0.7cm;
+                            margin-right: 2mm;
+                            margin-bottom: 0cm;
+                            margin-left: 1.2cm;
+                        }
+
+                        @frame footer {
+                            -pdf-frame-content: page-footer;
+                            bottom: 0cm;
+                            margin-left: 1cm;
+                            margin-right: 1cm;
+                            height: 1cm;
+                        }
                     }
+                </style>
+            {%endblock%}
+            {% block extra_style %}{% endblock %}
+        {% endblock %}
+    </head>
+    <body>
+        <div>
+            {%block page_header%}
+            {%endblock%}
 
-                    @frame footer {
-                        -pdf-frame-content: page-footer;
-                        bottom: 0cm;
-                        margin-left: 1cm;
-                        margin-right: 1cm;
-                        height: 1cm;
-                    }
-                }
-            </style>
-        {%endblock%}
-        {% block extra_style %}{% endblock %}
-    {% endblock %}
-</head>
-<body>
-    <div>
-        {%block page_header%}
-        {%endblock%}
+            {%block content%}
+            {%endblock%}
+        </div>
 
-        {%block content%}
-        {%endblock%}
-    </div>
-
-    <div id="page-footer">
-        {%block page_foot%}
+        <div id="page-footer">
+            {%block page_foot%}
             {% comment %}
                 <pdf:pagenumber />
             {% endcomment %}
-        {%endblock%}
-    </div>
-</body>
+            {%endblock%}
+        </div>
+    </body>
 </html>

--- a/proposals/templates/proposals/compare_documents.html
+++ b/proposals/templates/proposals/compare_documents.html
@@ -49,16 +49,16 @@
             <h2>{% trans 'Vergelijk documenten' %}</h2>
             <p>
                 {% blocktrans %}
-                Hier kan je twee versies van een document vergelijken. Standaard
-                geeft hij een <i>gecombineerde</i> versie weer, waarbij tekst
-                die verwijderd is in het rood is gemarkeerd en nieuwe tekst
-                in het groen is gemarkeerd.
+                    Hier kan je twee versies van een document vergelijken. Standaard
+                    geeft hij een <i>gecombineerde</i> versie weer, waarbij tekst
+                    die verwijderd is in het rood is gemarkeerd en nieuwe tekst
+                    in het groen is gemarkeerd.
                 {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans %}
-                Je kan ook de bestanden naast elkaar bekijken, met dezelfde
-                markeringen. Klik hiervoor op 'Bekijk apart'.
+                    Je kan ook de bestanden naast elkaar bekijken, met dezelfde
+                    markeringen. Klik hiervoor op 'Bekijk apart'.
                 {% endblocktrans %}
             </p>
             <h4>
@@ -76,20 +76,20 @@
             </button>
         </div>
     </div>
-        <div class="uu-inner-container document-compare">
-            <div class="col-6">
-                <p>
-                    <strong>{% trans "Oud" %}: </strong>
-                    <a href="{{ old_file.url }}" download="{{ old_file.name }}">{{ old_name }}</a>
-                </p>
-            </div>
-            <div class="col-6">
-                <p>
-                    <strong>{% trans "Nieuw" %}: </strong>
-                    <a href="{{ new_file.url }}" download="{{ new_file.name }}">{{ new_name }}</a>
-                </p>
-            </div>
+    <div class="uu-inner-container document-compare">
+        <div class="col-6">
+            <p>
+                <strong>{% trans "Oud" %}: </strong>
+                <a href="{{ old_file.url }}" download="{{ old_file.name }}">{{ old_name }}</a>
+            </p>
         </div>
+        <div class="col-6">
+            <p>
+                <strong>{% trans "Nieuw" %}: </strong>
+                <a href="{{ new_file.url }}" download="{{ new_file.name }}">{{ new_name }}</a>
+            </p>
+        </div>
+    </div>
     <div class="uu-inner-container compare">
         <div class="col-12 text-center mt-5 mb-5" id="loading-icon">
             <img src="{% static 'main/images/loading.gif' %}"/>

--- a/proposals/templates/proposals/diff/study.html
+++ b/proposals/templates/proposals/diff/study.html
@@ -84,7 +84,7 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-        
+
         {% if study|necessity_required or p_study|necessity_required %}
             <tr>
                 <th>{% get_verbose_field_name "studies" "study" "necessity" %}</th>
@@ -127,11 +127,11 @@
             <td>{{ study.hierarchy }}</td>
         </tr>
         {% if study.hierarchy or p_study.hierarchy %}
-        <tr>
-            <th>{% get_verbose_field_name "studies" "study" "hierarchy_details" %}</th>
-            <td>{{ p_study.hierarchy_details }}</td>
-            <td>{{ study.hierarchy_details }}</td>
-        </tr>
+            <tr>
+                <th>{% get_verbose_field_name "studies" "study" "hierarchy_details" %}</th>
+                <td>{{ p_study.hierarchy_details }}</td>
+                <td>{{ study.hierarchy_details }}</td>
+            </tr>
         {% endif %}
     </table>
 

--- a/proposals/templates/proposals/pdf/intervention_v1.html
+++ b/proposals/templates/proposals/pdf/intervention_v1.html
@@ -7,19 +7,19 @@
         <th>{% get_verbose_field_name "interventions" "intervention" "setting" %}</th><td>{{ intervention.setting.all|unordered_list }}</td>
     </tr>
     {% if intervention.setting.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td>{{ intervention.setting_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td>{{ intervention.setting_details }}</td>
+        </tr>
     {% endif %}
     {% if study.has_children and intervention.setting.all|needs_details:"needs_supervision" %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{{ intervention.supervision|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% if not intervention.supervision %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{{ intervention.leader_has_coc|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% endif %}
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{{ intervention.supervision|yesno:_("ja,nee") }}</td>
+        </tr>
+        {% if not intervention.supervision %}
+            <tr>
+                <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{{ intervention.leader_has_coc|yesno:_("ja,nee") }}</td>
+            </tr>
+        {% endif %}
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "interventions" "intervention" "period" %}</th><td>{{ intervention.period }}</td>
@@ -43,8 +43,8 @@
         <th>{% get_verbose_field_name "interventions" "intervention" "has_controls" %}</th><td>{{ intervention.has_controls|yesno:_("ja,nee") }}</td>
     </tr>
     {% if intervention.has_controls %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td>{{ intervention.controls_description }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td>{{ intervention.controls_description }}</td>
+        </tr>
     {% endif %}
 </table>

--- a/proposals/templates/proposals/pdf/intervention_v2.html
+++ b/proposals/templates/proposals/pdf/intervention_v2.html
@@ -7,19 +7,19 @@
         <th>{% get_verbose_field_name "interventions" "intervention" "setting" %}</th><td>{{ intervention.setting.all|unordered_list }}</td>
     </tr>
     {% if intervention.setting.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td>{{ intervention.setting_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td>{{ intervention.setting_details }}</td>
+        </tr>
     {% endif %}
     {% if study.has_children and intervention.setting.all|needs_details:"needs_supervision" %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{{ intervention.supervision|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% if not intervention.supervision %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{{ intervention.leader_has_coc|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% endif %}
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{{ intervention.supervision|yesno:_("ja,nee") }}</td>
+        </tr>
+        {% if not intervention.supervision %}
+            <tr>
+                <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{{ intervention.leader_has_coc|yesno:_("ja,nee") }}</td>
+            </tr>
+        {% endif %}
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "interventions" "intervention" "period" %}</th><td>{{ intervention.period }}</td>
@@ -28,9 +28,9 @@
         <th>{% get_verbose_field_name "interventions" "intervention" "multiple_sessions" %}</th><td>{{ intervention.multiple_sessions|yesno:_("ja,nee") }}</td>
     </tr>
     {% if intervention.multiple_sessions %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "session_frequency" %}</th><td>{{ intervention.session_frequency }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "session_frequency" %}</th><td>{{ intervention.session_frequency }}</td>
+        </tr>
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "interventions" "intervention" "duration" %}</th><td>{{ intervention.duration }}</td>
@@ -48,13 +48,13 @@
         <th>{% get_verbose_field_name "interventions" "intervention" "has_controls" %}</th><td>{{ intervention.has_controls|yesno:_("ja,nee") }}</td>
     </tr>
     {% if intervention.has_controls %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td>{{ intervention.controls_description }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td>{{ intervention.controls_description }}</td>
+        </tr>
     {% endif %}
     {% if not intervention.settings_contains_schools %}
-    <tr>
-        <th>{% get_verbose_field_name "interventions" "intervention" "extra_task" %}</th><td>{{ intervention.extra_task|yesno:_("ja,nee") }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "interventions" "intervention" "extra_task" %}</th><td>{{ intervention.extra_task|yesno:_("ja,nee") }}</td>
+        </tr>
     {% endif %}
 </table>

--- a/proposals/templates/proposals/pdf/observation_v1.html
+++ b/proposals/templates/proposals/pdf/observation_v1.html
@@ -7,19 +7,19 @@
         <th>{% get_verbose_field_name "observations" "observation" "setting" %}</th><td>{{ observation.setting.all|unordered_list }}</td>
     </tr>
     {% if observation.setting.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td>{{ observation.setting_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td>{{ observation.setting_details }}</td>
+        </tr>
     {% endif %}
     {% if study.has_children and observation.setting.all|needs_details:"needs_supervision" %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{{ observation.supervision|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% if not observation.supervision %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{{ observation.leader_has_coc|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% endif %}
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{{ observation.supervision|yesno:_("ja,nee") }}</td>
+        </tr>
+        {% if not observation.supervision %}
+            <tr>
+                <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{{ observation.leader_has_coc|yesno:_("ja,nee") }}</td>
+            </tr>
+        {% endif %}
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "days" %}</th><td>{{ observation.days }}</td>
@@ -37,29 +37,29 @@
         <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space" %}</th><td>{{ observation.is_nonpublic_space|yesno:_("ja,nee") }}</td>
     </tr>
     {% if observation.is_nonpublic_space %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{{ observation.has_advanced_consent|yesno:_("ja,nee") }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{{ observation.has_advanced_consent|yesno:_("ja,nee") }}</td>
+        </tr>
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "needs_approval" %}</th><td>{{ observation.needs_approval|yesno:_("ja,nee") }}</td>
     </tr>
     {% if observation.needs_approval %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td>{{ observation.approval_institution }}</td>
-    </tr>
-    {% if not proposal.is_practice %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "approval_document" %}</th><td><a href="{{ BASE_URL }}{{ observation.approval_document.url }}" target="_blank">{% trans "Download" %}</a></td>
-    </tr>
-    {% endif %}
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td>{{ observation.approval_institution }}</td>
+        </tr>
+        {% if not proposal.is_practice %}
+            <tr>
+                <th>{% get_verbose_field_name "observations" "observation" "approval_document" %}</th><td><a href="{{ BASE_URL }}{{ observation.approval_document.url }}" target="_blank">{% trans "Download" %}</a></td>
+            </tr>
+        {% endif %}
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "registrations" %}</th><td>{{ observation.registrations.all|unordered_list }}</td>
     </tr>
     {% if observation.registrations.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td>{{ observation.registrations_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td>{{ observation.registrations_details }}</td>
+        </tr>
     {% endif %}
 </table>

--- a/proposals/templates/proposals/pdf/observation_v2.html
+++ b/proposals/templates/proposals/pdf/observation_v2.html
@@ -7,19 +7,19 @@
         <th>{% get_verbose_field_name "observations" "observation" "setting" %}</th><td>{{ observation.setting.all|unordered_list }}</td>
     </tr>
     {% if observation.setting.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td>{{ observation.setting_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td>{{ observation.setting_details }}</td>
+        </tr>
     {% endif %}
     {% if study.has_children and observation.setting.all|needs_details:"needs_supervision" %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{{ observation.supervision|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% if not observation.supervision %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{{ observation.leader_has_coc|yesno:_("ja,nee") }}</td>
-    </tr>
-    {% endif %}
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{{ observation.supervision|yesno:_("ja,nee") }}</td>
+        </tr>
+        {% if not observation.supervision %}
+            <tr>
+                <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{{ observation.leader_has_coc|yesno:_("ja,nee") }}</td>
+            </tr>
+        {% endif %}
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "details_who"|safe %}</th><td>{{ observation.details_who }}</td>
@@ -34,50 +34,50 @@
         <th>{% get_verbose_field_name "observations" "observation" "is_anonymous" %}</th><td>{{ observation.is_anonymous|yesno:_("ja,nee") }}</td>
     </tr>
     {% if observation.is_anonymous %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "is_anonymous_details" %}</th><td>{{ observation.is_anonymous_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "is_anonymous_details" %}</th><td>{{ observation.is_anonymous_details }}</td>
+        </tr>
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "is_in_target_group" %}</th><td>{{ observation.is_in_target_group|yesno:_("ja,nee") }}</td>
     </tr>
     {% if observation.is_in_target_group %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "is_in_target_group_details" %}</th><td>{{ observation.is_in_target_group_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "is_in_target_group_details" %}</th><td>{{ observation.is_in_target_group_details }}</td>
+        </tr>
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space" %}</th><td>{{ observation.is_nonpublic_space|yesno:_("ja,nee") }}</td>
     </tr>
     {% if observation.is_nonpublic_space %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space_details" %}</th><td>{{ observation.is_nonpublic_space_details }}</td>
-    </tr>
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{{ observation.has_advanced_consent|yesno:_("ja,nee") }}</td>
-    </tr>
-        {% if not observation.has_advanced_consent %}
         <tr>
-            <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent_details" %}</th><td>{{ observation.has_advanced_consent_details }}</td>
+            <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space_details" %}</th><td>{{ observation.is_nonpublic_space_details }}</td>
         </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{{ observation.has_advanced_consent|yesno:_("ja,nee") }}</td>
+        </tr>
+        {% if not observation.has_advanced_consent %}
+            <tr>
+                <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent_details" %}</th><td>{{ observation.has_advanced_consent_details }}</td>
+            </tr>
         {% endif %}
     {% endif %}
     {% if observation.setting.all|needs_details:"is_school" %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "needs_approval" %}</th><td>{{ observation.needs_approval|yesno:_("ja,nee") }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "needs_approval" %}</th><td>{{ observation.needs_approval|yesno:_("ja,nee") }}</td>
+        </tr>
     {% endif %}
     {% if observation.needs_approval %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td>{{ observation.approval_institution }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td>{{ observation.approval_institution }}</td>
+        </tr>
     {% endif %}
     <tr>
         <th>{% get_verbose_field_name "observations" "observation" "registrations" %}</th><td>{{ observation.registrations.all|unordered_list }}</td>
     </tr>
     {% if observation.registrations.all|needs_details %}
-    <tr>
-        <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td>{{ observation.registrations_details }}</td>
-    </tr>
+        <tr>
+            <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td>{{ observation.registrations_details }}</td>
+        </tr>
     {% endif %}
 </table>

--- a/proposals/templates/proposals/proposal_copy.html
+++ b/proposals/templates/proposals/proposal_copy.html
@@ -49,7 +49,7 @@
                 <p>
                     {% blocktrans trimmed %}
                         Let op! Er kan maar één revisie tegelijk bestaan. Mocht je jouw aanvraag hier niet zien
-                        als optie om te reviseren, bekijk dan of je aanvraag niet al tussen je concept aanvragen 
+                        als optie om te reviseren, bekijk dan of je aanvraag niet al tussen je concept aanvragen
                         staat.
                     {% endblocktrans %}
                 </p>
@@ -63,7 +63,7 @@
                 <p>
                     {% blocktrans trimmed %}
                         Let op! Er kan maar één amendement tegelijk bestaan. Mocht je jouw aanvraag hier niet zien
-                        als optie om te reviseren, bekijk dan of je aanvraag niet al tussen je concept aanvragen 
+                        als optie om te reviseren, bekijk dan of je aanvraag niet al tussen je concept aanvragen
                         staat.
                     {% endblocktrans %}
                 </p>

--- a/proposals/templates/proposals/proposal_data_management.html
+++ b/proposals/templates/proposals/proposal_data_management.html
@@ -18,84 +18,84 @@
             </h1>
             <p>
                 {% blocktrans trimmed %}
-                De Universiteit Utrecht streeft naar integriteit, duurzaamheid, en transparantie in de omgang met onderzoeksdata, waaronder persoonsgegevens. Sinds de introductie van de AVG zijn er duidelijke regels die onderzoekers moeten volgen met betrekking tot deze data.
+                    De Universiteit Utrecht streeft naar integriteit, duurzaamheid, en transparantie in de omgang met onderzoeksdata, waaronder persoonsgegevens. Sinds de introductie van de AVG zijn er duidelijke regels die onderzoekers moeten volgen met betrekking tot deze data.
                 {% endblocktrans %}
             </p>
             <h2>{% trans "Data Management Plan" %}</h2>
             <ul>
-            <li>
-                {% blocktrans trimmed %}
-                Een data management plan is sinds 2020 <a href="https://intranet.uu.nl/actueel/nieuws/nieuw-facultair-datamanagementbeleid" target="_blank">verplicht</a> bij de faculteit geesteswetenschappen, zowel als bij de instanties
-NWO en ERC als zij subsidie voor een onderzoek bieden.
-                {% endblocktrans %}
-            </li>
-            <li>
-                {% blocktrans trimmed %}
-                De faculteit biedt uitgebreide informatie op het gebied van data management, waaronder ook <a href="https://www.uu.nl/en/research/research-data-management/guides/data-management-planning" target="_blank">hoe deze te schrijven</a>. <br/> Je kunt bij de faculteit ook je DMP laten nakijken door <a href="https://www.uu.nl/en/research/research-data-management/tools-services/data-management-plan-review" target="_blank">Research Data Management Support</a> of de facultaire <a href="mailto:datamanagement.gw@uu.nl" target="_blank">datamanager</a>.
-                {% endblocktrans %}
-            </li>
-            <li>
-                {% blocktrans trimmed %}
-                Op de website <a href="https://dmponline.dcc.ac.uk/" target="_blank">DMP-online</a> vind je na het inloggen met je Solis-ID templates voor een DMP. Dit is waar je de templates die NWO en ERC vereisen kunt terugvinden, aangeboden door de UU.
-                {% endblocktrans %}
-            </li>
+                <li>
+                    {% blocktrans trimmed %}
+                        Een data management plan is sinds 2020 <a href="https://intranet.uu.nl/actueel/nieuws/nieuw-facultair-datamanagementbeleid" target="_blank">verplicht</a> bij de faculteit geesteswetenschappen, zowel als bij de instanties
+                        NWO en ERC als zij subsidie voor een onderzoek bieden.
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    {% blocktrans trimmed %}
+                        De faculteit biedt uitgebreide informatie op het gebied van data management, waaronder ook <a href="https://www.uu.nl/en/research/research-data-management/guides/data-management-planning" target="_blank">hoe deze te schrijven</a>. <br/> Je kunt bij de faculteit ook je DMP laten nakijken door <a href="https://www.uu.nl/en/research/research-data-management/tools-services/data-management-plan-review" target="_blank">Research Data Management Support</a> of de facultaire <a href="mailto:datamanagement.gw@uu.nl" target="_blank">datamanager</a>.
+                    {% endblocktrans %}
+                </li>
+                <li>
+                    {% blocktrans trimmed %}
+                        Op de website <a href="https://dmponline.dcc.ac.uk/" target="_blank">DMP-online</a> vind je na het inloggen met je Solis-ID templates voor een DMP. Dit is waar je de templates die NWO en ERC vereisen kunt terugvinden, aangeboden door de UU.
+                    {% endblocktrans %}
+                </li>
             </ul>
             <h3>{% trans "Nuttige workshops:" %}</h3>
             <p>
                 {% blocktrans trimmed %}
-                Als je dit nog niet gedaan hebt, wordt er sterk aangeraden om de volgende workshop te volgen:
+                    Als je dit nog niet gedaan hebt, wordt er sterk aangeraden om de volgende workshop te volgen:
                 {% endblocktrans %}
             </p>
             <ul>{% blocktrans trimmed %}
                 <li>
                     de workshop <a href="https://www.uu.nl/en/node/75859" target="_blank">Quick
-start to Research Data Management</a>
+                        start to Research Data Management</a>
                 </li>
 
-                {% endblocktrans %}
+            {% endblocktrans %}
             </ul>
             <p>
                 {% blocktrans trimmed %}
-                Voor advies op het gebied van data management planning kun je contact opnemen met de datamanager GW, Frans de Liagre Böhl via <a href="mailto:datamanagement.gw@uu.nl" target="_blank">datamanagement.gw@uu.nl</a>.
+                    Voor advies op het gebied van data management planning kun je contact opnemen met de datamanager GW, Frans de Liagre Böhl via <a href="mailto:datamanagement.gw@uu.nl" target="_blank">datamanagement.gw@uu.nl</a>.
                 {% endblocktrans %}
             </p>
             <h2>{% trans "Privacy: AVG en GDPR" %}</h2>
             <p>
                 {% blocktrans trimmed %}
-                Wanneer je persoonsgebonden data verzamelt, zorg je er voor dat je je houdt aan de Algemene Verordening Gegevensbescherming, of AVG. Deze wet is de Nederlandse implementatie van het Europese <a href="https://gdpr.eu/" target="_blank">GDPR</a>.
+                    Wanneer je persoonsgebonden data verzamelt, zorg je er voor dat je je houdt aan de Algemene Verordening Gegevensbescherming, of AVG. Deze wet is de Nederlandse implementatie van het Europese <a href="https://gdpr.eu/" target="_blank">GDPR</a>.
                 {% endblocktrans %}
             </p>
             <ul>
-            <li>
-                {% blocktrans trimmed %}
-                De autoriteit persoonsgegevens heeft <a href="https://www.autoriteitpersoonsgegevens.nl/nl/onderwerpen/algemene-informatie-avg/algemene-informatie-avg" target="_blank">uitgebreide informatie</a> in het Nederlands over hoe de AVG dataverzameling beïnvloedt.
-                {% endblocktrans %}
-            </li>
+                <li>
+                    {% blocktrans trimmed %}
+                        De autoriteit persoonsgegevens heeft <a href="https://www.autoriteitpersoonsgegevens.nl/nl/onderwerpen/algemene-informatie-avg/algemene-informatie-avg" target="_blank">uitgebreide informatie</a> in het Nederlands over hoe de AVG dataverzameling beïnvloedt.
+                    {% endblocktrans %}
+                </li>
             </ul>
             <h3>{% trans "Nuttige workshops:" %}</h3>
             <p>
                 {% blocktrans trimmed %}
-                Als je dit nog niet gedaan hebt, wordt er sterk aangeraden om de volgende workshop te volgen:
+                    Als je dit nog niet gedaan hebt, wordt er sterk aangeraden om de volgende workshop te volgen:
                 {% endblocktrans %}
             </p>
             <ul>{% blocktrans trimmed %}
                 <li>
                     de workshop <a href="https://www.uu.nl/en/node/81799" target="_blank">Handling
-personal data in research</a>
+                        personal data in research</a>
                 </li>
 
-                {% endblocktrans %}
+            {% endblocktrans %}
             </ul>
             <p>{% blocktrans trimmed %}
                 Voor advies op het gebied van privacy en de AVG kun je contact opnemen met de privacy officer van GW via <a href="mailto:privacy.gw@uu.nl">privacy.gw@uu.nl</a>.
-                {% endblocktrans %}
+            {% endblocktrans %}
             </p>
 
 
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-            <table>
-            {{ form.as_table }}
-            </table>
+                <table>
+                    {{ form.as_table }}
+                </table>
                 {% include "base/form_buttons.html" %}
             </form>
         </div>

--- a/proposals/templates/proposals/proposal_diff.html
+++ b/proposals/templates/proposals/proposal_diff.html
@@ -66,28 +66,28 @@
                         </tr>
                     {% endif %}
                     {% if proposal.relation.check_in_course or p_proposal.relation.check_in_course %}
-                    <tr>
-                        <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th>
-                        <td>{{ p_proposal.student_program }}</td>
-                        <td>{{ proposal.student_program }}</td>
-                    </tr>
-                    <tr>
-                        <th>{% get_verbose_field_name "proposals" "proposal" "student_context" %}</th>
-                        <td>{{ p_proposal.student_context|default:"" }}</td>
-                        <td>{{ proposal.student_context|default:"" }}</td>
-                    </tr>
-                        {% if proposal.student_context.needs_details or p_proposal.student_context.needs_details %}
                         <tr>
-                            <th>{% get_verbose_field_name "proposals" "proposal" "student_context_details" %}</th>
-                            <td>{{ p_proposal.student_context_details }}</td>
-                            <td>{{ proposal.student_context_details }}</td>
+                            <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th>
+                            <td>{{ p_proposal.student_program }}</td>
+                            <td>{{ proposal.student_program }}</td>
                         </tr>
+                        <tr>
+                            <th>{% get_verbose_field_name "proposals" "proposal" "student_context" %}</th>
+                            <td>{{ p_proposal.student_context|default:"" }}</td>
+                            <td>{{ proposal.student_context|default:"" }}</td>
+                        </tr>
+                        {% if proposal.student_context.needs_details or p_proposal.student_context.needs_details %}
+                            <tr>
+                                <th>{% get_verbose_field_name "proposals" "proposal" "student_context_details" %}</th>
+                                <td>{{ p_proposal.student_context_details }}</td>
+                                <td>{{ proposal.student_context_details }}</td>
+                            </tr>
                         {% endif %}
-                    <tr>
-                        <th>{% get_verbose_field_name "proposals" "proposal" "student_justification" %}</th>
-                        <td>{{ p_proposal.student_justification }}</td>
-                        <td>{{ proposal.student_justification }}</td>
-                    </tr>
+                        <tr>
+                            <th>{% get_verbose_field_name "proposals" "proposal" "student_justification" %}</th>
+                            <td>{{ p_proposal.student_justification }}</td>
+                            <td>{{ proposal.student_justification }}</td>
+                        </tr>
                     {% endif %}
 
                     <tr>
@@ -100,18 +100,18 @@
                             <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th>
                             <td>
                                 <ul class="p-0">
-                                {% for applicant in p_proposal.applicants.all %}
-                                <li>{{ applicant.get_full_name }}</li>
-                                {% endfor %}
+                                    {% for applicant in p_proposal.applicants.all %}
+                                        <li>{{ applicant.get_full_name }}</li>
+                                    {% endfor %}
                                 </ul>
                             </td>
                             <td>
                                 <ul class="p-0">
-                                {% for applicant in proposal.applicants.all %}
-                                <li>
-                                    {{ applicant.get_full_name }}
-                                </li>
-                                {% endfor %}
+                                    {% for applicant in proposal.applicants.all %}
+                                        <li>
+                                            {{ applicant.get_full_name }}
+                                        </li>
+                                    {% endfor %}
                                 </ul>
                             </td>
                         </tr>

--- a/proposals/templates/proposals/proposal_export_list.html
+++ b/proposals/templates/proposals/proposal_export_list.html
@@ -37,9 +37,9 @@
                         <td>
                             {# Bad translation hack #}
                             {% if proposal.reviewing_committee.name == "AK" %}
-                            GC
+                                GC
                             {% else %}
-                            LC
+                                LC
                             {% endif %}
                         </td>
                     </tr>

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -9,70 +9,70 @@
 
 {% block html_head %}
   <script type="text/javascript" charset="utf8" src="{% static 'proposals/js/word_counter.js' %}"></script>
-    <script>
-        $(function () {
-            check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
-            check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
-            depends_on_value('other_applicants', 'True', 'applicants');
-            depends_on_value('other_stakeholders', 'True', 'stakeholders');
-            check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
-            check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
+  <script>
+    $(function () {
+      check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
+      check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
+      check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
+      check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
+      check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
+      depends_on_value('other_applicants', 'True', 'applicants');
+      depends_on_value('other_stakeholders', 'True', 'stakeholders');
+      check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
+      check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
 
     // Add datepicker for date_start, set locale to current language
-    $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
+      $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
 
-            var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'yy-mm-dd';
-            $("#id_date_start").datepicker({
-                dateFormat: date_format,
-            })
+      var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'yy-mm-dd';
+      $("#id_date_start").datepicker({
+        dateFormat: date_format,
+      })
 
     // AJAX applicants
-    $('select#id_applicants').select2({
-      ajax: {
-        url: '{% url 'main:user_search' %}',
-        dataType: 'json',
-        data: function (params) {
-          return {
-            q: params.term || '*',
-            page: params.page || 1
-          }
-        },
-        delay: 1500,
-        error: function (err) {
-          console.log(err)
-        },
-        cache: true
-      }
-    });
+      $('select#id_applicants').select2({
+        ajax: {
+          url: '{% url 'main:user_search' %}',
+          dataType: 'json',
+          data: function (params) {
+            return {
+              q: params.term || '*',
+              page: params.page || 1
+            }
+          },
+          delay: 1500,
+          error: function (err) {
+            console.log(err)
+          },
+          cache: true
+        }
+      });
 
     // AJAX supervisors
-    $('select#id_supervisor').select2({
-      ajax: {
-        url: '{% url 'main:user_search' %}',
-        dataType: 'json',
-        data: function (params) {
-          return {
-            q: params.term || '*',
-            page: params.page || 1
-          }
-        },
-        delay: 1500,
-        error: function (err) {
-          console.log(err)
-        },
-        cache: true
-      }
+      $('select#id_supervisor').select2({
+        ajax: {
+          url: '{% url 'main:user_search' %}',
+          dataType: 'json',
+          data: function (params) {
+            return {
+              q: params.term || '*',
+              page: params.page || 1
+            }
+          },
+          delay: 1500,
+          error: function (err) {
+            console.log(err)
+          },
+          cache: true
+        }
+      });
     });
-  });
-  $(function() {
+    $(function() {
     // adds running wordcounter for the summary and self_assessment text fields
-    let translated_string = " {% trans 'Aantal woorden:' %} "
-    wordCounter("summary", translated_string)
-    wordCounter("self_assessment", translated_string)
-  });
+      let translated_string = " {% trans 'Aantal woorden:' %} "
+      wordCounter("summary", translated_string)
+      wordCounter("self_assessment", translated_string)
+    });
   </script>
 {% endblock %}
 
@@ -107,51 +107,51 @@
   </div>
   <!-- Code for intended start date warning -->
   <style>
-  #date_start_warning {
-    line-height: 1.5;
-  }
+    #date_start_warning {
+      line-height: 1.5;
+    }
   </style>
   <script>
   /* Find date start input */
-  let date_start_input = $("#id_date_start")
+    let date_start_input = $("#id_date_start")
 
   /* Insert warning element */
-  date_start_input.after(`
+    date_start_input.after(`
 <p id="date_start_warning" class="mb-2 mt-2">
     {% trans "Als de beoogde startdatum binnen twee weken van het indienen van de aanvraag ligt, kan de FETC geen officiële goedkeuring meer geven."%}
 </p>
   `)
 
   /* Re-select warning paragraph */
-  const date_start_warning = $("#date_start_warning")
+    const date_start_warning = $("#date_start_warning")
 
   /* Define checker function */
-  function checkDateStart()
-  {
-    let date_value = date_start_input.val();
-    if (date_value=="") {
-      return true
+    function checkDateStart()
+    {
+      let date_value = date_start_input.val();
+      if (date_value=="") {
+        return true
+      }
+      let parsed_date = new Date(date_value);
+      let today = new Date();
+      let date_difference = parsed_date - today;
+      const two_weeks_ms = 1000*60*60*24*14;
+      return date_difference>two_weeks_ms;
     }
-    let parsed_date = new Date(date_value);
-    let today = new Date();
-    let date_difference = parsed_date - today;
-    const two_weeks_ms = 1000*60*60*24*14;
-    return date_difference>two_weeks_ms;
-  }
 
   /* Define warning update function */
-  function updateWarning()
-  {
-    date_start_warning.toggleClass("text-danger", checkDateStart()==false);
-  }
+    function updateWarning()
+    {
+      date_start_warning.toggleClass("text-danger", checkDateStart()==false);
+    }
 
   /* Listen for changing of start date */
-  date_start_input.on('change', () =>{
-    updateWarning();
-  });
+    date_start_input.on('change', () =>{
+      updateWarning();
+    });
 
   /* Give the update function a warmup run */
-  updateWarning();
+    updateWarning();
 
   </script>
 

--- a/proposals/templates/proposals/proposal_form_pre_approved.html
+++ b/proposals/templates/proposals/proposal_form_pre_approved.html
@@ -8,71 +8,71 @@
 {% endblock %}
 
 {% block html_head %}
-<script type="text/javascript" charset="utf8" src="{% static 'proposals/js/word_counter.js' %}"></script>
-<script>
-$(function() {
+    <script type="text/javascript" charset="utf8" src="{% static 'proposals/js/word_counter.js' %}"></script>
+    <script>
+        $(function() {
 
     // Default for proposals
-    check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
-    check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
-    check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
-    check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
-    check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
-    depends_on_value('relation', 'check_in_course', 'student_context_details');  
-    depends_on_value('student_context', 'needs_details', 'student_context_details');
-    depends_on_value('other_applicants', 'True', 'applicants');
-    depends_on_value('other_stakeholders', 'True', 'stakeholders');
-    check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
-    check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
+            check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
+            check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
+            depends_on_value('relation', 'check_in_course', 'student_context_details');
+            depends_on_value('student_context', 'needs_details', 'student_context_details');
+            depends_on_value('other_applicants', 'True', 'applicants');
+            depends_on_value('other_stakeholders', 'True', 'stakeholders');
+            check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
+            check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
 
     // Additional contraints for pre-approved proposals
-    depends_on_value('is_pre_approved', 'True', 'relation');
-    depends_on_value('is_pre_approved', 'True', 'supervisor');
-    depends_on_value('is_pre_approved', 'True', 'other_applicants');
-    depends_on_value('is_pre_approved', 'True', 'other_stakeholders');
-    depends_on_value('is_pre_approved', 'True', 'date_start');
-    depends_on_value('is_pre_approved', 'True', 'title');
-    depends_on_value('is_pre_approved', 'True', 'summary');
-    depends_on_value('is_pre_approved', 'True', 'pre_assessment_pdf');
-    depends_on_value('is_pre_approved', 'True', 'funding');
-    depends_on_value('is_pre_approved', 'True', 'pre_approval_institute');
-    depends_on_value('is_pre_approved', 'True', 'pre_approval_pdf');
-    warning_on_value('is_pre_approved', 'False', 'pre_approval_warning');
+            depends_on_value('is_pre_approved', 'True', 'relation');
+            depends_on_value('is_pre_approved', 'True', 'supervisor');
+            depends_on_value('is_pre_approved', 'True', 'other_applicants');
+            depends_on_value('is_pre_approved', 'True', 'other_stakeholders');
+            depends_on_value('is_pre_approved', 'True', 'date_start');
+            depends_on_value('is_pre_approved', 'True', 'title');
+            depends_on_value('is_pre_approved', 'True', 'summary');
+            depends_on_value('is_pre_approved', 'True', 'pre_assessment_pdf');
+            depends_on_value('is_pre_approved', 'True', 'funding');
+            depends_on_value('is_pre_approved', 'True', 'pre_approval_institute');
+            depends_on_value('is_pre_approved', 'True', 'pre_approval_pdf');
+            warning_on_value('is_pre_approved', 'False', 'pre_approval_warning');
 
     // Add datepicker for date_start, set locale to current language
-    $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
+            $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
 
-    var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
-    $("#id_date_start").datepicker({
-        dateFormat: date_format,
-        minDate: 'now',
-    })
+            var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'mm/dd/yy';
+            $("#id_date_start").datepicker({
+                dateFormat: date_format,
+                minDate: 'now',
+            })
 
     // AJAX applicants
-    $('select#id_applicants').select2({
-      ajax: {
-        url: '{% url 'main:user_search' %}',
-        dataType: 'json',
-        data: function (params) {
-          return {
-            q: params.term || '*',
-            page: params.page || 1
-          }
-        },
-        delay: 1500,
-        error: function (err) {
-            console.log(err)
-        },
-        cache: true
-      }
-    });
-});
-$(function() {
+            $('select#id_applicants').select2({
+                ajax: {
+                    url: '{% url 'main:user_search' %}',
+                    dataType: 'json',
+                    data: function (params) {
+                        return {
+                            q: params.term || '*',
+                            page: params.page || 1
+                        }
+                    },
+                    delay: 1500,
+                    error: function (err) {
+                        console.log(err)
+                    },
+                    cache: true
+                }
+            });
+        });
+        $(function() {
     // adds running wordcounter for the summary and self_assessment text fields
-    let translated_string = " {% trans 'Aantal woorden:' %} "
-    wordCounter("summary", translated_string)
-});
-</script>
+            let translated_string = " {% trans 'Aantal woorden:' %} "
+            wordCounter("summary", translated_string)
+        });
+    </script>
 {% endblock %}
 
 {% block content %}

--- a/proposals/templates/proposals/proposal_list.html
+++ b/proposals/templates/proposals/proposal_list.html
@@ -73,7 +73,7 @@
                 {% if supervised %}
                     <li>
                         {% blocktrans trimmed %}
-                        Klik op <img src="{{ img_decide }}" title="Beslissen"> om je beslissing door te geven (als eindverantwoordelijke).
+                            Klik op <img src="{{ img_decide }}" title="Beslissen"> om je beslissing door te geven (als eindverantwoordelijke).
                         {% endblocktrans %}
                     </li>
                 {% endif %}

--- a/proposals/templates/proposals/proposal_pdf.html
+++ b/proposals/templates/proposals/proposal_pdf.html
@@ -7,36 +7,36 @@
 {% load uil_filters %}
 
 {% block extra_style %}
-    <style type="text/css">
-        #content table {
-            border-top-width: .5px;
-            border-top-style: solid;
-            border-top-color: #cbcbcb;
-            border-right-width: .5px;
-            border-right-style: solid;
-            border-right-color: #cbcbcb;
-            border-bottom-width: .5px;
-            border-bottom-style: solid;
-            border-bottom-color: #cbcbcb;
-            border-left-width: .5px;
-            border-left-style: solid;
-            border-left-color: #cbcbcb;
-        }
+  <style type="text/css">
+    #content table {
+      border-top-width: .5px;
+      border-top-style: solid;
+      border-top-color: #cbcbcb;
+      border-right-width: .5px;
+      border-right-style: solid;
+      border-right-color: #cbcbcb;
+      border-bottom-width: .5px;
+      border-bottom-style: solid;
+      border-bottom-color: #cbcbcb;
+      border-left-width: .5px;
+      border-left-style: solid;
+      border-left-color: #cbcbcb;
+    }
 
-        #content th, td {
-            width: 500px;
-            font-weight: normal;
-            text-align: left;
-            padding-top: 3px;
-            padding-right: 3px;
-            padding-bottom: 3px;
-            padding-left: 3px;
-        }
+    #content th, td {
+      width: 500px;
+      font-weight: normal;
+      text-align: left;
+      padding-top: 3px;
+      padding-right: 3px;
+      padding-bottom: 3px;
+      padding-left: 3px;
+    }
 
-        #content li {
-            line-height: 10px;
-        }
-    </style>
+    #content li {
+      line-height: 10px;
+    }
+  </style>
 {% endblock %}
 
 {% block page_header %}
@@ -516,9 +516,9 @@
             <th>{% get_verbose_field_name "proposals" "proposal" "embargo" %}</th><td>{{ proposal.embargo|yesno:_("ja,nee") }}</td>
           </tr>
           {%if proposal.embargo %}
-          <tr>
-            <th>{% get_verbose_field_name "proposals" "proposal" "embargo_end_date" %}</th><td>{{ proposal.date_start|default:_("onbekend") }}</td>
-          </tr>
+            <tr>
+              <th>{% get_verbose_field_name "proposals" "proposal" "embargo_end_date" %}</th><td>{{ proposal.date_start|default:_("onbekend") }}</td>
+            </tr>
           {% endif %}
         </table>
         <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>

--- a/proposals/templates/proposals/proposal_pdf_empty.html
+++ b/proposals/templates/proposals/proposal_pdf_empty.html
@@ -38,357 +38,357 @@
 {% endblock %}
 
 {% block page_header %}
-<div id="page-header">
-    {% blocktrans %}
-    FETC-GW - <em>naam aanvraag</em> (referentienummer <em>referentienummer</em>)
-    {% endblocktrans %}
-</div>
+    <div id="page-header">
+        {% blocktrans %}
+            FETC-GW - <em>naam aanvraag</em> (referentienummer <em>referentienummer</em>)
+        {% endblocktrans %}
+    </div>
 {% endblock %}
 
 {% block page_foot %}
-Page <pdf:pagenumber /> of <pdf:pagecount />
+    Page <pdf:pagenumber /> of <pdf:pagecount />
 {% endblock %}
 
 {% block content %}
-<div id="content">
-    <div class="main">
-        <h1>
-            {% blocktrans %}
-            Referentienummer <em>referentienummer</em>
-            {% endblocktrans %}
-        </h1>
-        <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th><td>{% show_all "proposals" "relation" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "summary" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding" %}</th><td>{% show_all "proposals" "funding" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding_name" %}</th><td></td>
-            </tr>
-        </table>
+    <div id="content">
+        <div class="main">
+            <h1>
+                {% blocktrans %}
+                    Referentienummer <em>referentienummer</em>
+                {% endblocktrans %}
+            </h1>
+            <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th><td>{% show_all "proposals" "relation" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "summary" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "funding" %}</th><td>{% show_all "proposals" "funding" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "funding_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "funding_name" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Ethische toetsing nodig door een Medische Ethische Toetsingscommissie (METC)?" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_institution" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "is_medical" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Ethische toetsing nodig door een Medische Ethische Toetsingscommissie (METC)?" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc_institution" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "is_medical" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+            </table>
 
-        <h2>{% trans "Aanmelding bij de METC" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_application" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision_pdf" %}</th><td></td>
-            </tr>
-        </table>
+            <h2>{% trans "Aanmelding bij de METC" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc_application" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "wmo" "metc_decision_pdf" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Eén of meerdere trajecten?" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "studies_similar" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "studies_number" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Eén of meerdere trajecten?" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "studies_similar" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "studies_number" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "De deelnemers" %} <em>n</em></h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "age_groups" %}</th><td>{% show_all "studies" "agegroup" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "legally_incapable" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "legally_incapable_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "has_traits" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "traits" %}</th><td>{% show_all "studies" "trait" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "traits_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "necessity" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "necessity_reason" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "recruitment" %}</th><td>{% show_all "studies" "recruitment" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "recruitment_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "compensation" %}</th><td>{% show_all "studies" "compensation" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "compensation_details" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "De deelnemers" %} <em>n</em></h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "age_groups" %}</th><td>{% show_all "studies" "agegroup" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "legally_incapable" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "legally_incapable_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "has_traits" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "traits" %}</th><td>{% show_all "studies" "trait" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "traits_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "necessity" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "necessity_reason" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "recruitment" %}</th><td>{% show_all "studies" "recruitment" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "recruitment_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "compensation" %}</th><td>{% show_all "studies" "compensation" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "compensation_details" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Het interventieonderzoek" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "period" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "amount_per_week" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "duration" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "measurement" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "experimenter" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "description" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "has_controls" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            {% if intervention.has_controls %}
-            <tr>
-                <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td></td>
-            </tr>
-            {% endif %}
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Het interventieonderzoek" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "setting_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "supervision" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "period" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "amount_per_week" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "duration" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "measurement" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "experimenter" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "description" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "interventions" "intervention" "has_controls" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                {% if intervention.has_controls %}
+                    <tr>
+                        <th>{% get_verbose_field_name "interventions" "intervention" "controls_description" %}</th><td></td>
+                    </tr>
+                {% endif %}
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Het observatieonderzoek" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "days" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "mean_hours" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "is_anonymous" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "is_in_target_group" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "needs_approval" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "approval_document" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "registrations" %}</th><td>{% show_all "observations" "registration" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Het observatieonderzoek" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "setting_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "supervision" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "days" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "mean_hours" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "is_anonymous" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "is_in_target_group" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "is_nonpublic_space" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "has_advanced_consent" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "needs_approval" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "approval_institution" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "approval_document" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "registrations" %}</th><td>{% show_all "observations" "registration" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "observations" "observation" "registrations_details" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Het takenonderzoek en interviews" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "sessions_number" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Het takenonderzoek en interviews" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "sessions_number" %}</th><td></td>
+                </tr>
+            </table>
 
-        <h2>{% trans "Sessie" %} <em>n</em></h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "setting_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "supervision" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "tasks_number" %}</th><td></td>
-            </tr>
-        </table>
-        <h3>{% trans "Taak" %} <em>n</em></h3>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "name" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "description" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "duration" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "registrations" %}</th><td>{% show_all "tasks" "registration" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "registrations_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "registration_kinds" %}</th><td>{% show_all "tasks" "registrationkind" %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "registration_kinds_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "feedback" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "task" "feedback_details" %}</th><td></td>
-            </tr>
-        </table>
+            <h2>{% trans "Sessie" %} <em>n</em></h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "setting" %}</th><td>{% show_all "main" "setting" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "setting_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "supervision" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "leader_has_coc" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "tasks_number" %}</th><td></td>
+                </tr>
+            </table>
+            <h3>{% trans "Taak" %} <em>n</em></h3>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "name" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "description" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "duration" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "registrations" %}</th><td>{% show_all "tasks" "registration" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "registrations_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "registration_kinds" %}</th><td>{% show_all "tasks" "registrationkind" %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "registration_kinds_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "feedback" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "task" "feedback_details" %}</th><td></td>
+                </tr>
+            </table>
 
-        <h3>{% trans "Overzicht van het takenonderzoek" %}</h3>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "tasks" "session" "tasks_duration" 0 %}</th><td></td>
-            </tr>
-        </table>
+            <h3>{% trans "Overzicht van het takenonderzoek" %}</h3>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "tasks" "session" "tasks_duration" 0 %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Overzicht en eigen beoordeling van het gehele onderzoek" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "deception" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "deception_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "negativity" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "negativity_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "stressful" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "stressful_details" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "risk" %}</th><td>{% show_yesnodoubt %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "risk_details" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Overzicht en eigen beoordeling van het gehele onderzoek" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "deception" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "deception_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "negativity" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "negativity_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "stressful" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "stressful_details" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "risk" %}</th><td>{% show_yesnodoubt %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "risk_details" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Informed consent formulieren voor het onderzoek" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "documents" "informed_consent" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "documents" "briefing" %}</th><td></td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "passive_consent" %}</th><td>{% show_yesno %}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "studies" "study" "passive_consent_details" %}</th><td></td>
-            </tr>
-        </table>
+            <pdf:nextpage />
+            <h2>{% trans "Informed consent formulieren voor het onderzoek" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "documents" "informed_consent" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "documents" "briefing" %}</th><td></td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "passive_consent" %}</th><td>{% show_yesno %}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "studies" "study" "passive_consent_details" %}</th><td></td>
+                </tr>
+            </table>
 
-        <pdf:nextpage />
-        <h2>{% trans "Aanmelding versturen" %}</h2>
-        <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
+            <pdf:nextpage />
+            <h2>{% trans "Aanmelding versturen" %}</h2>
+            <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
 
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_pdf_pre_approved.html
+++ b/proposals/templates/proposals/proposal_pdf_pre_approved.html
@@ -38,120 +38,120 @@
 {% endblock %}
 
 {% block page_header %}
-<div id="page-header">
-    {% blocktrans with title=proposal.title reference_number=proposal.reference_number submitter=proposal.created_by.get_full_name %}
-    FETC-GW - Aanvraag elders al goedgekeurde aanvraag <em>{{ title }}</em> (referentienummer {{ reference_number }}, ingediend door {{ submitter }})
-    {% endblocktrans %}
-</div>
+    <div id="page-header">
+        {% blocktrans with title=proposal.title reference_number=proposal.reference_number submitter=proposal.created_by.get_full_name %}
+            FETC-GW - Aanvraag elders al goedgekeurde aanvraag <em>{{ title }}</em> (referentienummer {{ reference_number }}, ingediend door {{ submitter }})
+        {% endblocktrans %}
+    </div>
 {% endblock %}
 
 {% block page_foot %}
-Page <pdf:pagenumber /> of <pdf:pagecount />
+    Page <pdf:pagenumber /> of <pdf:pagecount />
 {% endblock %}
 
 {% block content %}
-<div id="content">
-    <div class="main">
-        <h1>
-            {% blocktrans with reference_number=proposal.reference_number %}
-            Referentienummer {{ reference_number }}
-            {% endblocktrans %}
-        </h1>
-        <h2>{% trans 'Indiener' %}</h2>
-        <table>
-            <tr>
-                <th>{% trans 'Naam' %}</th><td>{{ proposal.created_by.get_full_name }}</td>
-            </tr>
-            <tr>
-                <th>{% trans 'E-mail' %}</th><td>{{ proposal.created_by.email }}</td>
-            </tr>
-        </table>
-        <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "is_pre_approved" %}</th>
-                <td>{{ proposal.is_pre_approved }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th>
-                <td>{{ proposal.relation }}</td>
-            </tr>
-            {% if proposal.relation.needs_supervisor %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th>
-                <td>{{ proposal.supervisor.get_full_name }}</td>
-            </tr>
-            {% endif %}
-            {% if proposal.relation.check_in_course %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th>
-                <td>{{ proposal.other_applicants|yesno:_("ja,nee") }}</td>
-            </tr>
-            {% if proposal.other_applicants %}
-            <tr>
-              <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
-                <ul>
-                  {% for applicant in proposal.applicants.all %}
-                    <li>
-                      {{ applicant.get_full_name }}
-                    </li>
-                  {% endfor %}
-                </ul>
-              </td>
-            </tr>
-          {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th>
-                <td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>
-            </tr>
-            {% if proposal.other_stakeholders %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th>
-                <td>{{ proposal.stakeholders }}</td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th>
-                <td>{{ proposal.date_start|default:_("onbekend") }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th>
-                <td>{{ proposal.title }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding" %}</th><td>{{ proposal.funding.all|unordered_list }}</td>
-            </tr>
-            {% if proposal.funding.all|needs_details %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding_details" %}</th><td>{{ proposal.funding_details }}</td>
-            </tr>
-            {% endif %}
-            {% if proposal.funding.all|needs_details:"needs_name" %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "funding_name" %}</th><td>{{ proposal.funding_name }}</td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "pre_approval_institute" %}</th><td>{{ proposal.pre_approval_institute }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "pre_approval_pdf" %}</th>
-                <td><a href="{{ BASE_URL }}{{ proposal.pre_approval_pdf.url }}" target="_blank">{% trans "Download" %}</a></td>
-            </tr>
-        </table>
+    <div id="content">
+        <div class="main">
+            <h1>
+                {% blocktrans with reference_number=proposal.reference_number %}
+                    Referentienummer {{ reference_number }}
+                {% endblocktrans %}
+            </h1>
+            <h2>{% trans 'Indiener' %}</h2>
+            <table>
+                <tr>
+                    <th>{% trans 'Naam' %}</th><td>{{ proposal.created_by.get_full_name }}</td>
+                </tr>
+                <tr>
+                    <th>{% trans 'E-mail' %}</th><td>{{ proposal.created_by.email }}</td>
+                </tr>
+            </table>
+            <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "is_pre_approved" %}</th>
+                    <td>{{ proposal.is_pre_approved }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th>
+                    <td>{{ proposal.relation }}</td>
+                </tr>
+                {% if proposal.relation.needs_supervisor %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th>
+                        <td>{{ proposal.supervisor.get_full_name }}</td>
+                    </tr>
+                {% endif %}
+                {% if proposal.relation.check_in_course %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th>
+                    <td>{{ proposal.other_applicants|yesno:_("ja,nee") }}</td>
+                </tr>
+                {% if proposal.other_applicants %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
+                            <ul>
+                                {% for applicant in proposal.applicants.all %}
+                                    <li>
+                                        {{ applicant.get_full_name }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th>
+                    <td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>
+                </tr>
+                {% if proposal.other_stakeholders %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th>
+                        <td>{{ proposal.stakeholders }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th>
+                    <td>{{ proposal.date_start|default:_("onbekend") }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th>
+                    <td>{{ proposal.title }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "funding" %}</th><td>{{ proposal.funding.all|unordered_list }}</td>
+                </tr>
+                {% if proposal.funding.all|needs_details %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "funding_details" %}</th><td>{{ proposal.funding_details }}</td>
+                    </tr>
+                {% endif %}
+                {% if proposal.funding.all|needs_details:"needs_name" %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "funding_name" %}</th><td>{{ proposal.funding_name }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "pre_approval_institute" %}</th><td>{{ proposal.pre_approval_institute }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "pre_approval_pdf" %}</th>
+                    <td><a href="{{ BASE_URL }}{{ proposal.pre_approval_pdf.url }}" target="_blank">{% trans "Download" %}</a></td>
+                </tr>
+            </table>
 
-        <h3>{% get_verbose_field_name "proposals" "proposal" "summary" %}</h3>
-        <p>{{ proposal.summary|linebreaks }}</p>
+            <h3>{% get_verbose_field_name "proposals" "proposal" "summary" %}</h3>
+            <p>{{ proposal.summary|linebreaks }}</p>
 
-        <h2>{% trans "Aanmelding versturen" %}</h2>
-        <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
-        <p>
-            {{ proposal.comments }}
-        </p>
+            <h2>{% trans "Aanmelding versturen" %}</h2>
+            <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
+            <p>
+                {{ proposal.comments }}
+            </p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_pdf_pre_assessment.html
+++ b/proposals/templates/proposals/proposal_pdf_pre_assessment.html
@@ -37,101 +37,101 @@
 {% endblock %}
 
 {% block page_header %}
-<div id="page-header">
-    {% blocktrans with title=proposal.title reference_number=proposal.reference_number submitter=proposal.created_by.get_full_name %}
-    FETC-GW - Aanvraag voor voortoetsing <em>{{ title }}</em> (referentienummer {{ reference_number }}, ingediend door {{ submitter }})
-    {% endblocktrans %}
-</div>
+    <div id="page-header">
+        {% blocktrans with title=proposal.title reference_number=proposal.reference_number submitter=proposal.created_by.get_full_name %}
+            FETC-GW - Aanvraag voor voortoetsing <em>{{ title }}</em> (referentienummer {{ reference_number }}, ingediend door {{ submitter }})
+        {% endblocktrans %}
+    </div>
 {% endblock %}
 
 {% block page_foot %}
-Page <pdf:pagenumber /> of <pdf:pagecount />
+    Page <pdf:pagenumber /> of <pdf:pagecount />
 {% endblock %}
 
 {% block content %}
-<div id="content">
-    <div class="main">
-        <h1>
-            {% blocktrans with reference_number=proposal.reference_number %}
-            Referentienummer {{ reference_number }}
-            {% endblocktrans %}
-        </h1>
-        <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th><td>{{ proposal.relation }}</td>
-            </tr>
-            {% if proposal.relation.needs_supervisor %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th><td>{{ proposal.supervisor.get_full_name }}</td>
-            </tr>
-            {% endif %}
-            {% if proposal.relation.check_in_course %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th><td>{{ proposal.other_applicants|yesno:_("ja,nee") }}</td>
-            </tr>
-            {% if proposal.other_applicants %}
-            <tr>
-              <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
-                <ul>
-                  {% for applicant in proposal.applicants.all %}
-                    <li>
-                      {{ applicant.get_full_name }}
-                    </li>
-                  {% endfor %}
-                </ul>
-              </td>
-            </tr>
-          {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th><td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>
-            </tr>
-            {% if proposal.other_stakeholders %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th><td>{{ proposal.stakeholders }}</td>
-            </tr>
-            {% endif %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th><td>{{ proposal.date_start|default:_("onbekend") }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th><td>{{ proposal.title }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "proposal" "pre_assessment_pdf" %}</th><td><a href="{{ BASE_URL }}{{ proposal.pre_assessment_pdf.url }}" target="_blank">{% trans "Download" %}</a></td>
-            </tr>
-        </table>
+    <div id="content">
+        <div class="main">
+            <h1>
+                {% blocktrans with reference_number=proposal.reference_number %}
+                    Referentienummer {{ reference_number }}
+                {% endblocktrans %}
+            </h1>
+            <h2>{% trans "Algemene informatie over de aanvraag" %}</h2>
+            <table>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "relation" %}</th><td>{{ proposal.relation }}</td>
+                </tr>
+                {% if proposal.relation.needs_supervisor %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "supervisor" %}</th><td>{{ proposal.supervisor.get_full_name }}</td>
+                    </tr>
+                {% endif %}
+                {% if proposal.relation.check_in_course %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "student_program" %}</th><td>{{ proposal.student_program }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_applicants" %}</th><td>{{ proposal.other_applicants|yesno:_("ja,nee") }}</td>
+                </tr>
+                {% if proposal.other_applicants %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "applicants" %}</th><td>
+                            <ul>
+                                {% for applicant in proposal.applicants.all %}
+                                    <li>
+                                        {{ applicant.get_full_name }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "other_stakeholders" %}</th><td>{{ proposal.other_stakeholders|yesno:_("ja,nee") }}</td>
+                </tr>
+                {% if proposal.other_stakeholders %}
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "proposal" "stakeholders" %}</th><td>{{ proposal.stakeholders }}</td>
+                    </tr>
+                {% endif %}
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "date_start" %}</th><td>{{ proposal.date_start|default:_("onbekend") }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "title" %}</th><td>{{ proposal.title }}</td>
+                </tr>
+                <tr>
+                    <th>{% get_verbose_field_name "proposals" "proposal" "pre_assessment_pdf" %}</th><td><a href="{{ BASE_URL }}{{ proposal.pre_assessment_pdf.url }}" target="_blank">{% trans "Download" %}</a></td>
+                </tr>
+            </table>
 
-        {% with wmo=proposal.wmo %}
-        <h2>{% trans "Ethische toetsing nodig door een Medische Ethische Toetsingscommissie (METC)?" %}</h2>
-        <table>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc" %}</th><td>{{ wmo.get_metc_display }}</td>
-            </tr>
-            {% if wmo.metc == 'Y' %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_details" %}</th><td>{{ wmo.metc_details }}</td>
-            </tr>
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "metc_institution" %}</th><td>{{ wmo.metc_institution }}</td>
-            </tr>
-            {% else %}
-            <tr>
-                <th>{% get_verbose_field_name "proposals" "wmo" "is_medical" %}</th><td>{{ wmo.get_is_medical_display }}</td>
-            </tr>
-            {% endif %}
-        </table>
-        {% endwith %}
+            {% with wmo=proposal.wmo %}
+                <h2>{% trans "Ethische toetsing nodig door een Medische Ethische Toetsingscommissie (METC)?" %}</h2>
+                <table>
+                    <tr>
+                        <th>{% get_verbose_field_name "proposals" "wmo" "metc" %}</th><td>{{ wmo.get_metc_display }}</td>
+                    </tr>
+                    {% if wmo.metc == 'Y' %}
+                        <tr>
+                            <th>{% get_verbose_field_name "proposals" "wmo" "metc_details" %}</th><td>{{ wmo.metc_details }}</td>
+                        </tr>
+                        <tr>
+                            <th>{% get_verbose_field_name "proposals" "wmo" "metc_institution" %}</th><td>{{ wmo.metc_institution }}</td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <th>{% get_verbose_field_name "proposals" "wmo" "is_medical" %}</th><td>{{ wmo.get_is_medical_display }}</td>
+                        </tr>
+                    {% endif %}
+                </table>
+            {% endwith %}
 
-        <h2>{% trans "Aanvraag voor voortoetsing versturen" %}</h2>
-        <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
-        <p>
-            {{ proposal.comments }}
-        </p>
+            <h2>{% trans "Aanvraag voor voortoetsing versturen" %}</h2>
+            <h3>{% get_verbose_field_name "proposals" "proposal" "comments" %}</h3>
+            <p>
+                {{ proposal.comments }}
+            </p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_private_archive.html
+++ b/proposals/templates/proposals/proposal_private_archive.html
@@ -73,7 +73,7 @@
                 {% if supervised %}
                     <li>
                         {% blocktrans trimmed %}
-                        Klik op <img src="{{ img_decide }}" title="Beslissen"> om je beslissing door te geven (als eindverantwoordelijke).
+                            Klik op <img src="{{ img_decide }}" title="Beslissen"> om je beslissing door te geven (als eindverantwoordelijke).
                         {% endblocktrans %}
                     </li>
                 {% endif %}

--- a/proposals/templates/proposals/proposal_public_archive.html
+++ b/proposals/templates/proposals/proposal_public_archive.html
@@ -31,9 +31,9 @@
                             </td>
                             <td>
                                 {% if proposal.reviewing_committee.name == "AK" %}
-                                {% trans 'AK' %}
+                                    {% trans 'AK' %}
                                 {% else %}
-                                {% trans 'LK' %}
+                                    {% trans 'LK' %}
                                 {% endif %}
                             </td>
                         </tr>

--- a/proposals/templates/proposals/proposal_start.html
+++ b/proposals/templates/proposals/proposal_start.html
@@ -12,73 +12,73 @@
         <div class="col-12">
             <h2>{% trans "Een nieuwe aanvraag aanmelden" %}</h2>
 
-                <ul>
+            <ul>
                 <li>{% trans "Check voor het indienen:" %}
                     <ul>
-                    <li>
-                        {% blocktrans trimmed %}
-                            De
-                            <a href="https://fetc-gw.wp.hum.uu.nl/" target="_blank">
-                            UU-webpagina van de FETC-GW</a> voor nieuws en de agenda.
-                        {% endblocktrans %}
-                    </li>
-                    <li>
-                        {% blocktrans trimmed %}
-                            Het reglement van de
-                            <a href="https://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/">Algemene Kamer (AK)</a>
-                            of dat van de
-                            <a href="https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/">Linguïstiek Kamer (LK)</a>.
-                        {% endblocktrans %}
-                    </li>
+                        <li>
+                            {% blocktrans trimmed %}
+                                De
+                                <a href="https://fetc-gw.wp.hum.uu.nl/" target="_blank">
+                                    UU-webpagina van de FETC-GW</a> voor nieuws en de agenda.
+                            {% endblocktrans %}
+                        </li>
+                        <li>
+                            {% blocktrans trimmed %}
+                                Het reglement van de
+                                <a href="https://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/">Algemene Kamer (AK)</a>
+                                of dat van de
+                                <a href="https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/">Linguïstiek Kamer (LK)</a>.
+                            {% endblocktrans %}
+                        </li>
                     </ul>
-                <li>
-                {% blocktrans trimmed %}
-                    Gebruik de juiste (meest recente) <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw">voorbeelddocumenten</a> voor de <em>informed consent</em>.
-                {% endblocktrans %}
+                    <li>
+                        {% blocktrans trimmed %}
+                            Gebruik de juiste (meest recente) <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw">voorbeelddocumenten</a> voor de <em>informed consent</em>.
+                        {% endblocktrans %}
+                    </li>
+                    <p>
+                        {% blocktrans trimmed %}
+                            Studenten moeten hun begeleider vragen om deze formulieren; dezelfde voorbeeldteksten, maar op niet-officiële formulieren, zijn te vinden op <a href="https://fetc-gw.wp.hum.uu.nl/voorbeelddocumenten/">deze pagina</a>.
+                        {% endblocktrans %}
+                    </p>
                 </li>
-                <p>
-                {% blocktrans trimmed %}
-                Studenten moeten hun begeleider vragen om deze formulieren; dezelfde voorbeeldteksten, maar op niet-officiële formulieren, zijn te vinden op <a href="https://fetc-gw.wp.hum.uu.nl/voorbeelddocumenten/">deze pagina</a>.
-                {% endblocktrans %}
-                </p>
-                </li>
-                </ul>
+            </ul>
             <p>
                 {% blocktrans %}
                     Een voorstel is opgebouwd uit (van groot naar klein) (i) trajecten, (ii) sessies, (iii) taken.
                 {% endblocktrans %}
             </p>
             <ul>
-            <p>
-                <li><strong>{% trans "Traject" %}</strong>:
-                    {% blocktrans trimmed %}
-                    Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
-                    <p>{% blocktrans trimmed %}
-                        <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
-                        {% endblocktrans %}
-                </p>
-            </p>
-            <p>
-            <li><strong>{% trans "Sessie" %}</strong>:
-                {% blocktrans trimmed %}
-                    Alle taken/onderdelen die iemand op één dag uitvoert.
-                {% endblocktrans %}
-            </li>
-            </p>
-            <p>
-            <li><strong>{% trans "Taak" %}</strong>:
-                {% blocktrans trimmed %}
-                    Een taak of onderdeel van je onderzoek.
                 <p>
-                    <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
-                </p>
-                {% endblocktrans %}
-            </li>
-            </p>
-            </ul>
-            <a class="button button-colored float-right mb-4" href="{% url 'proposals:create' %}">
-                {% trans "Volgende stap >>" %}
-            </a>
+                    <li><strong>{% trans "Traject" %}</strong>:
+                        {% blocktrans trimmed %}
+                            Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
+                        <p>{% blocktrans trimmed %}
+                            <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
+                        {% endblocktrans %}
+                        </p>
+                    </p>
+                    <p>
+                        <li><strong>{% trans "Sessie" %}</strong>:
+                            {% blocktrans trimmed %}
+                                Alle taken/onderdelen die iemand op één dag uitvoert.
+                            {% endblocktrans %}
+                        </li>
+                    </p>
+                    <p>
+                        <li><strong>{% trans "Taak" %}</strong>:
+                            {% blocktrans trimmed %}
+                                Een taak of onderdeel van je onderzoek.
+                                <p>
+                                    <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
+                                </p>
+                            {% endblocktrans %}
+                        </li>
+                    </p>
+                </ul>
+                <a class="button button-colored float-right mb-4" href="{% url 'proposals:create' %}">
+                    {% trans "Volgende stap >>" %}
+                </a>
+            </div>
         </div>
-    </div>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_start_practice.html
+++ b/proposals/templates/proposals/proposal_start_practice.html
@@ -14,75 +14,75 @@
                 {% trans "Een nieuwe aanvraag aanmelden (oefenportaal)" %}
             </h2>
 
-                <ul>
+            <ul>
                 <li>{% trans "Check voor het indienen:" %}
                     <ul>
-                    <li>
-                        {% blocktrans trimmed %}
-                            De
-                            <a href="https://fetc-gw.wp.hum.uu.nl/" target="_blank">
-                            UU-webpagina van de FETC-GW</a> voor nieuws en de agenda.
-                        {% endblocktrans %}
-                    </li>
-                    <li>
-                        {% blocktrans trimmed %}
-                            Het reglement van de
-                            <a href="https://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/">Algemene Kamer (AK)</a>
-                            of dat van de
-                            <a href="https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/">Linguïstiek Kamer (LK)</a>.
-                        {% endblocktrans %}
-                    </li>
+                        <li>
+                            {% blocktrans trimmed %}
+                                De
+                                <a href="https://fetc-gw.wp.hum.uu.nl/" target="_blank">
+                                    UU-webpagina van de FETC-GW</a> voor nieuws en de agenda.
+                            {% endblocktrans %}
+                        </li>
+                        <li>
+                            {% blocktrans trimmed %}
+                                Het reglement van de
+                                <a href="https://fetc-gw.wp.hum.uu.nl/reglement-algemene-kamer/">Algemene Kamer (AK)</a>
+                                of dat van de
+                                <a href="https://fetc-gw.wp.hum.uu.nl/reglement-linguistiek-kamer/">Linguïstiek Kamer (LK)</a>.
+                            {% endblocktrans %}
+                        </li>
                     </ul>
-                <li>
-                {% blocktrans trimmed %}
-                    Gebruik de juiste (meest recente) <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw">voorbeelddocumenten</a> voor de <em>informed consent</em>.
-                {% endblocktrans %}
+                    <li>
+                        {% blocktrans trimmed %}
+                            Gebruik de juiste (meest recente) <a href="https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw">voorbeelddocumenten</a> voor de <em>informed consent</em>.
+                        {% endblocktrans %}
+                    </li>
+                    <p>
+                        {% blocktrans trimmed %}
+                            Studenten moeten hun begeleider vragen om deze formulieren; dezelfde voorbeeldteksten, maar op niet-officiële formulieren, zijn te vinden op <a href="https://fetc-gw.wp.hum.uu.nl/voorbeelddocumenten/">deze pagina</a>.
+                        {% endblocktrans %}
+                    </p>
                 </li>
-                <p>
-                {% blocktrans trimmed %}
-                Studenten moeten hun begeleider vragen om deze formulieren; dezelfde voorbeeldteksten, maar op niet-officiële formulieren, zijn te vinden op <a href="https://fetc-gw.wp.hum.uu.nl/voorbeelddocumenten/">deze pagina</a>.
-                {% endblocktrans %}
-                </p>
-                </li>
-                </ul>
+            </ul>
             <p>
                 {% blocktrans %}
                     Een voorstel is opgebouwd uit (van groot naar klein) (i) trajecten, (ii) sessies, (iii) taken.
                 {% endblocktrans %}
             </p>
             <ul>
-            <p>
-            <li><strong>{% trans "Traject" %}</strong>:
-                {% blocktrans trimmed %}
-                    Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
-                <p>{% blocktrans trimmed %}
-                    <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
-                    {% endblocktrans %}
-            </p>
-            <p>
-            <li><strong>{% trans "Sessie" %}</strong>:
-                {% blocktrans trimmed %}
-                    Alle taken/onderdelen die iemand op één dag uitvoert.
-                {% endblocktrans %}
-            </li>
-            </p>
-            <p>
-            <li><strong>{% trans "Taak" %}</strong>:
-                {% blocktrans trimmed %}
-                    Een taak of onderdeel van je onderzoek.
                 <p>
-                    <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
-                </p>
-                {% endblocktrans %}
-            </li>
-            </p>
-            </ul>
-            <p>{% trans "Houd er rekening mee dat een oefenaanvraag niet ingediend kan worden." %}</p>
-            <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-                <table>{{ form.as_table }}</table>
-                {% include "base/form_buttons.html" %}
-            </form>
-        </div>
-    </div>
+                    <li><strong>{% trans "Traject" %}</strong>:
+                        {% blocktrans trimmed %}
+                            Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
+                        <p>{% blocktrans trimmed %}
+                            <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
+                        {% endblocktrans %}
+                        </p>
+                        <p>
+                            <li><strong>{% trans "Sessie" %}</strong>:
+                                {% blocktrans trimmed %}
+                                    Alle taken/onderdelen die iemand op één dag uitvoert.
+                                {% endblocktrans %}
+                            </li>
+                        </p>
+                        <p>
+                            <li><strong>{% trans "Taak" %}</strong>:
+                                {% blocktrans trimmed %}
+                                    Een taak of onderdeel van je onderzoek.
+                                    <p>
+                                        <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
+                                    </p>
+                                {% endblocktrans %}
+                            </li>
+                        </p>
+                    </ul>
+                    <p>{% trans "Houd er rekening mee dat een oefenaanvraag niet ingediend kan worden." %}</p>
+                    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+                        <table>{{ form.as_table }}</table>
+                        {% include "base/form_buttons.html" %}
+                    </form>
+                </div>
+            </div>
 
 {% endblock %}

--- a/proposals/templates/proposals/proposal_start_pre_approved.html
+++ b/proposals/templates/proposals/proposal_start_pre_approved.html
@@ -18,13 +18,13 @@
                 {% trans "Een nieuwe aanvraag aanmelden (die al goedgekeurd is door een andere ethische toetsingscomissie)" %}
             </h2>
             <p>
-              {% blocktrans trimmed %}
-              Je wilt een nieuwe aanvraag ter toetsing bij de FETC-GW aanmelden, die al getoetst is
-              door een andere ethische (toetsings) commissie.
-              Het is daarvoor <em>noodzakelijk</em> dat je goed bekend bent met het <a href="{{reg_url}}" target="_blank">FETC-GW
-                reglement</a>. 
-                Je kan jezelf en de commissieleden veel tijd besparen door je eerst
-                goed te informeren.
+                {% blocktrans trimmed %}
+                    Je wilt een nieuwe aanvraag ter toetsing bij de FETC-GW aanmelden, die al getoetst is
+                    door een andere ethische (toetsings) commissie.
+                    Het is daarvoor <em>noodzakelijk</em> dat je goed bekend bent met het <a href="{{reg_url}}" target="_blank">FETC-GW
+                        reglement</a>.
+                    Je kan jezelf en de commissieleden veel tijd besparen door je eerst
+                    goed te informeren.
                 {% endblocktrans %}
             </p>
             <p>

--- a/proposals/templates/proposals/proposal_start_pre_assessment.html
+++ b/proposals/templates/proposals/proposal_start_pre_assessment.html
@@ -18,18 +18,18 @@
                 <ul>
                     <li>{% blocktrans trimmed %}Soms is bij het indienen van een aanvraag bij een subsidieverstrekker een ethische verklaring nodig.{% endblocktrans %}</li>
                     <li>{% blocktrans trimmed %}Goedgekeurde NWO-aanvragen hebben ook een ethische verklaring nodig alvorens een startdatum vastgesteld kan worden.{% endblocktrans %}</li>
-                    </ul>
+                </ul>
 
-                    <p>{% blocktrans trimmed %}In deze gevallen kunnen onderzoekers de FETC-GW verzoeken om de onderzoeksaanvraag te laten toetsen. Dit kan via deze route van de portal{% endblocktrans %}.</p>
+                <p>{% blocktrans trimmed %}In deze gevallen kunnen onderzoekers de FETC-GW verzoeken om de onderzoeksaanvraag te laten toetsen. Dit kan via deze route van de portal{% endblocktrans %}.</p>
 
-                    <p>{% blocktrans trimmed %}NB: De toetsing kan alleen op hoofdlijnen plaatsvinden en vervangt NIET de reguliere ethische toetsing van een onderzoek; elke mensgebonden studie die in het kader van de onderzoeksaanvraag zal worden uitgevoerd dient vóóraf goedgekeurd te zijn door de FETC-GW.{% endblocktrans %}
-            </p>
+                <p>{% blocktrans trimmed %}NB: De toetsing kan alleen op hoofdlijnen plaatsvinden en vervangt NIET de reguliere ethische toetsing van een onderzoek; elke mensgebonden studie die in het kader van de onderzoeksaanvraag zal worden uitgevoerd dient vóóraf goedgekeurd te zijn door de FETC-GW.{% endblocktrans %}
+                </p>
 
-            <p><img src="{% static 'proposals/images/fetc-flowchart-pre-2.png' %}" style="width: 100%;"></p>
+                <p><img src="{% static 'proposals/images/fetc-flowchart-pre-2.png' %}" style="width: 100%;"></p>
 
-            <a class="button button-colored float-right mb-3" href="{% url 'proposals:create_pre' %}">
-                {% trans "Volgende stap >>" %}
-            </a>
+                <a class="button button-colored float-right mb-3" href="{% url 'proposals:create_pre' %}">
+                    {% trans "Volgende stap >>" %}
+                </a>
+            </div>
         </div>
-    </div>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_submit.html
+++ b/proposals/templates/proposals/proposal_submit.html
@@ -15,25 +15,25 @@
 {% endblock %}
 
 {% block html_head %}
-<script type="text/javascript" charset="utf8" src="{% static 'proposals/js/word_counter.js' %}"></script>
-<script>
-    $(function () {
-        depends_on_value('embargo', 'True', 'embargo_end_date');
+    <script type="text/javascript" charset="utf8" src="{% static 'proposals/js/word_counter.js' %}"></script>
+    <script>
+        $(function () {
+            depends_on_value('embargo', 'True', 'embargo_end_date');
 
         // Add datepicker for date_start, set locale to current language
-        $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
+            $.datepicker.setDefaults($.datepicker.regional["{{ LANGUAGE_CODE }}"]);
 
-        var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'yy-mm-dd';
-        $("#id_embargo_end_date").datepicker({
-            dateFormat: date_format,
-        })
-    });
+            var date_format = '{{ LANGUAGE_CODE }}' === 'nl' ? 'dd-mm-yy' : 'yy-mm-dd';
+            $("#id_embargo_end_date").datepicker({
+                dateFormat: date_format,
+            })
+        });
 
-    $(function() {
-        let translated_string = " {% trans 'Aantal woorden:' %} "
-        wordCounter("comments", translated_string)
-    });
-</script>
+        $(function() {
+            let translated_string = " {% trans 'Aantal woorden:' %} "
+            wordCounter("comments", translated_string)
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -122,51 +122,51 @@
 
             <form action="" method="post" enctype="multipart/form-data">
 
-            {% if troublesome_pages %}
-            <div class="warning">
-	      <h5>
-                    {% blocktrans trimmed %}
-                        Er zijn nog errors gevonden op de volgende pagina's:
-                    {% endblocktrans %}
-		    </h5>
-                    <ul>
-                        {% for error_page in troublesome_pages %}
-                            <li>
-                                <a href="{{ error_page.url }}">
-                                    {{ error_page.page_name }}
-                                </a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                    {% blocktrans trimmed %}
-                        Dit komt waarschijnlijk doordat je nog niet alle verplichte velden heeft ingevuld. Je kan je
-                        aanmelding pas versturen wanneer deze fouten gecorrigeerd zijn.
-                    {% endblocktrans %}
-                </div>
-		{% endif %}
-		{% if start_date_warning %}
-		<div class="warning">
-		  <h5>{% trans "Controleer uw beoogde startdatum" %}</h5>
-		  <p>
-		    {% blocktrans trimmed %}
-		    Omdat de beoogde startdatum binnen twee weken van vandaag ligt, kan de FETC helaas geen officiële goedkeuring meer geven voor deze aanvraag. Controleer daarom bij een revisie altijd of de beoogde startdatum nog klopt.
-		    {% endblocktrans %}
-		    {% url "proposals:update" proposal.pk as first_page_url %}
-		    {% blocktrans trimmed %}
-		    De beoogde startdatum vindt u op
-		    <a href="{{first_page_url}}">deze pagina</a>.
-		    {% endblocktrans %}
-		  </p>
-		</div>		
-		{% endif %}
+                {% if troublesome_pages %}
+                    <div class="warning">
+                        <h5>
+                            {% blocktrans trimmed %}
+                                Er zijn nog errors gevonden op de volgende pagina's:
+                            {% endblocktrans %}
+                        </h5>
+                        <ul>
+                            {% for error_page in troublesome_pages %}
+                                <li>
+                                    <a href="{{ error_page.url }}">
+                                        {{ error_page.page_name }}
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                        {% blocktrans trimmed %}
+                            Dit komt waarschijnlijk doordat je nog niet alle verplichte velden heeft ingevuld. Je kan je
+                            aanmelding pas versturen wanneer deze fouten gecorrigeerd zijn.
+                        {% endblocktrans %}
+                    </div>
+                {% endif %}
+                {% if start_date_warning %}
+                    <div class="warning">
+                        <h5>{% trans "Controleer uw beoogde startdatum" %}</h5>
+                        <p>
+                            {% blocktrans trimmed %}
+                                Omdat de beoogde startdatum binnen twee weken van vandaag ligt, kan de FETC helaas geen officiële goedkeuring meer geven voor deze aanvraag. Controleer daarom bij een revisie altijd of de beoogde startdatum nog klopt.
+                            {% endblocktrans %}
+                            {% url "proposals:update" proposal.pk as first_page_url %}
+                            {% blocktrans trimmed %}
+                                De beoogde startdatum vindt u op
+                                <a href="{{first_page_url}}">deze pagina</a>.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                {% endif %}
 
 
-		{% csrf_token %}
+                {% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% if is_practice %}
-                <div class="info">
-                    {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
-                </div>
+                    <div class="info">
+                        {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+                    </div>
                 {% endif %}
                 {% if troublesome_pages or is_practice %}
                     {% include "base/form_buttons.html" with no_forward=1 %}

--- a/proposals/templates/proposals/proposal_update_attachments.html
+++ b/proposals/templates/proposals/proposal_update_attachments.html
@@ -15,8 +15,8 @@
             </h2>
             <p>
                 {% blocktrans trimmed with title=proposal.title ref_number=proposal.reference_number %}
-                Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
-                (referentienummer <em>{{ ref_number }}</em>).
+                    Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
+                    (referentienummer <em>{{ ref_number }}</em>).
                 {% endblocktrans %}
             </p>
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}

--- a/proposals/templates/proposals/study_consent.html
+++ b/proposals/templates/proposals/study_consent.html
@@ -20,45 +20,45 @@
     }
     $(function() {
     {# We use a counter so that in case we need more than 2 extra forms, this piece of code just works without changes #}
-    {% counter extra_form_counter create 1 %}
+      {% counter extra_form_counter create 1 %}
 
-    {% for form in formset %}
-      add_title('{{ form.prefix }}-informed_consent', 'Informed consent participant');
-      add_title('{{ form.prefix }}-director_consent_declaration', '{% trans 'Toestemmingsverklaring van de schoolleider/hoofd van het departement' %}');
+      {% for form in formset %}
+        add_title('{{ form.prefix }}-informed_consent', 'Informed consent participant');
+        add_title('{{ form.prefix }}-director_consent_declaration', '{% trans 'Toestemmingsverklaring van de schoolleider/hoofd van het departement' %}');
 
-      {% if not form.instance.study %}
-        if($("#extra-{% counter extra_form_counter value %}").attr('data-used') == 0)
-        $("#extra-{% counter extra_form_counter value %}").hide()
-        {% counter extra_form_counter increment 1 %}
-      {% else %}
+        {% if not form.instance.study %}
+          if($("#extra-{% counter extra_form_counter value %}").attr('data-used') == 0)
+            $("#extra-{% counter extra_form_counter value %}").hide()
+          {% counter extra_form_counter increment 1 %}
+        {% else %}
 
-        {% if not form.instance.study.needs_additional_external_forms %}
-          hide_school_forms("{{form.prefix}}");
+          {% if not form.instance.study.needs_additional_external_forms %}
+            hide_school_forms("{{form.prefix}}");
+          {% endif %}
         {% endif %}
-      {% endif %}
-    {% endfor %}
+      {% endfor %}
 
 
     // This code handles showing a new set of forms by clicking the add link
-    $("a.new").click(function ( event ) {
+      $("a.new").click(function ( event ) {
     // Prevent the link from firing
-    event.preventDefault();
+        event.preventDefault();
 
     // Get the form number
-    var self = $(this);
-    var n = parseInt(self.attr('data-n'));
+        var self = $(this);
+        var n = parseInt(self.attr('data-n'));
     // Hide the clicked button
-    self.hide();
+        self.hide();
 
     // Show the new form, and a new add link (if present, can be run without effect)
-    $("#extra-" + n).show();
-    $("#new-" + (n + 1)).show();
+        $("#extra-" + n).show();
+        $("#new-" + (n + 1)).show();
 
-    return false;
-    });
+        return false;
+      });
 
     // Show the first add link
-    $("a.new").first().show();
+      $("a.new").first().show();
     });
   </script>
 {% endblock %}
@@ -95,7 +95,7 @@
         {% blocktrans trimmed %}
           Let op dat je documenten geen redactionele fouten en/of taalfouten bevatten: een aanvraag kan hierom direct voor revisie worden teruggestuurd.
         {% endblocktrans %}
-	{% blocktrans trimmed %}
+        {% blocktrans trimmed %}
           Bij ontvangst worden alle bestandsnamen gewijzigd, zet hier dus geen belangrijke informatie in.
         {% endblocktrans %}
       </p>
@@ -121,34 +121,34 @@
               {% endwith %}
           {% else %}
               {# If not, we have to do some fancy stuff for the extra forms #}
-              {% if form.instance.informed_consent or form.instance.briefing or form.instance.parents_information or form.instance.director_consent_information or form.instance.director_consent_declaration %}
+            {% if form.instance.informed_consent or form.instance.briefing or form.instance.parents_information or form.instance.director_consent_information or form.instance.director_consent_declaration %}
                 {# We can't check this in Python, so we determine here if the object is empty or used  #}
-                {% set used = 1 %}
-              {% else %}
-                {% set used = 0 %}
+              {% set used = 1 %}
+            {% else %}
+              {% set used = 0 %}
                 {# We only add the add link if the form is empty, as this simplifies the JS #}
-                <div style="float:right;">
-                  <a href="#" id="new-{% counter extra_form_counter value %}" class="new" data-n="{% counter extra_form_counter value %}" style="display: none">
-                    <img src="{% static 'proposals/images/add.png' %}" /> {% trans 'Voeg extra formulieren toe' %}
-                  </a>
-                </div>
-              {% endif %}
+              <div style="float:right;">
+                <a href="#" id="new-{% counter extra_form_counter value %}" class="new" data-n="{% counter extra_form_counter value %}" style="display: none">
+                  <img src="{% static 'proposals/images/add.png' %}" /> {% trans 'Voeg extra formulieren toe' %}
+                </a>
+              </div>
+            {% endif %}
 
-              <div id="extra-{% counter extra_form_counter value %}" data-used="{{ used }}">
-                <h3>{% trans 'Extra formulieren' %} {% counter extra_form_counter value %}</h3>
-                {% counter extra_form_counter increment 1 %}
+            <div id="extra-{% counter extra_form_counter value %}" data-used="{{ used }}">
+              <h3>{% trans 'Extra formulieren' %} {% counter extra_form_counter value %}</h3>
+              {% counter extra_form_counter increment 1 %}
 
           {% endif %}
 
           <table>
             {{ form.as_table }}
           </table>
-              </div>
+          </div>
         {% endfor %}
         <br/>
         {% include "base/form_buttons.html" %}
       </form>
-            </div>
     </div>
+  </div>
 
 {% endblock %}

--- a/proposals/templates/proposals/study_start.html
+++ b/proposals/templates/proposals/study_start.html
@@ -8,48 +8,48 @@
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function() {
-    add_title('study_name_1', "{% trans 'Geef elk traject hieronder een behulpzame naam van maximaal 15 karakters.' %}");
+    <script>
+        $(function() {
+            add_title('study_name_1', "{% trans 'Geef elk traject hieronder een behulpzame naam van maximaal 15 karakters.' %}");
 
-    $('input[name=studies_similar]').change(function() {
-        var is_dissimilar = $('input[name=studies_similar]:checked').val() === 'False';
+            $('input[name=studies_similar]').change(function() {
+                var is_dissimilar = $('input[name=studies_similar]:checked').val() === 'False';
 
-        var text = "{{ is_similar }}";
-        if (is_dissimilar) {
+                var text = "{{ is_similar }}";
+                if (is_dissimilar) {
             // Set the default value for studies_number to 2 (if it's not already set)
-            if ($('input[name="studies_number"]').val() === '1') {
-                $('input[name="studies_number"]').val('2');
-            }
-        	text = "{{ is_dissimilar }}";
-        }
-        else {
-            $('input[name="studies_number"]').val('1');
-            $('input[name^="study_name"]').parents('tr').hide();
-            $('input[name="study_name_1"]').parents('tr').prev().hide();
-        }
+                    if ($('input[name="studies_number"]').val() === '1') {
+                        $('input[name="studies_number"]').val('2');
+                    }
+                    text = "{{ is_dissimilar }}";
+                }
+                else {
+                    $('input[name="studies_number"]').val('1');
+                    $('input[name^="study_name"]').parents('tr').hide();
+                    $('input[name="study_name_1"]').parents('tr').prev().hide();
+                }
 
-        $('#next_text').html(text);
-        $('#next_text').show();
+                $('#next_text').html(text);
+                $('#next_text').show();
 
-        $('#id_studies_number').parents('tr').toggle(is_dissimilar);
-        $('#id_studies_number').change();
-    });
-    $('input[name=studies_similar]').change();
+                $('#id_studies_number').parents('tr').toggle(is_dissimilar);
+                $('#id_studies_number').change();
+            });
+            $('input[name=studies_similar]').change();
 
-    $('input[name=studies_number]').change(function() {
-        var is_dissimilar = $('input[name=studies_similar]:checked').val() === 'False';
+            $('input[name=studies_number]').change(function() {
+                var is_dissimilar = $('input[name=studies_similar]:checked').val() === 'False';
 
-        if (is_dissimilar) {
-            $('input[name="study_name_1"]').parents('tr').prev().show();
-            for (var i = 1; i <= 10; i++) {
-                $('input[name="study_name_' + i + '"]').parents('tr').toggle(i <= $(this).val());
-            }
-        }
-    });
-    $('input[name=studies_number]').change();
-});
-</script>
+                if (is_dissimilar) {
+                    $('input[name="study_name_1"]').parents('tr').prev().show();
+                    for (var i = 1; i <= 10; i++) {
+                        $('input[name="study_name_' + i + '"]').parents('tr').toggle(i <= $(this).val());
+                    }
+                }
+            });
+            $('input[name=studies_number]').change();
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -69,39 +69,39 @@ $(function() {
                 {% endblocktrans %}
             </p>
             <ul>
-            <p>
-                <li><strong>{% trans "Traject" %}</strong>:
-                    {% blocktrans trimmed %}
-                    Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
-                    <p>{% blocktrans trimmed %}
-                        <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
-                        {% endblocktrans %}
-            </p>
-            <p>
-            <li><strong>{% trans "Sessie" %}</strong>:
-                {% blocktrans trimmed %}
-                    Alle taken/onderdelen die iemand op één dag uitvoert.
-                {% endblocktrans %}
-            </li>
-            </p>
-            <p>
-            <li><strong>{% trans "Taak" %}</strong>:
-                {% blocktrans trimmed %}
-                    Een taak of onderdeel van je onderzoek.
                 <p>
-                    <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
-                </p>
-                {% endblocktrans %}
-            </li>
-            </p>
-            </ul>
-            <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-                <table>
-                    {{ form.as_table }}
-                </table>
-                <p id="next_text"></p>
-                {% include "base/form_buttons.html" %}
-            </form>
-        </div>
-    </div>
+                    <li><strong>{% trans "Traject" %}</strong>:
+                        {% blocktrans trimmed %}
+                            Als je met verschillende deelnemersgroepen werkt die een verschillend onderzoekstraject doorlopen waarvoor verschillende informed consent documenten nodig zijn.{% endblocktrans %}
+                        <p>{% blocktrans trimmed %}
+                            <u>Bijvoorbeeld</u>: ouders van leerlingen 15 jaar en jonger, docenten, een controlegroep en een experimentele groep die verschillende taken krijgen.
+                        {% endblocktrans %}
+                        </p>
+                        <p>
+                            <li><strong>{% trans "Sessie" %}</strong>:
+                                {% blocktrans trimmed %}
+                                    Alle taken/onderdelen die iemand op één dag uitvoert.
+                                {% endblocktrans %}
+                            </li>
+                        </p>
+                        <p>
+                            <li><strong>{% trans "Taak" %}</strong>:
+                                {% blocktrans trimmed %}
+                                    Een taak of onderdeel van je onderzoek.
+                                    <p>
+                                        <u>Bijvoorbeeld</u>: het invullen van een vragenlijst, een interview, of een taaltest.
+                                    </p>
+                                {% endblocktrans %}
+                            </li>
+                        </p>
+                    </ul>
+                    <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+                        <table>
+                            {{ form.as_table }}
+                        </table>
+                        <p id="next_text"></p>
+                        {% include "base/form_buttons.html" %}
+                    </form>
+                </div>
+            </div>
 {% endblock %}

--- a/proposals/templates/proposals/translated_consent_forms.html
+++ b/proposals/templates/proposals/translated_consent_forms.html
@@ -11,8 +11,8 @@
     <script>
         $(function () {
             depends_on_value('translated_forms', 'True', 'translated_forms_languages');
-    });
-  </script>
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -20,24 +20,24 @@
         <div class="col-12">
             {% with nav_items=proposal.available_urls active=pagenr %}
                 {% include 'base/navigation.html' %}
-            {% endwith %}            
+            {% endwith %}
             <h2>
                 {% trans "Vertaling informed consent formulieren" %}
             </h2>
 
             <p>
                 {% blocktrans trimmed %}
-                Documenten moet in het Nederlands of in het Engels worden ingediend. 
-                Echter, om je deelnemers op een adequate manier te informeren kan het noodzakelijk zijn om de documenten in hun moedertaal te vertalen. 
-                Als dat het geval is, dan hoeven deze niet direct te worden ingediend. Het is wel noodzakelijk te vermelden dat deze vertaald zullen gaan worden. 
-                Bij goedkeuring moeten de documenten in andere talen wel worden aangeleverd, omdat de portal ook dient als officieel archief van goedgekeurde aanvragen. 
-                Dit kan eventueel na goedkeuring, maar kan ook bij een minimale revisie.
+                    Documenten moet in het Nederlands of in het Engels worden ingediend.
+                    Echter, om je deelnemers op een adequate manier te informeren kan het noodzakelijk zijn om de documenten in hun moedertaal te vertalen.
+                    Als dat het geval is, dan hoeven deze niet direct te worden ingediend. Het is wel noodzakelijk te vermelden dat deze vertaald zullen gaan worden.
+                    Bij goedkeuring moeten de documenten in andere talen wel worden aangeleverd, omdat de portal ook dient als officieel archief van goedgekeurde aanvragen.
+                    Dit kan eventueel na goedkeuring, maar kan ook bij een minimale revisie.
                 {% endblocktrans %}
             </p>
 
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
-                    {% include "base/form_buttons.html" %}
+                {% include "base/form_buttons.html" %}
             </form>
         </div>
     </div>

--- a/proposals/templates/proposals/vue_templates/proposal_archive_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_archive_list.html
@@ -11,7 +11,7 @@
 <script type="text/x-template" id="proposalsUFLList">
     <FancyList
             {# It's a long, but standard, list, so we just include the default list #}
-            {% include 'uil.vue/fancy-list-params.txt' %}
+    {% include 'uil.vue/fancy-list-params.txt' %}
     >
         {# General note: the #{slot}="data" defines in which Vue variable all properties are loaded.  #}
         {# FancyList only exposes `item` and `context`, where item is the item from the data for a given row.  #}
@@ -20,135 +20,135 @@
 
         {# Here we do some JS deconstructing to pull the data out in seperate variables. We also rename item #}
         {# to proposal, for clarity. #}
-        <template #title="{ item: proposal, context }">
-            <h4>
+    <template #title="{ item: proposal, context }">
+    <h4>
                 {# Verbatim tags are needed to stop Django from interpreting these braces as Django template code #}
                 {# They are actually vue template code #}
                 {% verbatim %}
                 {{ proposal.reference_number }} -
                 {{ proposal.title }}
                 {% endverbatim %}
-            </h4>
-        </template>
+    </h4>
+    </template>
 
 
-        <template #actions="{ item: proposal, context }">
+    <template #actions="{ item: proposal, context }">
 
-            <a
-                v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
-                :href="$url('proposals:pdf', [proposal.pk])"
-                target="_blank"
-            >
-                <img src="{{ img_pdf }}"
-                     title="{% trans 'Inzien' %}">
-            </a>
-        </template>
+    <a
+    v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
+    :href="$url('proposals:pdf', [proposal.pk])"
+    target="_blank"
+    >
+    <img src="{{ img_pdf }}"
+    title="{% trans 'Inzien' %}">
+    </a>
+    </template>
 
 
-        <template #undertitle="{ item: proposal, context }">
-            <div class="ufl-undertitle-line">
-                {% trans 'Soort aanvraag' %}:
+    <template #undertitle="{ item: proposal, context }">
+    <div class="ufl-undertitle-line">
+    {% trans 'Soort aanvraag' %}:
                 {% verbatim %}
                 {{ proposal.type }}
                 {% endverbatim %}
-            </div>
-            <div class="ufl-undertitle-line">
-                <span v-if="proposal.latest_review && proposal.latest_review.continuation == context.review.REVISION">
-                    {% trans "Besloten op" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    <span v-if="proposal.latest_review && proposal.latest_review.continuation == context.review.REVISION">
+    {% trans "Besloten op" %}:
                     {% verbatim %}
                     {{ proposal.date_reviewed | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-                <span
-                    v-else-if="proposal.date_confirmed"
-                >
-                    {% trans "Besloten op" %}:
+    </span>
+    <span
+    v-else-if="proposal.date_confirmed"
+    >
+    {% trans "Besloten op" %}:
                     {% verbatim %}
                     {{ proposal.date_confirmed | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-                <span v-else>
-                    {% trans "Laatst bijgewerkt" %}:
+    </span>
+    <span v-else>
+    {% trans "Laatst bijgewerkt" %}:
                     {% verbatim %}
                     {{ proposal.date_modified | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans 'Status' %}:
-                <span
-                    v-if="proposal.status >= context.proposal.DECISION_MADE"
-                >
+    </span>
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans 'Status' %}:
+        <span
+    v-if="proposal.status >= context.proposal.DECISION_MADE"
+    >
                     {% verbatim %}
                     {{ proposal.latest_review.get_continuation_display }}
                     {% endverbatim %}
-                </span>
-                <span v-else>
+    </span>
+    <span v-else>
                     {% verbatim %}
                     {{ proposal.get_status_display }}
                     {% endverbatim %}
-                </span>
-            </div>
-        </template>
+    </span>
+    </div>
+    </template>
 
 
-        <template #details="{ item: proposal, context }">
-            <div class="row">
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    {% trans "Datum ingediend" %}:
-                                </td>
-                                <td v-if="proposal.date_submitted">
+    <template #details="{ item: proposal, context }">
+    <div class="row">
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr>
+    <td>
+    {% trans "Datum ingediend" %}:
+        </td>
+    <td v-if="proposal.date_submitted">
                                     {% verbatim %}
                                     {{ proposal.date_submitted | date("DD-MM-YYYY, HH:mm") }}
                                     {% endverbatim %}
-                                </td>
-                                <td v-else>
-                                    {% trans 'Nog niet ingediend' %}
-                                </td>
-                            </tr>
-                            <tr v-if="proposal.supervisor">
-                                <td>
-                                    {% trans "Eindverantwoordelijke onderzoeker" %}:
-                                </td>
-                                <td v-html="proposal.supervisor.fullname">
+    </td>
+    <td v-else>
+    {% trans 'Nog niet ingediend' %}
+    </td>
+    </tr>
+    <tr v-if="proposal.supervisor">
+    <td>
+    {% trans "Eindverantwoordelijke onderzoeker" %}:
+        </td>
+    <td v-html="proposal.supervisor.fullname">
 
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="context.wants_route_info && proposal.latest_review">
-                                <td>
-                                    {% trans "Route:" %}
-                                </td>
-                                <td v-html="proposal.latest_review.route">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">
-                                    {% trans "Indieners" %}:<br/>
-                                    <span
-                                       v-for="(applicant, index) in proposal.applicants"
-                                   >
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="context.wants_route_info && proposal.latest_review">
+    <td>
+    {% trans "Route:" %}
+    </td>
+    <td v-html="proposal.latest_review.route">
+    </td>
+    </tr>
+    <tr>
+    <td colspan="2">
+    {% trans "Indieners" %}:<br/>
+    <span
+    v-for="(applicant, index) in proposal.applicants"
+    >
                                         {% verbatim %}
                                         <span v-if="index != 0">, </span>
                                         {{ applicant.fullname }}
                                         {% endverbatim %}
-                                    </span>
-                                </td>
-                            </tr>
-                        </tbody>
+    </span>
+    </td>
+    </tr>
+    </tbody>
 
-                    </table>
-                </div>
-            </div>
-        </template>
+    </table>
+    </div>
+    </div>
+    </template>
     </FancyList>
 </script>

--- a/proposals/templates/proposals/vue_templates/proposal_list.html
+++ b/proposals/templates/proposals/vue_templates/proposal_list.html
@@ -11,7 +11,7 @@
 <script type="text/x-template" id="proposalsUFLList">
     <FancyList
             {# It's a long, but standard, list, so we just include the default list #}
-            {% include 'uil.vue/fancy-list-params.txt' %}
+    {% include 'uil.vue/fancy-list-params.txt' %}
     >
         {# General note: the #{slot}="data" defines in which Vue variable all properties are loaded.  #}
         {# FancyList only exposes `item` and `context`, where item is the item from the data for a given row.  #}
@@ -20,186 +20,186 @@
 
         {# Here we do some JS deconstructing to pull the data out in seperate variables. We also rename item #}
         {# to proposal, for clarity. #}
-        <template #title="{ item: proposal, context }">
-            <h4>
+    <template #title="{ item: proposal, context }">
+    <h4>
                 {# Verbatim tags are needed to stop Django from interpreting these braces as Django template code #}
                 {# They are actually vue template code #}
                 {% verbatim %}
                 {{ proposal.reference_number }} -
                 {{ proposal.title }}
                 {% endverbatim %}
-            </h4>
-        </template>
+    </h4>
+    </template>
 
 
-        <template #actions="{ item: proposal, context }">
-            <a
-                :href="$url('reviews:decide', [proposal.supervisor_decision.pk])"
-                v-if="proposal.status == context.proposal.SUBMITTED_TO_SUPERVISOR && proposal.supervisor && context.user_pk == proposal.supervisor.pk"
-            >
-                <img src="{% static 'reviews/images/scale.png' %}"
-                     title="{% trans 'Beslissen' %}">
-            </a>
+    <template #actions="{ item: proposal, context }">
+    <a
+    :href="$url('reviews:decide', [proposal.supervisor_decision.pk])"
+    v-if="proposal.status == context.proposal.SUBMITTED_TO_SUPERVISOR && proposal.supervisor && context.user_pk == proposal.supervisor.pk"
+    >
+    <img src="{% static 'reviews/images/scale.png' %}"
+    title="{% trans 'Beslissen' %}">
+    </a>
 
-            <a
-                :href="$url('proposals:diff', [proposal.pk])"
-                v-if="proposal.is_revision"
-            >
-                <img src="{{ img_diff }}"
-                     title="{% trans 'Toon verschillen' %}">
-            </a>
+    <a
+    :href="$url('proposals:diff', [proposal.pk])"
+    v-if="proposal.is_revision"
+    >
+    <img src="{{ img_diff }}"
+    title="{% trans 'Toon verschillen' %}">
+    </a>
 
-            <template
-                v-if="proposal.status < context.proposal.SUBMITTED_TO_SUPERVISOR"
-            >
-                <a
-                    :href="proposal.continue_url"
-                    v-if="proposal.applicants.filter( a => { return a.pk === context.user_pk}).length > 0 || (proposal.supervisor && context.user_pk == proposal.supervisor.pk)"
-                >
-                    <img src="{{ img_next }}"
-                         title="{% trans 'Naar volgende stap' %}">
-                </a>
-                <a :href="$url('proposals:delete', [proposal.pk])">
-                    <img src="{{ img_delete }}"
-                         title="{% trans 'Verwijderen' %}">
-                </a>
-            </template>
-            <a
-                v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
-                :href="$url('proposals:pdf', [proposal.pk])"
-                target="_blank"
-            >
-                <img src="{{ img_pdf }}"
-                     title="{% trans 'Inzien' %}">
-            </a>
-            <a
-                :href="$url('proposals:archive_status', [proposal.pk])"
-                v-if="proposal.in_archive && context.is_secretary"
-            >
-                <img src="{{ img_hide }}"
-                     title="{% trans 'Verberg' %}">
-            </a>
-        </template>
+    <template
+    v-if="proposal.status < context.proposal.SUBMITTED_TO_SUPERVISOR"
+    >
+    <a
+    :href="proposal.continue_url"
+    v-if="proposal.applicants.filter( a => { return a.pk === context.user_pk}).length > 0 || (proposal.supervisor && context.user_pk == proposal.supervisor.pk)"
+    >
+    <img src="{{ img_next }}"
+    title="{% trans 'Naar volgende stap' %}">
+    </a>
+    <a :href="$url('proposals:delete', [proposal.pk])">
+    <img src="{{ img_delete }}"
+    title="{% trans 'Verwijderen' %}">
+    </a>
+    </template>
+    <a
+    v-if="proposal.status >= context.proposal.SUBMITTED_TO_SUPERVISOR"
+    :href="$url('proposals:pdf', [proposal.pk])"
+    target="_blank"
+    >
+    <img src="{{ img_pdf }}"
+    title="{% trans 'Inzien' %}">
+    </a>
+    <a
+    :href="$url('proposals:archive_status', [proposal.pk])"
+    v-if="proposal.in_archive && context.is_secretary"
+    >
+    <img src="{{ img_hide }}"
+    title="{% trans 'Verberg' %}">
+    </a>
+    </template>
 
 
-        <template #undertitle="{ item: proposal, context }">
-            <div class="ufl-undertitle-line">
-                {% trans 'Soort aanvraag' %}:
+    <template #undertitle="{ item: proposal, context }">
+    <div class="ufl-undertitle-line">
+    {% trans 'Soort aanvraag' %}:
                 {% verbatim %}
                 {{ proposal.type }}
                 {% endverbatim %}
-            </div>
-            <div class="ufl-undertitle-line">
-                <span v-if="proposal.latest_review && proposal.latest_review.continuation == context.review.REVISION">
-                    {% trans "Besloten op" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    <span v-if="proposal.latest_review && proposal.latest_review.continuation == context.review.REVISION">
+    {% trans "Besloten op" %}:
                     {% verbatim %}
                     {{ proposal.date_reviewed | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-                <span
-                    v-else-if="proposal.date_confirmed"
-                >
-                    {% trans "Besloten op" %}:
+    </span>
+    <span
+    v-else-if="proposal.date_confirmed"
+    >
+    {% trans "Besloten op" %}:
                     {% verbatim %}
                     {{ proposal.date_confirmed | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-                <span v-else>
-                    {% trans "Laatst bijgewerkt" %}:
+    </span>
+    <span v-else>
+    {% trans "Laatst bijgewerkt" %}:
                     {% verbatim %}
                     {{ proposal.date_modified | date("DD-MM-YYYY, HH:mm") }}
                     {% endverbatim %}
-                </span>
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans 'Status' %}:
-                <span
-                    v-if="proposal.status >= context.proposal.DECISION_MADE"
-                >
+    </span>
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans 'Status' %}:
+        <span
+    v-if="proposal.status >= context.proposal.DECISION_MADE"
+    >
                     {% verbatim %}
                     {{ proposal.latest_review.get_continuation_display }}
                     {% endverbatim %}
-                </span>
-                <span v-else>
+    </span>
+    <span v-else>
                     {% verbatim %}
                     {{ proposal.get_status_display }}
                     {% endverbatim %}
-                </span>
-            </div>
-        </template>
+    </span>
+    </div>
+    </template>
 
 
-        <template #details="{ item: proposal, context }">
-            <div class="row">
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="proposal.parent && proposal.parent.latest_review">
-                                <td>
-                                    {% trans "Revisie/amendement van" %}:
-                                </td>
-                                <td v-if="proposal.parent.pdf != undefined">
-                                    <a
-                                        :href="proposal.parent.pdf.url"
-                                        v-html="proposal.parent.reference_number"
-                                    ></a>
-                                </td>
-                                <td v-else v-html="proposal.parent.reference_number">
+    <template #details="{ item: proposal, context }">
+    <div class="row">
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="proposal.parent && proposal.parent.latest_review">
+    <td>
+    {% trans "Revisie/amendement van" %}:
+        </td>
+    <td v-if="proposal.parent.pdf != undefined">
+    <a
+    :href="proposal.parent.pdf.url"
+    v-html="proposal.parent.reference_number"
+    ></a>
+    </td>
+    <td v-else v-html="proposal.parent.reference_number">
 
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Datum ingediend" %}:
-                                </td>
-                                <td v-if="proposal.date_submitted">
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Datum ingediend" %}:
+        </td>
+    <td v-if="proposal.date_submitted">
                                     {% verbatim %}
                                     {{ proposal.date_submitted | date("DD-MM-YYYY, HH:mm") }}
                                     {% endverbatim %}
-                                </td>
-                                <td v-else>
-                                    {% trans 'Nog niet ingediend' %}
-                                </td>
-                            </tr>
-                            <tr v-if="proposal.supervisor">
-                                <td>
-                                    {% trans "Eindverantwoordelijke onderzoeker" %}:
-                                </td>
-                                <td v-html="proposal.supervisor.fullname">
+    </td>
+    <td v-else>
+    {% trans 'Nog niet ingediend' %}
+    </td>
+    </tr>
+    <tr v-if="proposal.supervisor">
+    <td>
+    {% trans "Eindverantwoordelijke onderzoeker" %}:
+        </td>
+    <td v-html="proposal.supervisor.fullname">
 
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="context.wants_route_info && proposal.latest_review">
-                                <td>
-                                    {% trans "Route:" %}
-                                </td>
-                                <td v-html="proposal.latest_review.route">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">
-                                    {% trans "Indieners" %}:<br/>
-                                    <span
-                                       v-for="(applicant, index) in proposal.applicants"
-                                   >
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="context.wants_route_info && proposal.latest_review">
+    <td>
+    {% trans "Route:" %}
+    </td>
+    <td v-html="proposal.latest_review.route">
+    </td>
+    </tr>
+    <tr>
+    <td colspan="2">
+    {% trans "Indieners" %}:<br/>
+    <span
+    v-for="(applicant, index) in proposal.applicants"
+    >
                                         {% verbatim %}
                                         <span v-if="index != 0">, </span>
                                         {{ applicant.fullname }}
                                         {% endverbatim %}
-                                    </span>
-                                </td>
-                            </tr>
-                        </tbody>
+    </span>
+    </td>
+    </tr>
+    </tbody>
 
-                    </table>
-                </div>
-            </div>
-        </template>
+    </table>
+    </div>
+    </div>
+    </template>
     </FancyList>
 </script>

--- a/proposals/templates/proposals/wmo_check.html
+++ b/proposals/templates/proposals/wmo_check.html
@@ -8,12 +8,12 @@
 {% endblock %}
 
 {% block html_head %}
-<script type="text/javascript" charset="utf8" src="{% static 'proposals/js/wmo.js' %}"></script>
-<script>
-$(function() {
-    check_metc_required("{% url 'proposals:check_wmo' %}");
-});
-</script>
+    <script type="text/javascript" charset="utf8" src="{% static 'proposals/js/wmo.js' %}"></script>
+    <script>
+        $(function() {
+            check_metc_required("{% url 'proposals:check_wmo' %}");
+        });
+    </script>
 {% endblock %}
 
 {% block content %}

--- a/proposals/templates/proposals/wmo_form.html
+++ b/proposals/templates/proposals/wmo_form.html
@@ -10,12 +10,12 @@
 {% block html_head %}
     <script type="text/javascript" charset="utf8" src="{% static 'proposals/js/wmo.js' %}"></script>
     <script>
-    $(function() {
-        check_metc_required("{% url 'proposals:check_wmo' %}");
+        $(function() {
+            check_metc_required("{% url 'proposals:check_wmo' %}");
 
-        depends_on_value('metc', 'Y', 'metc_details');
-        depends_on_value('metc', 'Y', 'metc_institution');
-    });
+            depends_on_value('metc', 'Y', 'metc_details');
+            depends_on_value('metc', 'Y', 'metc_institution');
+        });
     </script>
 {% endblock %}
 

--- a/reviews/templates/mail/concept_creator.html
+++ b/reviews/templates/mail/concept_creator.html
@@ -1,21 +1,21 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-Beste collega,<br />
-<br />
-Uw concept-aanmelding wordt door de eindverantwoordelijk onderzoeker {{ supervisor }} van deze aanvraag gecontroleerd.
-Zodra deze de concept-aanmelding, evt. na kleine aanpassingen, heeft goedgekeurd en ter toetsing bij de FETC-GW heeft ingediend, krijgt u van ons bericht.<br />
-Indien de concept-aanmelding nog aanzienlijke wijzigingen uwerzijds behoeft zal de eindverantwoordelijk onderzoeker zelf contact met u opnemen.<br />
-U kunt uw ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br />
-<br />
+    Beste collega,<br />
+    <br />
+    Uw concept-aanmelding wordt door de eindverantwoordelijk onderzoeker {{ supervisor }} van deze aanvraag gecontroleerd.
+    Zodra deze de concept-aanmelding, evt. na kleine aanpassingen, heeft goedgekeurd en ter toetsing bij de FETC-GW heeft ingediend, krijgt u van ons bericht.<br />
+    Indien de concept-aanmelding nog aanzienlijke wijzigingen uwerzijds behoeft zal de eindverantwoordelijk onderzoeker zelf contact met u opnemen.<br />
+    U kunt uw ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br />
+    <br />
 {% endblock %}
 
 {% block content_en %}
-Dear colleague,<br />
-<br />
-Your draft application will be checked by your supervisor {{ supervisor }}, the researcher who has the final responsibility of this study.<br />
-You will receive a notification as soon as {{ supervisor }} has approved and formally submitted your draft application, possibly after making some minor revisions.<br />
-In case {{ supervisor }} finds it necessary for you to make more substantial revisions in the application, he/she will notify you about this, and meanwhile formally disapprove the study in order for you to be able to revise and resubmit it.<br />
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.
-<br />
+    Dear colleague,<br />
+    <br />
+    Your draft application will be checked by your supervisor {{ supervisor }}, the researcher who has the final responsibility of this study.<br />
+    You will receive a notification as soon as {{ supervisor }} has approved and formally submitted your draft application, possibly after making some minor revisions.<br />
+    In case {{ supervisor }} finds it necessary for you to make more substantial revisions in the application, he/she will notify you about this, and meanwhile formally disapprove the study in order for you to be able to revise and resubmit it.<br />
+    You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.
+    <br />
 {% endblock %}

--- a/reviews/templates/mail/concept_other_applicants.html
+++ b/reviews/templates/mail/concept_other_applicants.html
@@ -1,23 +1,23 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-Beste collega,<br />
-<br />
-Uw collega {{ creator }} heeft een concept-aanmelding ingediend bij de ethische commissie voor het onderzoek {{ title }}, waar u aan meewerkt.<br />
-De aanmelding wordt door de eindverantwoordelijk onderzoeker {{ supervisor }} van deze aanvraag gecontroleerd.
-Zodra deze de concept-aanmelding, evt. na kleine aanpassingen, heeft goedgekeurd en ter toetsing bij de FETC-GW heeft ingediend, krijgt uw collega {{ creator }} van ons bericht.<br />
-Indien de concept-aanmelding nog aanzienlijke wijzigingen uwerzijds behoeft zal de eindverantwoordelijk onderzoeker zelf contact met uw collega opnemen.<br />
-U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br />
-<br />
+    Beste collega,<br />
+    <br />
+    Uw collega {{ creator }} heeft een concept-aanmelding ingediend bij de ethische commissie voor het onderzoek {{ title }}, waar u aan meewerkt.<br />
+    De aanmelding wordt door de eindverantwoordelijk onderzoeker {{ supervisor }} van deze aanvraag gecontroleerd.
+    Zodra deze de concept-aanmelding, evt. na kleine aanpassingen, heeft goedgekeurd en ter toetsing bij de FETC-GW heeft ingediend, krijgt uw collega {{ creator }} van ons bericht.<br />
+    Indien de concept-aanmelding nog aanzienlijke wijzigingen uwerzijds behoeft zal de eindverantwoordelijk onderzoeker zelf contact met uw collega opnemen.<br />
+    U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br />
+    <br />
 {% endblock %}
 
 {% block content_en %}
-Dear colleague,<br />
-<br />
-Your colleague {{ creator }} has submitted a draft application to the ethics commision for the study {{ title }}, in which you are participating.<b />
-The application will be checked by the study's supervisor {{ supervisor }}, the researcher who has the final responsibility of this study.<br />
-Your colleague {{ creator }} will receive a notification as soon as {{ supervisor }} has approved and formally submitted your draft application, possibly after making some minor revisions.<br />
-In case {{ supervisor }} finds it necessary for you to make more substantial revisions in the application, he/she will notify your colleague about this, and meanwhile formally disapprove the study in order for you to be able to revise and resubmit it.<br />
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
-<br />
+    Dear colleague,<br />
+    <br />
+    Your colleague {{ creator }} has submitted a draft application to the ethics commision for the study {{ title }}, in which you are participating.<b />
+    The application will be checked by the study's supervisor {{ supervisor }}, the researcher who has the final responsibility of this study.<br />
+    Your colleague {{ creator }} will receive a notification as soon as {{ supervisor }} has approved and formally submitted your draft application, possibly after making some minor revisions.<br />
+    In case {{ supervisor }} finds it necessary for you to make more substantial revisions in the application, he/she will notify your colleague about this, and meanwhile formally disapprove the study in order for you to be able to revise and resubmit it.<br />
+    You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
+    <br />
 {% endblock %}

--- a/reviews/templates/mail/concept_supervisor.html
+++ b/reviews/templates/mail/concept_supervisor.html
@@ -1,39 +1,39 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-Beste collega,<br/>
-<br/>
-{{ creator }} heeft binnen de FETC-GW-webportal een concept-aanvraag opgesteld voor een onderzoek waarbij u als de eindverantwoordelijke onderzoeker bent aangewezen.<br/>
+    Beste collega,<br/>
+    <br/>
+    {{ creator }} heeft binnen de FETC-GW-webportal een concept-aanvraag opgesteld voor een onderzoek waarbij u als de eindverantwoordelijke onderzoeker bent aangewezen.<br/>
 
-<p>
-{{ proposal.reference_number }}: {{ proposal.title }}</p>
+    <p>
+        {{ proposal.reference_number }}: {{ proposal.title }}</p>
 
-U kunt deze concept-aanmelding <a href="{{ proposal_url }}">hier</a> bekijken, eventueel na aanpassingen van uzelf of {{ creator }}, formeel ter toetsing bij de FETC-GW indienen.<br/>
-Indien {{ creator }} wordt geacht de aanpassingen te maken, dient u de aanvraag formeel af te keuren en zelf {{ creator }} hiervan op de hoogte stellen.<br/>
-<br/>
-U kunt al uw aanmeldingen als supervisor en hun status <a href="{{ my_supervised }}">hier</a> bekijken.<br/>
-<br/>
-{% if revision %}
-<strong>Let op:</strong> het gaat hierbij om een {{ revision_type|lower }} van een eerdere aanmelding.<br/>
-Op het webportaal kunt u de wijzigingen ten opzichte van de vorige aanmelding inzien.<br/>
-{% endif %}
+    U kunt deze concept-aanmelding <a href="{{ proposal_url }}">hier</a> bekijken, eventueel na aanpassingen van uzelf of {{ creator }}, formeel ter toetsing bij de FETC-GW indienen.<br/>
+    Indien {{ creator }} wordt geacht de aanpassingen te maken, dient u de aanvraag formeel af te keuren en zelf {{ creator }} hiervan op de hoogte stellen.<br/>
+    <br/>
+    U kunt al uw aanmeldingen als supervisor en hun status <a href="{{ my_supervised }}">hier</a> bekijken.<br/>
+    <br/>
+    {% if revision %}
+        <strong>Let op:</strong> het gaat hierbij om een {{ revision_type|lower }} van een eerdere aanmelding.<br/>
+        Op het webportaal kunt u de wijzigingen ten opzichte van de vorige aanmelding inzien.<br/>
+    {% endif %}
 {% endblock %}
 
 {% block content_en %}
-Dear colleague,<br/>
-<br/>
-{{ creator }} has created, within the portal of the FEtC-H, a draft application for a study for which you are appointed as the supervisor.<br/>
+    Dear colleague,<br/>
+    <br/>
+    {{ creator }} has created, within the portal of the FEtC-H, a draft application for a study for which you are appointed as the supervisor.<br/>
 
-<p>
-{{ proposal.reference_number }}: {{ proposal.title }}</p>
+    <p>
+        {{ proposal.reference_number }}: {{ proposal.title }}</p>
 
-You can review this draft application <a href="{{ proposal_url }}">here</a> and submit this study to the FEtC-H after you have approved it. Note that in case minor revisions are necessary, you can adjust the study yourself before submitting it.<br/>
-In case the application needs to be revised more substantially by {{ creator }}, we ask you to formally disapprove it in order for {{ creator }} to be able to revise it. In such a case, we ask you to inform {{ creator }} about this.<br/>
-<br/>
-You can view all your supervised applications and their status <a href="{{ my_supervised }}">here</a>.<br/>
-<br/>
-{% if revision %}
-<strong>Please note</strong> that this involves a {{ revision_type | lower }} of a previous application.<br/>
-On the web portal you can check the differences between the current and previous application.<br/>
-{% endif %}
+    You can review this draft application <a href="{{ proposal_url }}">here</a> and submit this study to the FEtC-H after you have approved it. Note that in case minor revisions are necessary, you can adjust the study yourself before submitting it.<br/>
+    In case the application needs to be revised more substantially by {{ creator }}, we ask you to formally disapprove it in order for {{ creator }} to be able to revise it. In such a case, we ask you to inform {{ creator }} about this.<br/>
+    <br/>
+    You can view all your supervised applications and their status <a href="{{ my_supervised }}">here</a>.<br/>
+    <br/>
+    {% if revision %}
+        <strong>Please note</strong> that this involves a {{ revision_type | lower }} of a previous application.<br/>
+        On the web portal you can check the differences between the current and previous application.<br/>
+    {% endif %}
 {% endblock %}

--- a/reviews/templates/mail/pre_assessment_secretary.html
+++ b/reviews/templates/mail/pre_assessment_secretary.html
@@ -1,7 +1,7 @@
 {% extends "mail/base-internal.html" %}
 
 {% block content %}
-Er is een nieuwe aanvraag voor voortoetsing ingediend (referentienummer: {{ proposal.reference_number }}, <br/>
-eindverantwoordelijke: {{ proposal.accountable_user.get_full_name }}).<br/>
-U kunt de aanvraag <a href="{{ proposal_pdf }}">hier</a> bekijken.<br/>
+    Er is een nieuwe aanvraag voor voortoetsing ingediend (referentienummer: {{ proposal.reference_number }}, <br/>
+    eindverantwoordelijke: {{ proposal.accountable_user.get_full_name }}).<br/>
+    U kunt de aanvraag <a href="{{ proposal_pdf }}">hier</a> bekijken.<br/>
 {% endblock %}

--- a/reviews/templates/mail/reminder.html
+++ b/reviews/templates/mail/reminder.html
@@ -1,15 +1,15 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-Beste collega,<br/>
-<br/>
-Je moet met spoed de aanvraag van {{ creator }} beoordelen. De deadline voor beoordeling is (bijna) verlopen.<br/>
-U kunt deze aanvraag beoordelen via {{ proposal_url }}<br/>
+    Beste collega,<br/>
+    <br/>
+    Je moet met spoed de aanvraag van {{ creator }} beoordelen. De deadline voor beoordeling is (bijna) verlopen.<br/>
+    U kunt deze aanvraag beoordelen via {{ proposal_url }}<br/>
 {% endblock %}
 
 {% block content_en %}
-Dear colleague,<br/>
-<br/>
-You must urgently review {{creator}}'s study. The deadline for assessment has (almost) expired.<br/>
-You can review this application via {{ proposal_url }}<br/>
+    Dear colleague,<br/>
+    <br/>
+    You must urgently review {{creator}}'s study. The deadline for assessment has (almost) expired.<br/>
+    You can review this application via {{ proposal_url }}<br/>
 {% endblock %}

--- a/reviews/templates/mail/submitted_longroute.html
+++ b/reviews/templates/mail/submitted_longroute.html
@@ -1,35 +1,35 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-{% if was_revised %}
-Beste collega,<br/>
-<br/>
-Je gereviseerde aanvraag is door de FETC-GW ontvangen.<br/>
-<br/>
-Dit houdt in dat je revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen je binnenkort een beoordeling te kunnen sturen.<br/>
+    {% if was_revised %}
+        Beste collega,<br/>
+        <br/>
+        Je gereviseerde aanvraag is door de FETC-GW ontvangen.<br/>
+        <br/>
+        Dit houdt in dat je revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen je binnenkort een beoordeling te kunnen sturen.<br/>
 
-{% else %}
-Beste collega,<br/>
-<br/>
-Je aanmelding is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>lange-route onderzoek</em>, zie <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">appendix A van het reglement</a> voor de criteria.<br/>
-<br/>
-Dit houdt in dat je aanvraag op de eerstvolgende vergadering van de FETC-GW zal worden besproken, wanneer je aanvraag tenminste een week voor die vergadering is ingediend. Zie <a href="https://fetc-gw.wp.hum.uu.nl/category/agenda/">de FETC-GW-agenda</a> voor een overzicht van de komende vergaderingen. Zeer kort na de vergadering zult u de beoordeling ontvangen.<br/>
-{% endif %}
+    {% else %}
+        Beste collega,<br/>
+        <br/>
+        Je aanmelding is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>lange-route onderzoek</em>, zie <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">appendix A van het reglement</a> voor de criteria.<br/>
+        <br/>
+        Dit houdt in dat je aanvraag op de eerstvolgende vergadering van de FETC-GW zal worden besproken, wanneer je aanvraag tenminste een week voor die vergadering is ingediend. Zie <a href="https://fetc-gw.wp.hum.uu.nl/category/agenda/">de FETC-GW-agenda</a> voor een overzicht van de komende vergaderingen. Zeer kort na de vergadering zult u de beoordeling ontvangen.<br/>
+    {% endif %}
 {% endblock %}
 
 {% block content_en %}
-{% if was_revised %}
-Dear colleague,<br/>
-<br/>
-The FEtC-H has received your revised application.<br/>
-<br/>
-This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
+    {% if was_revised %}
+        Dear colleague,<br/>
+        <br/>
+        The FEtC-H has received your revised application.<br/>
+        <br/>
+        This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
 
-{% else %}
-Dear colleague,<br/>
-<br/>
-The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>long-route research</em>, see <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/"> appendix A in the regulations</a> for the criteria.<br/>
-<br/>
-This means that your study will be discussed during the next FEtC-H meeting, if your application was submitted at least one week before that meeting. See <a href="https://fetc-gw.wp.hum.uu.nl/en/category/agenda-en/">the FEtC-H agenda</a> for an overview of upcoming meetings. You will receive the assessment shortly after the meeting.<br/>
-{% endif %}
+    {% else %}
+        Dear colleague,<br/>
+        <br/>
+        The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>long-route research</em>, see <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/"> appendix A in the regulations</a> for the criteria.<br/>
+        <br/>
+        This means that your study will be discussed during the next FEtC-H meeting, if your application was submitted at least one week before that meeting. See <a href="https://fetc-gw.wp.hum.uu.nl/en/category/agenda-en/">the FEtC-H agenda</a> for an overview of upcoming meetings. You will receive the assessment shortly after the meeting.<br/>
+    {% endif %}
 {% endblock %}

--- a/reviews/templates/mail/submitted_longroute_other_applicants.html
+++ b/reviews/templates/mail/submitted_longroute_other_applicants.html
@@ -1,37 +1,37 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-{% if was_revised %}
-Beste collega,<br/>
-<br/>
-Uw collega {{ creator }} heeft een gereviseerde aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen.<br/>
-<br/>
-Dit houdt in dat de revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen uw collega, {{ creator }}, binnenkort een beoordeling te kunnen sturen.<br/>
-U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
-{% else %}
-Beste collega,<br/>
-<br/>
-Uw collega {{ creator }} heeft een aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>lange-route onderzoek</em>, zie <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">appendix A van het reglement</a> voor de criteria.<br/>
-<br/>
-Dit houdt in dat je aanvraag op de eerstvolgende vergadering van de FETC-GW zal worden besproken, wanneer je aanvraag tenminste een week voor die vergadering is ingediend. Zie <a href="https://fetc-gw.wp.hum.uu.nl/category/agenda/">de FETC-GW-agenda</a> voor een overzicht van de komende vergaderingen. Kort na de vergadering zal {{ creator }} de beoordeling ontvangen.<br/>
-U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
-{% endif %}
+    {% if was_revised %}
+        Beste collega,<br/>
+        <br/>
+        Uw collega {{ creator }} heeft een gereviseerde aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen.<br/>
+        <br/>
+        Dit houdt in dat de revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen uw collega, {{ creator }}, binnenkort een beoordeling te kunnen sturen.<br/>
+        U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
+    {% else %}
+        Beste collega,<br/>
+        <br/>
+        Uw collega {{ creator }} heeft een aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>lange-route onderzoek</em>, zie <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">appendix A van het reglement</a> voor de criteria.<br/>
+        <br/>
+        Dit houdt in dat je aanvraag op de eerstvolgende vergadering van de FETC-GW zal worden besproken, wanneer je aanvraag tenminste een week voor die vergadering is ingediend. Zie <a href="https://fetc-gw.wp.hum.uu.nl/category/agenda/">de FETC-GW-agenda</a> voor een overzicht van de komende vergaderingen. Kort na de vergadering zal {{ creator }} de beoordeling ontvangen.<br/>
+        U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
+    {% endif %}
 {% endblock %}
 
 {% block content_en %}
-{% if was_revised %}
-Dear colleague,<br/>
-<br/>
-Your colleague {{ creator }} has submitted a revised application for the study {{ title }}, in which you are participating. The FEtC-H has received your application.<br/>
-<br/>
-This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send your colleague {{ creator }} a review soon.<br/>
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
-{% else %}
-Dear colleague,<br/>
-<br/>
-Your colleague {{ creator }} has submitted an application for the study {{ title }}, in which you are participating. The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>long-route research</em>, see <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/"> appendix A in the regulations</a> for the criteria.<br/>
-<br/>
-This means that your study will be discussed during the next FEtC-H meeting, if your application was submitted at least one week before that meeting. See <a href="https://fetc-gw.wp.hum.uu.nl/en/category/agenda-en/">the FEtC-H agenda</a> for an overview of upcoming meetings. {{ creator }} will receive the assessment shortly after the meeting.<br/>
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
-{% endif %}
+    {% if was_revised %}
+        Dear colleague,<br/>
+        <br/>
+        Your colleague {{ creator }} has submitted a revised application for the study {{ title }}, in which you are participating. The FEtC-H has received your application.<br/>
+        <br/>
+        This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send your colleague {{ creator }} a review soon.<br/>
+        You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
+    {% else %}
+        Dear colleague,<br/>
+        <br/>
+        Your colleague {{ creator }} has submitted an application for the study {{ title }}, in which you are participating. The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>long-route research</em>, see <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/"> appendix A in the regulations</a> for the criteria.<br/>
+        <br/>
+        This means that your study will be discussed during the next FEtC-H meeting, if your application was submitted at least one week before that meeting. See <a href="https://fetc-gw.wp.hum.uu.nl/en/category/agenda-en/">the FEtC-H agenda</a> for an overview of upcoming meetings. {{ creator }} will receive the assessment shortly after the meeting.<br/>
+        You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
+    {% endif %}
 {% endblock %}

--- a/reviews/templates/mail/submitted_shortroute.html
+++ b/reviews/templates/mail/submitted_shortroute.html
@@ -1,39 +1,39 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-{% if was_revised %}
-Beste collega,<br/>
-<br/>
-Je gereviseerde aanvraag is door de FETC-GW ontvangen.<br/>
-<br/>
-Dit houdt in dat je revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen je binnenkort een beoordeling te kunnen sturen.<br/>
+    {% if was_revised %}
+        Beste collega,<br/>
+        <br/>
+        Je gereviseerde aanvraag is door de FETC-GW ontvangen.<br/>
+        <br/>
+        Dit houdt in dat je revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen je binnenkort een beoordeling te kunnen sturen.<br/>
 
-{% else %}
-Beste collega,<br/>
-<br/>
-Je aanmelding is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>korte-route onderzoek</em> gekregen.<br/>
-<br/>
-Dit houdt in dat wij ernaar streven om je binnen twee werkweken een eerste beoordeling van de FETC-GW te sturen.<br/>
-<br/>
-NB: Het is mogelijk dat je aanvraag alsnog als 'lange-route onderzoek' wordt aangemerkt, in welk geval de beoordeling langer kan duren, zie het <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">reglement</a>. Houdt u hier a.u.b. rekening mee.<br/>
-{% endif %}
+    {% else %}
+        Beste collega,<br/>
+        <br/>
+        Je aanmelding is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>korte-route onderzoek</em> gekregen.<br/>
+        <br/>
+        Dit houdt in dat wij ernaar streven om je binnen twee werkweken een eerste beoordeling van de FETC-GW te sturen.<br/>
+        <br/>
+        NB: Het is mogelijk dat je aanvraag alsnog als 'lange-route onderzoek' wordt aangemerkt, in welk geval de beoordeling langer kan duren, zie het <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">reglement</a>. Houdt u hier a.u.b. rekening mee.<br/>
+    {% endif %}
 {% endblock %}
 
 {% block content_en %}
-{% if was_revised %}
-Dear colleague,<br/>
-<br/>
-The FEtC-H has received your revised application.<br/>
-<br/>
-This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
+    {% if was_revised %}
+        Dear colleague,<br/>
+        <br/>
+        The FEtC-H has received your revised application.<br/>
+        <br/>
+        This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
 
-{% else %}
-Dear colleague,<br/>
-<br/>
-The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>short-route research</em>.
-This means that you will receive an assessment within two working weeks.<br/>
-<br/>
-Note: It is possible that your application may still be classified as a 'long-route research', in which case the asssessment procedure may take longer, see the <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/">regulations</a> for information. If the latter case, see <a href="http://fetc-gw.wp.hum.uu.nl/regulations/">section 2.8, p. 14</a> for the possible time paths.<br/>
-Please be aware of these possibilities and the different time paths involved.<br/>
-{% endif %}
+    {% else %}
+        Dear colleague,<br/>
+        <br/>
+        The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>short-route research</em>.
+        This means that you will receive an assessment within two working weeks.<br/>
+        <br/>
+        Note: It is possible that your application may still be classified as a 'long-route research', in which case the asssessment procedure may take longer, see the <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/">regulations</a> for information. If the latter case, see <a href="http://fetc-gw.wp.hum.uu.nl/regulations/">section 2.8, p. 14</a> for the possible time paths.<br/>
+        Please be aware of these possibilities and the different time paths involved.<br/>
+    {% endif %}
 {% endblock %}

--- a/reviews/templates/mail/submitted_shortroute_other_applicants.html
+++ b/reviews/templates/mail/submitted_shortroute_other_applicants.html
@@ -1,39 +1,39 @@
 {% extends "mail/base.html" %}
 
 {% block content_nl %}
-{% if was_revised %}
-Beste collega,<br/>
-<br/>
-Uw collega {{ creator }} heeft een gereviseerde aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen.<br/>
-<br/>
-Dit houdt in dat de revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen uw collega, {{ creator }}, binnenkort een beoordeling te kunnen sturen.<br/>
-U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
-{% else %}
-Beste collega,<br/>
-<br/>
-Uw collega {{ creator }} heeft een aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>korte-route onderzoek</em> gekregen.<br/>
-<br/>
-Dit houdt in dat wij ernaar streven om uw collega binnen twee werkweken een eerste beoordeling van de FETC-GW te sturen.<br/>
-U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
-<br/>
-NB: Het is mogelijk dat je aanvraag alsnog als 'lange-route onderzoek' wordt aangemerkt, in welk geval de beoordeling langer kan duren, zie het <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">reglement</a>. Houdt u hier a.u.b. rekening mee.<br/>
-{% endif %}
+    {% if was_revised %}
+        Beste collega,<br/>
+        <br/>
+        Uw collega {{ creator }} heeft een gereviseerde aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen.<br/>
+        <br/>
+        Dit houdt in dat de revisie nu door twee leden van de FETC-GW zal worden beoordeeld; een eenvoudige revisie wordt alleen door de secretaris beoordeeld. We hopen uw collega, {{ creator }}, binnenkort een beoordeling te kunnen sturen.<br/>
+        U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
+    {% else %}
+        Beste collega,<br/>
+        <br/>
+        Uw collega {{ creator }} heeft een aanvraag ingediend voor het onderzoek {{ title }}, waar u aan meewerkt, bij de ethische commissie. De aanvraag is door de FETC-GW ontvangen. De automatische screening van de portal heeft op basis van de door jou gegeven beschrijving voorlopig de status <em>korte-route onderzoek</em> gekregen.<br/>
+        <br/>
+        Dit houdt in dat wij ernaar streven om uw collega binnen twee werkweken een eerste beoordeling van de FETC-GW te sturen.<br/>
+        U kunt de ingediende aanmelding <a href="{{ pdf_url }}">hier</a> in PDF vorm bekijken.<br/>
+        <br/>
+        NB: Het is mogelijk dat je aanvraag alsnog als 'lange-route onderzoek' wordt aangemerkt, in welk geval de beoordeling langer kan duren, zie het <a href="https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/">reglement</a>. Houdt u hier a.u.b. rekening mee.<br/>
+    {% endif %}
 {% endblock %}
 
 {% block content_en %}
-{% if was_revised %}
-Dear colleague,<br/>
-<br/>
-Your colleague {{ creator }} has submitted a revised application for the study {{ title }}, in which you are participating. The FEtC-H has received your revised application.<br/>
-<br/>
-This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
-{% else %}
-Dear colleague,<br/>
-<br/>
-Your colleague {{ creator }} has submitted an application for the study {{ title }}, in which you are participating. The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>short-route research</em>. This means that your colleague will receive an assessment within two working weeks.<br/>
-You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
-<br/>
-Note: It is possible that your application may still be classified as a 'long-route research', in which case the asssessment procedure may take longer, see the <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/">regulations</a> for information. If the latter case, see <a href="http://fetc-gw.wp.hum.uu.nl/regulations/">section 2.8, p. 14</a> for the possible time paths.<br/>
-{% endif %}
+    {% if was_revised %}
+        Dear colleague,<br/>
+        <br/>
+        Your colleague {{ creator }} has submitted a revised application for the study {{ title }}, in which you are participating. The FEtC-H has received your revised application.<br/>
+        <br/>
+        This means that your study will be assessed by two members of the FEtC-H; minor revisions will be assessed by the secretary only. We hope to be able to send you a review soon.<br/>
+        You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
+    {% else %}
+        Dear colleague,<br/>
+        <br/>
+        Your colleague {{ creator }} has submitted an application for the study {{ title }}, in which you are participating. The FEtC-H has received your application. The automatic screening of the portal has given your study the status of <em>short-route research</em>. This means that your colleague will receive an assessment within two working weeks.<br/>
+        You can find a PDF of your submission <a href="{{pdf_url}}">here</a>.<br/>
+        <br/>
+        Note: It is possible that your application may still be classified as a 'long-route research', in which case the asssessment procedure may take longer, see the <a href="https://fetc-gw.wp.hum.uu.nl/en/regulations-fetc-h/">regulations</a> for information. If the latter case, see <a href="http://fetc-gw.wp.hum.uu.nl/regulations/">section 2.8, p. 14</a> for the possible time paths.<br/>
+    {% endif %}
 {% endblock %}

--- a/reviews/templates/reviews/auto_review.html
+++ b/reviews/templates/reviews/auto_review.html
@@ -4,17 +4,17 @@
 <p>
     <div class="{{ auto_review_go|yesno:"success,warning" }}">
         {% if auto_review_go %}
-        {% trans "Volgens de automatische review kan dit voorstel de <em>korte (2-weken) route</em> volgen." %}
+            {% trans "Volgens de automatische review kan dit voorstel de <em>korte (2-weken) route</em> volgen." %}
         {% else %}
-        {% trans "Volgens de automatische review moet dit voorstel nader worden bekeken." %}
+            {% trans "Volgens de automatische review moet dit voorstel nader worden bekeken." %}
         {% endif %}
     </div>
     {% if not auto_review_go %}
-    <h3>{% trans "Redenen" %}</h3>
-    <ul>
-        {% for reason in auto_review_reasons %}
-        <li>{{ reason }}</li>
-        {% endfor %}
-    </ul>
+        <h3>{% trans "Redenen" %}</h3>
+        <ul>
+            {% for reason in auto_review_reasons %}
+                <li>{{ reason }}</li>
+            {% endfor %}
+        </ul>
     {% endif %}
 </p>

--- a/reviews/templates/reviews/committee_members_workload.html
+++ b/reviews/templates/reviews/committee_members_workload.html
@@ -19,44 +19,44 @@
 
             <table class="dt w-100" data-language="{% datatables_lang %}">
                 <thead>
-                <tr>
-                    <th>{% trans "Reviewer" %}</th>
-                    <th>{% trans "Traject" %}</th>
-                    <th>{% trans "Referentienummer" %}</th>
-                    <th>{% trans "Datum ingediend" %}</th>
-                    <th>{% trans "Gewenste einddatum" %}</th>
-                </tr>
+                    <tr>
+                        <th>{% trans "Reviewer" %}</th>
+                        <th>{% trans "Traject" %}</th>
+                        <th>{% trans "Referentienummer" %}</th>
+                        <th>{% trans "Datum ingediend" %}</th>
+                        <th>{% trans "Gewenste einddatum" %}</th>
+                    </tr>
                 </thead>
                 <tbody>
-                {% for decision in decisions %}
-                    <tr>
-                        <th scope="row">{{ decision.reviewer.get_full_name }} </th>
-                        <td>
-                            {% if decision.review.proposal.is_revision == True %}
-                                {% trans 'Revisie' %}
-                            {% elif decision.review.short_route == True %}
-                                {% trans 'Korte route' %}
+                    {% for decision in decisions %}
+                        <tr>
+                            <th scope="row">{{ decision.reviewer.get_full_name }} </th>
+                            <td>
+                                {% if decision.review.proposal.is_revision == True %}
+                                    {% trans 'Revisie' %}
+                                {% elif decision.review.short_route == True %}
+                                    {% trans 'Korte route' %}
+                                {% else %}
+                                    {% trans 'Lange route' %}
+                                {% endif %}
+                            </td>
+                            <td>
+                                <a href="{% url 'reviews:detail' pk=decision.review.pk %}">
+                                    {{ decision.review.proposal.reference_number }}
+                                </a> - {{decision.review.proposal.title}}
+                            </td>
+                            <td data-order="{{ decision.review.date_start|date:'c' }}">{{ decision.review.date_start|date:"j M Y" }}</td>
+                            {% if decision.review.date_should_end < today %}
+                                <td data-order="{{ decision.review.date_should_end|date:'c' }}" class="text-danger">
+                                    {{ decision.review.date_should_end|date:"j M Y" }}
+                                </td>
                             {% else %}
-                                {% trans 'Lange route' %}
+                                <td data-order="{{ decision.review.date_should_end|date:'c' }}">
+                                    {{ decision.review.date_should_end|date:"j M Y" }}
+                                </td>
                             {% endif %}
-                        </td>
-                        <td> 
-                            <a href="{% url 'reviews:detail' pk=decision.review.pk %}">
-                                {{ decision.review.proposal.reference_number }} 
-                            </a> - {{decision.review.proposal.title}}
-                        </td>
-                        <td data-order="{{ decision.review.date_start|date:'c' }}">{{ decision.review.date_start|date:"j M Y" }}</td>
-                        {% if decision.review.date_should_end < today %}
-                            <td data-order="{{ decision.review.date_should_end|date:'c' }}" class="text-danger"> 
-                                    {{ decision.review.date_should_end|date:"j M Y" }} 
-                            </td>
-                        {% else %}
-                            <td data-order="{{ decision.review.date_should_end|date:'c' }}">
-                                {{ decision.review.date_should_end|date:"j M Y" }}
-                            </td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
+                        </tr>
+                    {% endfor %}
                 </tbody>
             </table>
             <br />
@@ -67,20 +67,20 @@
             <form action="" method="post">
                 {% csrf_token %}
                 <table>
-                {{ form.as_table }}
+                    {{ form.as_table }}
                 </table>
                 <input type="submit" value="{% trans 'Periode toepassen'%}">
             </form>
             <br />
             <table class="dt w-100" data-language="{% datatables_lang %}">
                 <thead>
-                <tr>
-                    <th>{% trans "Reviewer" %}</th>
-                    <th>{% trans "Totaal" %}</th>
-                    <th>{% trans "Korte route" %}</th>
-                    <th>{% trans "Lange Route" %}</th>
-                    <th>{% trans "Revisie" %}</th>
-                </tr>
+                    <tr>
+                        <th>{% trans "Reviewer" %}</th>
+                        <th>{% trans "Totaal" %}</th>
+                        <th>{% trans "Korte route" %}</th>
+                        <th>{% trans "Lange Route" %}</th>
+                        <th>{% trans "Revisie" %}</th>
+                    </tr>
                 </thead>
                 <tbody>
                     {% for reviewer in reviewers %}
@@ -89,7 +89,7 @@
                             <td >{{ reviewer.total }}</td>
                             <td >{{ reviewer.num_short_route }}</td>
                             <td >{{ reviewer.num_long_route }}</td>
-                            <td >{{ reviewer.num_revision }}</td>                       
+                            <td >{{ reviewer.num_revision }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/reviews/templates/reviews/decision_form.html
+++ b/reviews/templates/reviews/decision_form.html
@@ -9,9 +9,9 @@
 
 {% block content %}
     <div class="uu-inner-container">
-    {% with review=decision.review %}
-        {% include "reviews/review_detail_sidebar.html" %}
-    {% endwith %}
+        {% with review=decision.review %}
+            {% include "reviews/review_detail_sidebar.html" %}
+        {% endwith %}
         <div class="col-12 col-md-9">
             <h2>
                 {% trans "Aanvraag beoordelen" %}

--- a/reviews/templates/reviews/documents_list.html
+++ b/reviews/templates/reviews/documents_list.html
@@ -9,43 +9,43 @@
 
 {% for container in containers %}
 
-<h5>
-    {{container.header}}
-</h5>
+    <h5>
+        {{container.header}}
+    </h5>
 
-<ul>
-    {% for item in container.items %}
-    <li>
-        <a href="{{ item.get_link_url }}" target="_blank"
+    <ul>
+        {% for item in container.items %}
+            <li>
+                <a href="{{ item.get_link_url }}" target="_blank"
 
-           {% if not item.sets_content_disposition %}
-               download="{{item.get_filename}}"
-           {% endif %}
-        >
-            {{item.name}}
+                   {% if not item.sets_content_disposition %}
+                       download="{{item.get_filename}}"
+                   {% endif %}
+                >
+                    {{item.name}}
+                </a>
+                {% if item.comparable %}
+                    {% simple_compare_link item.object item.field %}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+
+    {% if container.dmp_edit_link %}
+        <a href="{{ container.dmp_edit_link }}" class="d-block mb-3">
+            {% trans "Data Management Plan wijzigen" %}
+            <img src="{% static 'proposals/images/pencil.png' %}"
+                 title="{% trans 'Data Management Plan wijzigen' %}" />
         </a>
-        {% if item.comparable %}
-        {% simple_compare_link item.object item.field %}
-        {% endif %} 
-    </li>
-    {% endfor %}
-</ul>
+    {% endif %}
 
-{% if container.dmp_edit_link %}
-    <a href="{{ container.dmp_edit_link }}" class="d-block mb-3">
-        {% trans "Data Management Plan wijzigen" %}
-        <img src="{% static 'proposals/images/pencil.png' %}"
-            title="{% trans 'Data Management Plan wijzigen' %}" />
-    </a>
-{% endif %}
-
-{% if container.edit_link %}
-<a href="{{ container.edit_link }}" class="d-block mb-3">
-    {% trans "Documenten wijzigen" %}
-    <img src="{% static 'proposals/images/pencil.png' %}"
-         title="{% trans 'Documenten wijzigen' %}" />
-</a>
-{% endif %}
+    {% if container.edit_link %}
+        <a href="{{ container.edit_link }}" class="d-block mb-3">
+            {% trans "Documenten wijzigen" %}
+            <img src="{% static 'proposals/images/pencil.png' %}"
+                 title="{% trans 'Documenten wijzigen' %}" />
+        </a>
+    {% endif %}
 
 
 {% endfor %}

--- a/reviews/templates/reviews/review_assign_form.html
+++ b/reviews/templates/reviews/review_assign_form.html
@@ -23,9 +23,9 @@
 {% block content %}
     <div class="uu-inner-container">
 
-    {% with review=review %}
-        {% include "reviews/review_detail_sidebar.html" %}
-    {% endwith %}
+        {% with review=review %}
+            {% include "reviews/review_detail_sidebar.html" %}
+        {% endwith %}
 
         <div class="col-12 col-md-9">
             <h2>
@@ -37,7 +37,7 @@
                 <p>
                     Kies hier de geschikte route en commissieleden voor de aanvraag <em>{{ title }}</em>.
                     klik <a href="{{ workload_url }}">hier</a> voor een overzicht van de werkverdeling van deze commissie.
-                <p\>
+                    <p\>
             {% endblocktrans %}
             <form class="clearfix" action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>

--- a/reviews/templates/reviews/review_detail.html
+++ b/reviews/templates/reviews/review_detail.html
@@ -27,9 +27,9 @@
     </div>
     <div class="uu-inner-container">
 
-    {% with review=review %}
-        {% include "reviews/review_detail_sidebar.html" %}
-    {% endwith %}
+        {% with review=review %}
+            {% include "reviews/review_detail_sidebar.html" %}
+        {% endwith %}
 
         <div class="col-12 col-md-9">
             <h4>
@@ -38,15 +38,15 @@
             {% include "reviews/review_table.html" %}
             <h4>{% trans "Handelingen" %}</h4>
             <ul>
-            {% for action in detail_actions %}
-                <li>
-                    {{ action }}
-                </li>
+                {% for action in detail_actions %}
+                    <li>
+                        {{ action }}
+                    </li>
                 {% empty %}
-                <li>
-                    {% trans "Geen handelingen beschikbaar" %}
-                </li>
-            {% endfor %}
+                    <li>
+                        {% trans "Geen handelingen beschikbaar" %}
+                    </li>
+                {% endfor %}
             </ul>
             {% if not review.proposal.is_pre_assessment %}
                 {% include "reviews/auto_review.html" %}

--- a/reviews/templates/reviews/review_detail_sidebar.html
+++ b/reviews/templates/reviews/review_detail_sidebar.html
@@ -102,21 +102,21 @@ Remember to include it in a with statement if the view does not provide it.
     </ul>
 
 
-        {% if review.proposal.has_minor_revision %}
-            <h4>{% trans 'Revisie' %}</h4>
+    {% if review.proposal.has_minor_revision %}
+        <h4>{% trans 'Revisie' %}</h4>
+        <p>{% blocktrans %}
+            Deze aanvraag heeft een revisie gehad tijdens het beslisproces.
+        {% endblocktrans %}</p>
+        {% if review.proposal.minor_revision_description %}
             <p>{% blocktrans %}
-                Deze aanvraag heeft een revisie gehad tijdens het beslisproces.
-            {% endblocktrans %}</p>
-            {% if review.proposal.minor_revision_description %}
-                <p>{% blocktrans %}
-                    Er zijn de volgende opmerkingen bijgevoegd:<br/>
-                {% endblocktrans %}
+                Er zijn de volgende opmerkingen bijgevoegd:<br/>
+            {% endblocktrans %}
                 {{ review.proposal.minor_revision_description }}</p>
-            {% endif %}
         {% endif %}
+    {% endif %}
 
 
-                <h3>{% trans "Documenten" %}</h3>
-                {% documents_list review user %}
+    <h3>{% trans "Documenten" %}</h3>
+    {% documents_list review user %}
 
 </div>

--- a/reviews/templates/reviews/review_discontinue_form.html
+++ b/reviews/templates/reviews/review_discontinue_form.html
@@ -23,9 +23,9 @@
 {% block content %}
     <div class="uu-inner-container">
 
-    {% with review=review %}
-        {% include "reviews/review_detail_sidebar.html" %}
-    {% endwith %}
+        {% with review=review %}
+            {% include "reviews/review_detail_sidebar.html" %}
+        {% endwith %}
 
         <div class="col-12 col-md-9">
             <h2>
@@ -34,47 +34,47 @@
 
             <p>
                 {% blocktrans trimmed %}
-                Als een aanvraag definitief niet meer door de FETC-GW
-                afgehandeld gaat worden, en deze in de weg staat,
-                kan er voor gekozen worden deze te beëindigen.
+                    Als een aanvraag definitief niet meer door de FETC-GW
+                    afgehandeld gaat worden, en deze in de weg staat,
+                    kan er voor gekozen worden deze te beëindigen.
                 {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans trimmed %}
-                Een beëindigde aanvraag verschijnt niet meer in de pagina's
-                van de secretaris en beoordelaars. Deze
-                aanvraag kan ook niet meer gereviseerd worden,
-                maar nog wel gekopieerd. De aanvraag is nog wel zichtbaar
-                in de lijst met "alle ingediende aanvragen".
+                    Een beëindigde aanvraag verschijnt niet meer in de pagina's
+                    van de secretaris en beoordelaars. Deze
+                    aanvraag kan ook niet meer gereviseerd worden,
+                    maar nog wel gekopieerd. De aanvraag is nog wel zichtbaar
+                    in de lijst met "alle ingediende aanvragen".
                 {% endblocktrans %}
             </p>
             {% if review.stage == review.CLOSED %}
-            <p>
-                <strong>
-                    {% trans "Attentie" %}
-                </strong>:
-                {% blocktrans trimmed %}
-                Deze aanvraag heeft op dit moment geen lopende beoordeling. Om deze aanvraag definitief te
-                beëindigen, moeten we de uitkomst van laatste beoordeling (zie linker balk) veranderen.
-                Dit kan verwarring veroorzaken bij de indiener, dus houd hier rekening mee.
-                {% endblocktrans %}
-            </p>
+                <p>
+                    <strong>
+                        {% trans "Attentie" %}
+                    </strong>:
+                    {% blocktrans trimmed %}
+                        Deze aanvraag heeft op dit moment geen lopende beoordeling. Om deze aanvraag definitief te
+                        beëindigen, moeten we de uitkomst van laatste beoordeling (zie linker balk) veranderen.
+                        Dit kan verwarring veroorzaken bij de indiener, dus houd hier rekening mee.
+                    {% endblocktrans %}
+                </p>
             {% endif %}
             <p>
                 <strong>{% trans "Aanvraag" %}</strong>:
                 {% blocktrans with title=review.proposal.title author=review.proposal.created_by trimmed %}
-                <em>{{title}}</em> door {{author}}
+                    <em>{{title}}</em> door {{author}}
                 {% endblocktrans %}
-            <form class="clearfix" action="" method="post" enctype="multipart/form-data">{% csrf_token %}
-                <table>{{ form.as_table }}</table>
-                <div class="float-right">
-                    <a class="button" href="javascript:history.go(-1);">
-                        {% trans "Terug naar de vorige pagina" %}
-                    </a>
-                    <input class="pure-button pure-button-primary" type="submit" value="{% trans 'OK' %}"/>
-                </div>
+                <form class="clearfix" action="" method="post" enctype="multipart/form-data">{% csrf_token %}
+                    <table>{{ form.as_table }}</table>
+                    <div class="float-right">
+                        <a class="button" href="javascript:history.go(-1);">
+                            {% trans "Terug naar de vorige pagina" %}
+                        </a>
+                        <input class="pure-button pure-button-primary" type="submit" value="{% trans 'OK' %}"/>
+                    </div>
 
-            </form>
+                </form>
+            </div>
         </div>
-    </div>
 {% endblock %}

--- a/reviews/templates/reviews/review_table.html
+++ b/reviews/templates/reviews/review_table.html
@@ -13,12 +13,12 @@
     </thead>
     <tbody>
         {% for decision in review.decision_set.all %}
-        <tr>
-            <td>{{ decision.reviewer }}</td>
-            <td>{{ decision.get_go_display|default:_("open") }}</td>
-            <td data-order="{{ decision.date_decision|date:'c' }}">{{ decision.date_decision|date:"j F Y, G:i" }}</td>
-            <td>{{ decision.comments }}</td>
-        </tr>
+            <tr>
+                <td>{{ decision.reviewer }}</td>
+                <td>{{ decision.get_go_display|default:_("open") }}</td>
+                <td data-order="{{ decision.date_decision|date:'c' }}">{{ decision.date_decision|date:"j F Y, G:i" }}</td>
+                <td>{{ decision.comments }}</td>
+            </tr>
         {% endfor %}
     </tbody>
 </table>

--- a/reviews/templates/reviews/simple_compare_link.html
+++ b/reviews/templates/reviews/simple_compare_link.html
@@ -4,7 +4,7 @@
 
 
 {% if compare_url %}
-<a href="{{compare_url}}" target="_blank" class="icon-link">
-    <img src="{% static 'proposals/images/arrow_divide.png' %}" title="{% trans 'Toon verschillen' %}">
-</a>
+    <a href="{{compare_url}}" target="_blank" class="icon-link">
+        <img src="{% static 'proposals/images/arrow_divide.png' %}" title="{% trans 'Toon verschillen' %}">
+    </a>
 {% endif %}

--- a/reviews/templates/reviews/vue_templates/decision_list.html
+++ b/reviews/templates/reviews/vue_templates/decision_list.html
@@ -16,7 +16,7 @@
 <script type="text/x-template" id="reviewsUFLList">
     <FancyList
             {# It's a long, but standard, list, so we just include the default list #}
-            {% include 'uil.vue/fancy-list-params.txt' %}
+    {% include 'uil.vue/fancy-list-params.txt' %}
     >
         {# General note: the #{slot}="data" defines in which Vue variable all properties are loaded.  #}
         {# FancyList only exposes `item` and `context`, where item is the item from the data for a given row.  #}
@@ -25,178 +25,178 @@
 
         {# Here we do some JS deconstructing to pull the data out in seperate variables. We also rename item #}
         {# to decision, for clarity. #}
-        <template #title="{ item: decision, context }">
-            <h4>
+    <template #title="{ item: decision, context }">
+    <h4>
                 {# Verbatim tags are needed to stop Django from interpreting these braces as Django template code #}
                 {# They are actually vue template code #}
                 {% verbatim %}
                 {{ decision.proposal.reference_number }} -
                 {{ decision.proposal.title }}
                 {% endverbatim %}
-            </h4>
-        </template>
+    </h4>
+    </template>
 
 
-        <template #actions="{ item: decision, context }">
+    <template #actions="{ item: decision, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
-            <a
-               :href="$url('proposals:pdf', [decision.proposal.pk])"
-               target="_blank"
-            >
+    <a
+    :href="$url('proposals:pdf', [decision.proposal.pk])"
+    target="_blank"
+    >
                 {# Note the absence of {% verbatim %}, we actually use django here for the image! #}
-                <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
-            </a>
-            <a :href="$url('reviews:detail', [decision.review.pk])">
-                <img src="{{ img_details }}" title="{% trans 'Details' %}">
-            </a>
-            <a :href="$url('proposals:diff', [decision.proposal.pk])" v-if="decision.proposal.is_revision">
-                <img src="{{ img_diff }}" title="{% trans 'Toon verschillen' %}">
-            </a>
+    <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
+    </a>
+    <a :href="$url('reviews:detail', [decision.review.pk])">
+    <img src="{{ img_details }}" title="{% trans 'Details' %}">
+    </a>
+    <a :href="$url('proposals:diff', [decision.proposal.pk])" v-if="decision.proposal.is_revision">
+    <img src="{{ img_diff }}" title="{% trans 'Toon verschillen' %}">
+    </a>
             {# The template tag doesn't add anything by itself, so it's a good if container #}
-            <template v-if="context.is_secretary && decision.review.stage === context.review.ASSIGNMENT">
-                <a :href="$url('reviews:assign', [decision.review.pk])">
-                    <img src="{{ img_add_reviewers }}"
-                         title="{% trans 'Aanstellen' %}">
-                </a>
-                <a :href="$url('reviews:change_chamber', [decision.proposal.pk])">
-                    <img src="{{ img_change_chamber }}"
-                         title="{% trans 'Verplaats naar andere kamer' %}">
-                </a>
-            </template>
-            <template v-else-if="!decision.review.date_end">
-                <a :href="$url('reviews:decide', [decision.pk])" v-if="decision.review.current_reviewers.includes(context.current_user_pk)">
-                    <img src="{{ img_decide }}" title="{% trans 'Beslissen' %}">
-                </a>
-                <a :href="$url('reviews:decide_new', [decision.review.pk])" v-else-if="context.is_secretary">
-                    <img src="{{ img_decide }}" title="{% trans 'Beslissen' %}">
-                </a>
-            </template>
-            <a
-                    v-if="context.is_secretary && decision.review.stage === context.review.CLOSING"
-                    :href="$url('reviews:close', [decision.review.pk])"
-            >
-                <img src="{{ img_close }}" title="{% trans 'Afsluiten' %}">
-            </a>
-            <template v-else-if="context.is_secretary && decision.review.stage === context.review.CLOSED">
-                <template v-if="[context.review.GO, context.review.GO_POST_HOC].includes(decision.review.continuation)">
-                    <a :href="$url('proposals:archive_export', [decision.proposal.pk])">
-                        <img src="{{ img_export }}"
-                             title="{% trans 'Website export tekst' %}">
-                    </a>
-                    <a :href="$url('proposals:confirmation', [decision.proposal.pk])">
-                        <img
-                            v-if="decision.proposal.date_confirmed"
-                            src="{{ img_confirmed }}"
-                            title="{% trans 'Bevestigingsbrief verstuurd' %}"
-                        />
-                        <img
-                            v-else
-                            src="{{ img_confirm }}"
-                            title="{% trans 'Bevestigingsbrief versturen' %}"
-                        />
-                    </a>
-                </template>
-            </template>
-        </template>
+    <template v-if="context.is_secretary && decision.review.stage === context.review.ASSIGNMENT">
+    <a :href="$url('reviews:assign', [decision.review.pk])">
+    <img src="{{ img_add_reviewers }}"
+    title="{% trans 'Aanstellen' %}">
+    </a>
+    <a :href="$url('reviews:change_chamber', [decision.proposal.pk])">
+    <img src="{{ img_change_chamber }}"
+    title="{% trans 'Verplaats naar andere kamer' %}">
+    </a>
+    </template>
+    <template v-else-if="!decision.review.date_end">
+    <a :href="$url('reviews:decide', [decision.pk])" v-if="decision.review.current_reviewers.includes(context.current_user_pk)">
+    <img src="{{ img_decide }}" title="{% trans 'Beslissen' %}">
+    </a>
+    <a :href="$url('reviews:decide_new', [decision.review.pk])" v-else-if="context.is_secretary">
+    <img src="{{ img_decide }}" title="{% trans 'Beslissen' %}">
+    </a>
+    </template>
+    <a
+    v-if="context.is_secretary && decision.review.stage === context.review.CLOSING"
+    :href="$url('reviews:close', [decision.review.pk])"
+    >
+    <img src="{{ img_close }}" title="{% trans 'Afsluiten' %}">
+    </a>
+    <template v-else-if="context.is_secretary && decision.review.stage === context.review.CLOSED">
+    <template v-if="[context.review.GO, context.review.GO_POST_HOC].includes(decision.review.continuation)">
+    <a :href="$url('proposals:archive_export', [decision.proposal.pk])">
+    <img src="{{ img_export }}"
+    title="{% trans 'Website export tekst' %}">
+    </a>
+    <a :href="$url('proposals:confirmation', [decision.proposal.pk])">
+    <img
+    v-if="decision.proposal.date_confirmed"
+    src="{{ img_confirmed }}"
+    title="{% trans 'Bevestigingsbrief verstuurd' %}"
+    />
+    <img
+    v-else
+    src="{{ img_confirm }}"
+    title="{% trans 'Bevestigingsbrief versturen' %}"
+    />
+    </a>
+    </template>
+    </template>
+    </template>
 
 
-        <template #undertitle="{ item: decision, context }">
-            <div class="ufl-undertitle-line">
-                {% trans 'Eindverantwoordelijke' %}:
+    <template #undertitle="{ item: decision, context }">
+    <div class="ufl-undertitle-line">
+    {% trans 'Eindverantwoordelijke' %}:
                 {% verbatim %}
                 {{ decision.review.accountable_user.fullname }}
                 {% endverbatim %}
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans "Stadium" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans "Stadium" %}:
                 {% verbatim %}
                 {{ decision.review.get_stage_display }}
                 {% endverbatim %}
 
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans "Mijn besluit" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans "Mijn besluit" %}:
                 {% verbatim %}
                 {{ decision.get_go_display ? decision.get_go_display : "Open" }}
                 {% endverbatim %}
-            </div>
-        </template>
+    </div>
+    </template>
 
 
-        <template #details="{ item: decision, context }">
-            <div class="row">
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="decision.review.stage === context.review.CLOSED">
-                                <td>
-                                    {% trans "Afhandeling" %}:
-                                </td>
-                                <td v-html="decision.review.get_continuation_display">
+    <template #details="{ item: decision, context }">
+    <div class="row">
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="decision.review.stage === context.review.CLOSED">
+    <td>
+    {% trans "Afhandeling" %}:
+        </td>
+    <td v-html="decision.review.get_continuation_display">
 
-                                </td>
-                            </tr>
-                            <tr v-if="decision.proposal.parent && decision.proposal.parent.latest_review">
-                                <td>
-                                    {% trans "Revisie/amendement van" %}:
-                                </td>
-                                <td>
-                                    <a
-                                        :href="$url('reviews:detail', [decision.proposal.parent.latest_review.pk])"
-                                        v-html="decision.proposal.parent.reference_number"
-                                    >
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Datum ingediend" %}:
-                                </td>
-                                <td>
+    </td>
+    </tr>
+    <tr v-if="decision.proposal.parent && decision.proposal.parent.latest_review">
+    <td>
+    {% trans "Revisie/amendement van" %}:
+        </td>
+    <td>
+    <a
+    :href="$url('reviews:detail', [decision.proposal.parent.latest_review.pk])"
+    v-html="decision.proposal.parent.reference_number"
+    >
+    </a>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Datum ingediend" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ decision.review.date_start | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Gewenste einddatum" %}:
-                                </td>
-                                <td>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Gewenste einddatum" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ decision.review.date_should_end | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tr v-if="decision.review.stage >= context.review.COMMISSION">
-                            <td>
-                                {% trans "Route" %}:
-                            </td>
-                            <td v-html="decision.review.route">
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2">
-                                {% trans "Indieners" %}:<br/>
-                                <a
-                                   v-for="(applicant, index) in decision.proposal.applicants"
-                                   :href="$url('main:user_detail', [applicant.pk])"
-                               >
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="col-12 col-md-6">
+    <table>
+    <tr v-if="decision.review.stage >= context.review.COMMISSION">
+    <td>
+    {% trans "Route" %}:
+        </td>
+    <td v-html="decision.review.route">
+    </td>
+    </tr>
+    <tr>
+    <td colspan="2">
+    {% trans "Indieners" %}:<br/>
+    <a
+    v-for="(applicant, index) in decision.proposal.applicants"
+    :href="$url('main:user_detail', [applicant.pk])"
+    >
                                     {% verbatim %}
                                     <span v-if="index != 0">, </span>
                                     {{ applicant.fullname }}
                                     {% endverbatim %}
-                                </a>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-        </template>
+    </a>
+    </td>
+    </tr>
+    </table>
+    </div>
+    </div>
+    </template>
     </FancyList>
 </script>

--- a/reviews/templates/reviews/vue_templates/decision_list_reviewer.html
+++ b/reviews/templates/reviews/vue_templates/decision_list_reviewer.html
@@ -16,7 +16,7 @@
 <script type="text/x-template" id="reviewsUFLList">
     <FancyList
             {# It's a long, but standard, list, so we just include the default list #}
-            {% include 'uil.vue/fancy-list-params.txt' %}
+    {% include 'uil.vue/fancy-list-params.txt' %}
     >
         {# General note: the #{slot}="data" defines in which Vue variable all properties are loaded.  #}
         {# FancyList only exposes `item` and `context`, where item is the item from the data for a given row.  #}
@@ -25,122 +25,122 @@
 
         {# Here we do some JS deconstructing to pull the data out in seperate variables. We also rename item #}
         {# to decision, for clarity. #}
-        <template #title="{ item: decision, context }">
-            <h4>
+    <template #title="{ item: decision, context }">
+    <h4>
                 {# Verbatim tags are needed to stop Django from interpreting these braces as Django template code #}
                 {# They are actually vue template code #}
                 {% verbatim %}
                 {{ decision.proposal.reference_number }} -
                 {{ decision.proposal.title }}
                 {% endverbatim %}
-            </h4>
-        </template>
+    </h4>
+    </template>
 
-        <template #actions="{ item: decision, context }">
+    <template #actions="{ item: decision, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
-            <a
-                :href="$url('proposals:pdf', [decision.proposal.pk])"
-                target="_blank"
-            >
+    <a
+    :href="$url('proposals:pdf', [decision.proposal.pk])"
+    target="_blank"
+    >
                 {# Note the absence of {% verbatim %}, we actually use django here for the image! #}
-                <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
-            </a>
-            <a :href="$url('reviews:detail', [decision.review.pk])">
-                <img src="{{ img_details }}" title="{% trans 'Details' %}">
-            </a>
-        </template>
+    <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
+    </a>
+    <a :href="$url('reviews:detail', [decision.review.pk])">
+    <img src="{{ img_details }}" title="{% trans 'Details' %}">
+    </a>
+    </template>
 
-        <template #undertitle="{ item: decision, context }">
-            <div class="ufl-undertitle-line">
-                {% trans 'Eindverantwoordelijke' %}:
+    <template #undertitle="{ item: decision, context }">
+    <div class="ufl-undertitle-line">
+    {% trans 'Eindverantwoordelijke' %}:
                 {% verbatim %}
                 {{ decision.review.accountable_user.fullname }}
                 {% endverbatim %}
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans "Stadium" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans "Stadium" %}:
                 {% verbatim %}
                 {{ decision.review.get_stage_display }}
                 {% endverbatim %}
 
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans "Reviewer" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans "Reviewer" %}:
                 {% verbatim %}
                 {{ decision.reviewer.fullname }}
                 {% endverbatim %}
-            </div>
-        </template>
+    </div>
+    </template>
 
 
-        <template #details="{ item: decision, context }">
-            <div class="row">
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="decision.proposal.parent && decision.proposal.parent.latest_review">
-                                <td>
-                                    {% trans "Revisie/amendement van" %}:
-                                </td>
-                                <td>
-                                    <a
-                                        :href="$url('reviews:detail', [decision.proposal.parent.latest_review.pk])"
-                                        v-html="decision.proposal.parent.reference_number"
-                                    >
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Datum ingediend" %}:
-                                </td>
-                                <td>
+    <template #details="{ item: decision, context }">
+    <div class="row">
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="decision.proposal.parent && decision.proposal.parent.latest_review">
+    <td>
+    {% trans "Revisie/amendement van" %}:
+        </td>
+    <td>
+    <a
+    :href="$url('reviews:detail', [decision.proposal.parent.latest_review.pk])"
+    v-html="decision.proposal.parent.reference_number"
+    >
+    </a>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Datum ingediend" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ decision.review.date_start | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Gewenste einddatum" %}:
-                                </td>
-                                <td>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Gewenste einddatum" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ decision.review.date_should_end | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="decision.review.stage >= context.review.COMMISSION">
-                                <td>
-                                    {% trans "Route" %}:
-                                </td>
-                                <td v-html="decision.review.route">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">
-                                    {% trans "Indieners" %}:<br/>
-                                    <a
-                                       v-for="(applicant, index) in decision.proposal.applicants"
-                                       :href="$url('main:user_detail', [applicant.pk])"
-                                   >
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="decision.review.stage >= context.review.COMMISSION">
+    <td>
+    {% trans "Route" %}:
+        </td>
+    <td v-html="decision.review.route">
+    </td>
+    </tr>
+    <tr>
+    <td colspan="2">
+    {% trans "Indieners" %}:<br/>
+    <a
+    v-for="(applicant, index) in decision.proposal.applicants"
+    :href="$url('main:user_detail', [applicant.pk])"
+    >
                                         {% verbatim %}
                                         <span v-if="index != 0">, </span>
                                         {{ applicant.fullname }}
                                         {% endverbatim %}
-                                    </a>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </template>
+    </a>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    </div>
+    </template>
     </FancyList>
 </script>

--- a/reviews/templates/reviews/vue_templates/review_list.html
+++ b/reviews/templates/reviews/vue_templates/review_list.html
@@ -17,7 +17,7 @@
 <script type="text/x-template" id="reviewsUFLList">
     <FancyList
             {# It's a long, but standard, list, so we just include the default list #}
-            {% include 'uil.vue/fancy-list-params.txt' %}
+    {% include 'uil.vue/fancy-list-params.txt' %}
     >
         {# General note: the #{slot}="data" defines in which Vue variable all properties are loaded.  #}
         {# FancyList only exposes `item` and `context`, where item is the item from the data for a given row.  #}
@@ -26,177 +26,177 @@
 
         {# Here we do some JS deconstructing to pull the data out in seperate variables. We also rename item #}
         {# to review, for clarity. #}
-        <template #title="{ item: review, context }">
-            <h4>
+    <template #title="{ item: review, context }">
+    <h4>
                 {# Verbatim tags are needed to stop Django from interpreting these braces as Django template code #}
                 {# They are actually vue template code #}
                 {% verbatim %}
                 {{ review.proposal.reference_number }} -
                 {{ review.proposal.title }}
                 {% endverbatim %}
-            </h4>
-        </template>
+    </h4>
+    </template>
 
 
-        <template #actions="{ item: review, context }">
+    <template #actions="{ item: review, context }">
             {# The :href means that we use Vue to provide the actual link. Thus, the expression is Vue code! #}
-            <a
-               :href="$url('proposals:pdf', [review.proposal.pk])"
-               target="_blank"
-            >
+    <a
+    :href="$url('proposals:pdf', [review.proposal.pk])"
+    target="_blank"
+    >
                 {# Note the absence of {% verbatim %}, we actually use django here for the image! #}
-                <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
-            </a>
-            <a :href="$url('reviews:detail', [review.pk])">
-                <img src="{{ img_details }}" title="{% trans 'Details' %}">
-            </a>
-            <a :href="$url('proposals:diff', [review.proposal.pk])" v-if="review.proposal.is_revision">
-                <img src="{{ img_diff }}" title="{% trans 'Toon verschillen' %}">
-            </a>
+    <img src="{{ img_pdf }}" title="{% trans 'Aanvraag inzien' %}">
+    </a>
+    <a :href="$url('reviews:detail', [review.pk])">
+    <img src="{{ img_details }}" title="{% trans 'Details' %}">
+    </a>
+    <a :href="$url('proposals:diff', [review.proposal.pk])" v-if="review.proposal.is_revision">
+    <img src="{{ img_diff }}" title="{% trans 'Toon verschillen' %}">
+    </a>
             {# The template tag doesn't add anything by itself, so it's a good if container #}
-            <template v-if="context.is_secretary && review.stage === context.review.ASSIGNMENT">
-                <a :href="$url('reviews:assign', [review.pk])">
-                    <img src="{{ img_add_reviewers }}"
-                         title="{% trans 'Aanstellen' %}">
-                </a>
-                <a :href="$url('reviews:change_chamber', [review.proposal.pk])">
-                    <img src="{{ img_change_chamber }}"
-                         title="{% trans 'Verplaats naar andere kamer' %}">
-                </a>
-            </template>
-            <a
-                    v-if="context.is_secretary && review.stage === context.review.CLOSING"
-                    :href="$url('reviews:close', [review.pk])"
-            >
-                <img src="{{ img_close }}" title="{% trans 'Afsluiten' %}">
-            </a>
-            <template v-else-if="context.is_secretary && review.stage === context.review.CLOSED">
-                <template v-if="[context.review.GO, context.review.GO_POST_HOC].includes(review.continuation)">
-                    <a :href="$url('proposals:archive_export', [review.proposal.pk])">
-                        <img src="{{ img_export }}"
-                             title="{% trans 'Website export tekst' %}">
-                    </a>
-                    <a :href="$url('proposals:confirmation', [review.proposal.pk])">
-                        <img
-                            v-if="review.proposal.date_confirmed"
-                            src="{{ img_confirmed }}"
-                            title="{% trans 'Bevestigingsbrief verstuurd' %}"
-                        />
-                        <img
-                            v-else
-                            src="{{ img_confirm }}"
-                            title="{% trans 'Bevestigingsbrief versturen' %}"
-                        />
-                    </a>
-                    <a :href="$url('proposals:archive_status', [review.proposal.pk])">
-                        <img
-                            v-if="review.proposal.in_archive === true"
-                            src="{{ img_hide }}"
-                            title="{% trans 'Verberg aanvraag uit het archief' %}"
-                        />
-                        <img
-                            v-else
-                            src="{{ img_add }}"
-                            title="{% trans 'Plaats aanvraag in archief' %}"
-                        />
-                    </a>
-                </template>
-            </template>
-        </template>
+    <template v-if="context.is_secretary && review.stage === context.review.ASSIGNMENT">
+    <a :href="$url('reviews:assign', [review.pk])">
+    <img src="{{ img_add_reviewers }}"
+    title="{% trans 'Aanstellen' %}">
+    </a>
+    <a :href="$url('reviews:change_chamber', [review.proposal.pk])">
+    <img src="{{ img_change_chamber }}"
+    title="{% trans 'Verplaats naar andere kamer' %}">
+    </a>
+    </template>
+    <a
+    v-if="context.is_secretary && review.stage === context.review.CLOSING"
+    :href="$url('reviews:close', [review.pk])"
+    >
+    <img src="{{ img_close }}" title="{% trans 'Afsluiten' %}">
+    </a>
+    <template v-else-if="context.is_secretary && review.stage === context.review.CLOSED">
+    <template v-if="[context.review.GO, context.review.GO_POST_HOC].includes(review.continuation)">
+    <a :href="$url('proposals:archive_export', [review.proposal.pk])">
+    <img src="{{ img_export }}"
+    title="{% trans 'Website export tekst' %}">
+    </a>
+    <a :href="$url('proposals:confirmation', [review.proposal.pk])">
+    <img
+    v-if="review.proposal.date_confirmed"
+    src="{{ img_confirmed }}"
+    title="{% trans 'Bevestigingsbrief verstuurd' %}"
+    />
+    <img
+    v-else
+    src="{{ img_confirm }}"
+    title="{% trans 'Bevestigingsbrief versturen' %}"
+    />
+    </a>
+    <a :href="$url('proposals:archive_status', [review.proposal.pk])">
+    <img
+    v-if="review.proposal.in_archive === true"
+    src="{{ img_hide }}"
+    title="{% trans 'Verberg aanvraag uit het archief' %}"
+    />
+    <img
+    v-else
+    src="{{ img_add }}"
+    title="{% trans 'Plaats aanvraag in archief' %}"
+    />
+    </a>
+    </template>
+    </template>
+    </template>
 
 
-        <template #undertitle="{ item: review, context }">
-            <div class="ufl-undertitle-line">
-                {% trans 'Eindverantwoordelijke' %}:
+    <template #undertitle="{ item: review, context }">
+    <div class="ufl-undertitle-line">
+    {% trans 'Eindverantwoordelijke' %}:
                 {% verbatim %}
                 {{ review.accountable_user.fullname }}
                 {% endverbatim %}
-            </div>
-            <div class="ufl-undertitle-line">
-                {% trans "Stadium" %}:
+    </div>
+    <div class="ufl-undertitle-line">
+    {% trans "Stadium" %}:
                 {% verbatim %}
                 {{ review.get_stage_display }}
                 {% endverbatim %}
-            </div>
-        </template>
+    </div>
+    </template>
 
 
-        <template #details="{ item: review, context }">
-            <div class="row">
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="review.stage === context.review.CLOSED">
-                                <td>
-                                    {% trans "Afhandeling" %}:
-                                </td>
-                                <td v-html="review.get_continuation_display">
+    <template #details="{ item: review, context }">
+    <div class="row">
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="review.stage === context.review.CLOSED">
+    <td>
+    {% trans "Afhandeling" %}:
+        </td>
+    <td v-html="review.get_continuation_display">
 
-                                </td>
-                            </tr>
-                            <tr v-if="review.proposal.parent && review.proposal.parent.latest_review">
-                                <td>
-                                    {% trans "Revisie/amendement van" %}:
-                                </td>
-                                <td>
-                                    <a
-                                        :href="$url('reviews:detail', [review.proposal.parent.latest_review.pk])"
-                                        v-html="review.proposal.parent.reference_number"
-                                    >
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Datum ingediend" %}:
-                                </td>
-                                <td>
+    </td>
+    </tr>
+    <tr v-if="review.proposal.parent && review.proposal.parent.latest_review">
+    <td>
+    {% trans "Revisie/amendement van" %}:
+        </td>
+    <td>
+    <a
+    :href="$url('reviews:detail', [review.proposal.parent.latest_review.pk])"
+    v-html="review.proposal.parent.reference_number"
+    >
+    </a>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Datum ingediend" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ review.date_start | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    {% trans "Gewenste einddatum" %}:
-                                </td>
-                                <td>
+    </td>
+    </tr>
+    <tr>
+    <td>
+    {% trans "Gewenste einddatum" %}:
+        </td>
+    <td>
                                     {% verbatim %}
                                     {{ review.date_should_end | date("DD-MM-YYYY") }}
                                     {% endverbatim %}
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="col-12 col-md-6">
-                    <table>
-                        <tbody>
-                            <tr v-if="review.stage >= context.review.COMMISSION">
-                                <td>
-                                    {% trans "Route" %}:
-                                </td>
-                                <td v-html="review.route">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">
-                                    {% trans "Indieners" %}:<br/>
-                                    <a
-                                       v-for="(applicant, index) in review.proposal.applicants"
-                                       :href="$url('main:user_detail', [applicant.pk])"
-                                   >
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    <div class="col-12 col-md-6">
+    <table>
+    <tbody>
+    <tr v-if="review.stage >= context.review.COMMISSION">
+    <td>
+    {% trans "Route" %}:
+        </td>
+    <td v-html="review.route">
+    </td>
+    </tr>
+    <tr>
+    <td colspan="2">
+    {% trans "Indieners" %}:<br/>
+    <a
+    v-for="(applicant, index) in review.proposal.applicants"
+    :href="$url('main:user_detail', [applicant.pk])"
+    >
                                         {% verbatim %}
                                         <span v-if="index != 0">, </span>
                                         {{ applicant.fullname }}
                                         {% endverbatim %}
-                                    </a>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </template>
+    </a>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    </div>
+    </div>
+    </template>
     </FancyList>
 </script>

--- a/studies/templates/studies/session_start.html
+++ b/studies/templates/studies/session_start.html
@@ -19,17 +19,17 @@
             {% include "studies/study_title.html" %}
             <p>
                 {% blocktrans %}
-                In de volgende vragen gaan we nader in op wat je in jouw onderzoek van je deelnemers zal verlangen. Daarbij gelden de volgende definities:
+                    In de volgende vragen gaan we nader in op wat je in jouw onderzoek van je deelnemers zal verlangen. Daarbij gelden de volgende definities:
                 {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans %}
-                <strong>Sessie:</strong> Het geheel van de voor je onderzoek benodigde betrokkenheid die je op één dag van een deelnemer vraagt. Bij een labonderzoek is dat bijvoorbeeld alles wat er van onderzoekswege gebeurt vanaf het moment dat je de deelnemer ontvangt tot het moment dat je afscheid neemt, inclusief de benodigde pauzes. En bij een internet-vragenlijst is dat alles wat er van onderzoekswege gebeurt vanaf het welkomstscherm tot de afronding van de (reeks) vragenlijst(en), wederom inclusief benodigde pauzes. Bij veldwerk is dat de tijd dat je met de deelnemer in interactie bent op één dag.
+                    <strong>Sessie:</strong> Het geheel van de voor je onderzoek benodigde betrokkenheid die je op één dag van een deelnemer vraagt. Bij een labonderzoek is dat bijvoorbeeld alles wat er van onderzoekswege gebeurt vanaf het moment dat je de deelnemer ontvangt tot het moment dat je afscheid neemt, inclusief de benodigde pauzes. En bij een internet-vragenlijst is dat alles wat er van onderzoekswege gebeurt vanaf het welkomstscherm tot de afronding van de (reeks) vragenlijst(en), wederom inclusief benodigde pauzes. Bij veldwerk is dat de tijd dat je met de deelnemer in interactie bent op één dag.
                 {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans %}
-                <strong>Taak:</strong> Een coherente verzameling handelingen die je via een gesproken of geschreven taak-instructie aan de deelnemer oplegt, en ook als zodanig als 'taak' in een artikel zou beschrijven (bijvoorbeeld: "Beluister de volgende 200 zinnetjes en druk op een knop als je een fout ontdekt", "Vul persoonlijkheidsvragenlijst X in", "Speel 10 minuten met je kind zoals je dat thuis doet", “houd 1 week een dagboek bij van jouw media-gebruik”, “wil je je gender identiteit beschrijven”, “maak foto’s van plekken in jouw leefomgeving die je bedreigend en inspirerend vindt”, “zoek en deel met ons 10 foto’s uit jouw prive-archief om je levensverhaal te kunnen vertellen”). Indien de specifieke opdracht aan de deelnemer per item varieert (bijvoorbeeld: "bij een Nederlandse zin beoordeel je de betekenis, bij een Engelse zin de grammatica"), beschouw dit dan gewoon als één taak.
+                    <strong>Taak:</strong> Een coherente verzameling handelingen die je via een gesproken of geschreven taak-instructie aan de deelnemer oplegt, en ook als zodanig als 'taak' in een artikel zou beschrijven (bijvoorbeeld: "Beluister de volgende 200 zinnetjes en druk op een knop als je een fout ontdekt", "Vul persoonlijkheidsvragenlijst X in", "Speel 10 minuten met je kind zoals je dat thuis doet", “houd 1 week een dagboek bij van jouw media-gebruik”, “wil je je gender identiteit beschrijven”, “maak foto’s van plekken in jouw leefomgeving die je bedreigend en inspirerend vindt”, “zoek en deel met ons 10 foto’s uit jouw prive-archief om je levensverhaal te kunnen vertellen”). Indien de specifieke opdracht aan de deelnemer per item varieert (bijvoorbeeld: "bij een Nederlandse zin beoordeel je de betekenis, bij een Engelse zin de grammatica"), beschouw dit dan gewoon als één taak.
                 {% endblocktrans %}
             </p>
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
@@ -38,7 +38,7 @@
                     {% trans "Voor elke sessie stellen we in de komende schermen steeds dezelfde vragen." %}
                 </p>
                 {% with proposal=study.proposal %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/studies/templates/studies/study_design.html
+++ b/studies/templates/studies/study_design.html
@@ -76,18 +76,18 @@
                                 {% endfor %}
                             </ul>
                             <span class="helptext">
-                    {% blocktrans trimmed %}
-                        Dit is bijvoorbeeld het geval wanneer je een
-                        observatiedeel combineert met een taakonderzoeksdeel,
-                        of met een interventiedeel (in dezelfde sessie, of
-                        verspreid over dagen).
-                        Wanneer je in interventieonderzoek <em>extra</em> taken
-                        inzet om de effecten van de interventie te bemeten
-                        (bijvoorbeeld een speciale voor- en nameting met een
-                        vragenlijst die anders niet zou worden afgenomen)
-                        dien je die apart als taakonderzoek te specificeren.
-                    {% endblocktrans %}
-                </span>
+                                {% blocktrans trimmed %}
+                                    Dit is bijvoorbeeld het geval wanneer je een
+                                    observatiedeel combineert met een taakonderzoeksdeel,
+                                    of met een interventiedeel (in dezelfde sessie, of
+                                    verspreid over dagen).
+                                    Wanneer je in interventieonderzoek <em>extra</em> taken
+                                    inzet om de effecten van de interventie te bemeten
+                                    (bijvoorbeeld een speciale voor- en nameting met een
+                                    vragenlijst die anders niet zou worden afgenomen)
+                                    dien je die apart als taakonderzoek te specificeren.
+                                {% endblocktrans %}
+                            </span>
                         </td>
                     </tr>
                 </table>

--- a/studies/templates/studies/study_end.html
+++ b/studies/templates/studies/study_end.html
@@ -63,20 +63,20 @@
                             </h4>
                             <table class="mb-3">
                                 <thead>
-                                <tr>
-                                    <th>{% trans "Setting" %}</th>
-                                    <th>{% trans "Aantal sessies (per week)" %}</th>
-                                    <th>{% trans "Duur per sessie (in minuten)" %}</th>
-                                    <th>{% trans "Controlegroep?" %}</th>
-                                </tr>
+                                    <tr>
+                                        <th>{% trans "Setting" %}</th>
+                                        <th>{% trans "Aantal sessies (per week)" %}</th>
+                                        <th>{% trans "Duur per sessie (in minuten)" %}</th>
+                                        <th>{% trans "Controlegroep?" %}</th>
+                                    </tr>
                                 </thead>
                                 <tbody>
-                                <tr>
-                                    <td>{{ intervention.setting.all|unordered_list }}</td>
-                                    <td>{{ intervention.amount_per_week }}</td>
-                                    <td>{{ intervention.duration }}</td>
-                                    <td>{{ intervention.has_controls|yesno:_("ja, nee") }}</td>
-                                </tr>
+                                    <tr>
+                                        <td>{{ intervention.setting.all|unordered_list }}</td>
+                                        <td>{{ intervention.amount_per_week }}</td>
+                                        <td>{{ intervention.duration }}</td>
+                                        <td>{{ intervention.has_controls|yesno:_("ja, nee") }}</td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </li>
@@ -94,34 +94,34 @@
                             </h4>
                             <table class="mb-3">
                                 <thead>
-                                <tr>
-                                    <th>{% trans "Setting" %}</th>
-                                    <th>{% trans "Aantal dagen" %}</th>
-                                    <th>{% trans "Duur per sessie (in uren)" %}</th>
-                                    <th>{% trans "Anoniem?" %}</th>
-                                    <th>{% trans "Doelgroep?" %}</th>
-                                    <th>{% trans "Niet openbaar?" %}</th>
-                                    <th>{% trans "Toestemming nodig?" %}</th>
-                                    {% if observation.needs_approval %}
-                                        <th>{% trans "Instantie" %}</th>
-                                    {% endif %}
-                                    <th>{% trans "Registratie via" %}</th>
-                                </tr>
+                                    <tr>
+                                        <th>{% trans "Setting" %}</th>
+                                        <th>{% trans "Aantal dagen" %}</th>
+                                        <th>{% trans "Duur per sessie (in uren)" %}</th>
+                                        <th>{% trans "Anoniem?" %}</th>
+                                        <th>{% trans "Doelgroep?" %}</th>
+                                        <th>{% trans "Niet openbaar?" %}</th>
+                                        <th>{% trans "Toestemming nodig?" %}</th>
+                                        {% if observation.needs_approval %}
+                                            <th>{% trans "Instantie" %}</th>
+                                        {% endif %}
+                                        <th>{% trans "Registratie via" %}</th>
+                                    </tr>
                                 </thead>
                                 <tbody>
-                                <tr>
-                                    <td>{{ observation.setting.all|unordered_list }}</td>
-                                    <td>{{ observation.days }}</td>
-                                    <td>{{ observation.mean_hours }}</td>
-                                    <td>{{ observation.is_anonymous|yesno:_("ja, nee") }}</td>
-                                    <td>{{ observation.is_in_target_group|yesno:_("ja, nee") }}</td>
-                                    <td>{{ observation.is_nonpublic_space|yesno:_("ja, nee") }}</td>
-                                    <td>{{ observation.needs_approval|yesno:_("ja, nee") }}</td>
-                                    {% if observation.needs_approval %}
-                                        <td>{{ observation.approval_institution }}</td>
-                                    {% endif %}
-                                    <td>{{ observation.registrations.all|unordered_list }}</td>
-                                </tr>
+                                    <tr>
+                                        <td>{{ observation.setting.all|unordered_list }}</td>
+                                        <td>{{ observation.days }}</td>
+                                        <td>{{ observation.mean_hours }}</td>
+                                        <td>{{ observation.is_anonymous|yesno:_("ja, nee") }}</td>
+                                        <td>{{ observation.is_in_target_group|yesno:_("ja, nee") }}</td>
+                                        <td>{{ observation.is_nonpublic_space|yesno:_("ja, nee") }}</td>
+                                        <td>{{ observation.needs_approval|yesno:_("ja, nee") }}</td>
+                                        {% if observation.needs_approval %}
+                                            <td>{{ observation.approval_institution }}</td>
+                                        {% endif %}
+                                        <td>{{ observation.registrations.all|unordered_list }}</td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </li>
@@ -138,8 +138,8 @@
                                         minuten)
                                         {% if study.sessions_number > 1 %}
                                             <a href="{% url 'tasks:session_delete' session.pk %}"><img
-                                                    src="{% static 'proposals/images/delete.png' %}"
-                                                    title="{% trans 'Sessie verwijderen' %}"></a>
+                                                src="{% static 'proposals/images/delete.png' %}"
+                                                title="{% trans 'Sessie verwijderen' %}"></a>
                                         {% endif %}
                                     </h5>
                                     <p>

--- a/studies/templates/studies/study_form.html
+++ b/studies/templates/studies/study_form.html
@@ -8,67 +8,67 @@
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function() {
-    $('input[name=age_groups]').change();
+    <script>
+        $(function() {
+            $('input[name=age_groups]').change();
 
-    depends_on_value('has_special_details', 'True', 'special_details');
-    check_field_required('special_details', 'medical_traits', 'traits', 'studies', 'SpecialDetail');
-    check_field_required('traits', 'needs_details', 'traits_details', 'studies', 'Trait');
-    check_field_required('compensation', 'needs_details', 'compensation_details', 'studies');
-    check_field_required('recruitment', 'needs_details', 'recruitment_details', 'studies');
-    depends_on_value('hierarchy', 'True', 'hierarchy_details');
+            depends_on_value('has_special_details', 'True', 'special_details');
+            check_field_required('special_details', 'medical_traits', 'traits', 'studies', 'SpecialDetail');
+            check_field_required('traits', 'needs_details', 'traits_details', 'studies', 'Trait');
+            check_field_required('compensation', 'needs_details', 'compensation_details', 'studies');
+            check_field_required('recruitment', 'needs_details', 'recruitment_details', 'studies');
+            depends_on_value('hierarchy', 'True', 'hierarchy_details');
 
-    add_title('age_groups', "{% trans 'De leeftijdsgroep van je deelnemers' %}");
-    add_title('legally_incapable', "{% trans 'Wilsonbekwaamheid' %}");
-    add_title('has_special_details', "{% trans 'Bijzondere persoonsgegevens' %}");
-    add_title('necessity', "{% trans 'Noodzakelijkheid' %}");
-    add_title('recruitment', "{% trans 'Werving' %}");
-    add_title('compensation', "{% trans 'Vergoeding' %}");
-    add_title('hierarchy', "{% trans 'Hiërarchie' %}");
+            add_title('age_groups', "{% trans 'De leeftijdsgroep van je deelnemers' %}");
+            add_title('legally_incapable', "{% trans 'Wilsonbekwaamheid' %}");
+            add_title('has_special_details', "{% trans 'Bijzondere persoonsgegevens' %}");
+            add_title('necessity', "{% trans 'Noodzakelijkheid' %}");
+            add_title('recruitment', "{% trans 'Werving' %}");
+            add_title('compensation', "{% trans 'Vergoeding' %}");
+            add_title('hierarchy', "{% trans 'Hiërarchie' %}");
 
 
     // Logic for legally_incapable
-    $('input[name=age_groups], input[name=legally_incapable]').change(function() {
-        var age_groups = $('input[name=age_groups]:checked').map(function() {
-            return this.value;
-        }).get();
+            $('input[name=age_groups], input[name=legally_incapable]').change(function() {
+                var age_groups = $('input[name=age_groups]:checked').map(function() {
+                    return this.value;
+                }).get();
 
-        var url = "{% url 'studies:check_has_adults' %}";
-        var params = {
-            'age_groups': age_groups
-        };
-        $.post(url, params, function(data) {
-            $('#id_legally_incapable').parents('tr').toggle(data.result);
-            $('#id_legally_incapable').parents('tr').prev().toggle(data.result); // Toggles header as well
+                var url = "{% url 'studies:check_has_adults' %}";
+                var params = {
+                    'age_groups': age_groups
+                };
+                $.post(url, params, function(data) {
+                    $('#id_legally_incapable').parents('tr').toggle(data.result);
+                    $('#id_legally_incapable').parents('tr').prev().toggle(data.result); // Toggles header as well
 
-            var check = data.result && $('input[name=legally_incapable]:checked').val() === 'True';
-            $('#id_legally_incapable_details').parents('tr').toggle(check);
-        });
-    });
-    $('input[name=age_groups], input[name=legally_incapable]').change();
+                    var check = data.result && $('input[name=legally_incapable]:checked').val() === 'True';
+                    $('#id_legally_incapable_details').parents('tr').toggle(check);
+                });
+            });
+            $('input[name=age_groups], input[name=legally_incapable]').change();
 
     // Logic for necessity display
-    $('input[name=age_groups], input[name=legally_incapable]').change(function() {
-        var age_groups = $('input[name=age_groups]:checked').map(function() {
-            return this.value;
-        }).get();
-        var legally_incapable = $('input[name=legally_incapable]:checked').val();
+            $('input[name=age_groups], input[name=legally_incapable]').change(function() {
+                var age_groups = $('input[name=age_groups]:checked').map(function() {
+                    return this.value;
+                }).get();
+                var legally_incapable = $('input[name=legally_incapable]:checked').val();
 
-        var url = "{% url 'studies:check_necessity_required' %}";
-        var params = {
-            'age_groups': age_groups,
-            'legally_incapable': legally_incapable,
-            'proposal_pk': {{ study.proposal.pk }}
-        };
-        $.post(url, params, function(data) {
-            $('#id_necessity, #id_necessity_reason').parents('tr').toggle(data.result);
-            $('#id_necessity').parents('tr').prev().toggle(data.result); // Toggles header as well
+                var url = "{% url 'studies:check_necessity_required' %}";
+                var params = {
+                    'age_groups': age_groups,
+                    'legally_incapable': legally_incapable,
+                    'proposal_pk': {{ study.proposal.pk }}
+                };
+                $.post(url, params, function(data) {
+                    $('#id_necessity, #id_necessity_reason').parents('tr').toggle(data.result);
+                    $('#id_necessity').parents('tr').prev().toggle(data.result); // Toggles header as well
+                });
+            });
+            $('input[name=age_groups], input[name=legally_incapable]').change();
         });
-    });
-    $('input[name=age_groups], input[name=legally_incapable]').change();
-});
-</script>
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -95,7 +95,7 @@ $(function() {
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% with proposal=study.proposal %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/studies/templates/studies/study_title.html
+++ b/studies/templates/studies/study_title.html
@@ -1,15 +1,15 @@
 {% load i18n %}
 
 {% if study.proposal.studies_number > 1 %}
-<h3>
-    {% if study.name %}
-    {% blocktrans with order=study.order name=study.name %}
-    Traject {{ order }} (<em>{{ name }}</em>)
-    {% endblocktrans %}
-    {% else %}
-    {% blocktrans with order=study.order %}
-    Traject {{ order }}
-    {% endblocktrans %}
-    {% endif %}
-</h3>
+    <h3>
+        {% if study.name %}
+            {% blocktrans with order=study.order name=study.name %}
+                Traject {{ order }} (<em>{{ name }}</em>)
+            {% endblocktrans %}
+        {% else %}
+            {% blocktrans with order=study.order %}
+                Traject {{ order }}
+            {% endblocktrans %}
+        {% endif %}
+    </h3>
 {% endif %}

--- a/studies/templates/studies/study_update_attachments.html
+++ b/studies/templates/studies/study_update_attachments.html
@@ -15,8 +15,8 @@
             </h2>
             <p>
                 {% blocktrans trimmed with title=documents.proposal.title ref_number=documents.proposal.reference_number order=documents.study.order %}
-                Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
-                (referentienummer <em>{{ ref_number }}</em>), traject {{ order }}.
+                    Op deze pagina kan je de formulieren aanpassen behorende bij de aanvraag {{ title }}
+                    (referentienummer <em>{{ ref_number }}</em>), traject {{ order }}.
                 {% endblocktrans %}
             </p>
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}

--- a/tasks/templates/tasks/session_title.html
+++ b/tasks/templates/tasks/session_title.html
@@ -1,23 +1,23 @@
 {% load i18n %}
 
 {% with order=session.order study_order=session.study.order study_name=session.study.name studies_number=session.study.proposal.studies_number sessions_number=session.study.sessions_number %}
-{% if studies_number > 1 and sessions_number > 1 %}
-<h3>
-    {% blocktrans %}
-    Traject {{ study_order }} (<em>{{ study_name }}</em>), sessie {{ order }}
-    {% endblocktrans %}
-</h3>
-{% elif studies_number > 1 %}
-<h3>
-    {% blocktrans %}
-    Traject {{ study_order }} (<em>{{ study_name }}</em>)
-    {% endblocktrans %}
-</h3>
-{% elif sessions_number >= 1 %}
-<h3>
-    {% blocktrans %}
-    Sessie {{ order }}
-    {% endblocktrans %}
-</h3>
-{% endif %}
+    {% if studies_number > 1 and sessions_number > 1 %}
+        <h3>
+            {% blocktrans %}
+                Traject {{ study_order }} (<em>{{ study_name }}</em>), sessie {{ order }}
+            {% endblocktrans %}
+        </h3>
+    {% elif studies_number > 1 %}
+        <h3>
+            {% blocktrans %}
+                Traject {{ study_order }} (<em>{{ study_name }}</em>)
+            {% endblocktrans %}
+        </h3>
+    {% elif sessions_number >= 1 %}
+        <h3>
+            {% blocktrans %}
+                Sessie {{ order }}
+            {% endblocktrans %}
+        </h3>
+    {% endif %}
 {% endwith %}

--- a/tasks/templates/tasks/task_end.html
+++ b/tasks/templates/tasks/task_end.html
@@ -28,7 +28,7 @@
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% with proposal=session.study.proposal study=session.study %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/tasks/templates/tasks/task_form.html
+++ b/tasks/templates/tasks/task_form.html
@@ -8,14 +8,14 @@
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function() {
-    check_field_required('registrations', 'needs_kind', 'registration_kinds', 'tasks', 'Registration');
-    check_field_required('registrations', 'needs_details', 'registrations_details', 'tasks', 'Registration');
-    check_field_required('registration_kinds', 'needs_details', 'registration_kinds_details', 'tasks', 'RegistrationKind');
-    depends_on_value('feedback', 'True', 'feedback_details');
-});
-</script>
+    <script>
+        $(function() {
+            check_field_required('registrations', 'needs_kind', 'registration_kinds', 'tasks', 'Registration');
+            check_field_required('registrations', 'needs_details', 'registrations_details', 'tasks', 'Registration');
+            check_field_required('registration_kinds', 'needs_details', 'registration_kinds_details', 'tasks', 'RegistrationKind');
+            depends_on_value('feedback', 'True', 'feedback_details');
+        });
+    </script>
 {% endblock %}
 
 
@@ -33,7 +33,7 @@ $(function() {
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <table>{{ form.as_table }}</table>
                 {% with proposal=task.session.study.proposal study=task.session.study session=task.session %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/tasks/templates/tasks/task_list.html
+++ b/tasks/templates/tasks/task_list.html
@@ -13,47 +13,47 @@
     </thead>
     <tbody>
         {% for task in session.task_set.all %}
-        <tr>
-            <td>{{ task.name }}</td>
-            <td>{{ task.duration }}</td>
-            <td>{{ task.registrations.all|unordered_list }}</td>
-            <td class="task_feedback">
-                <span class="label">{{ task.feedback|yesno:_("ja,nee") }}</span>
-                {% if task.feedback %}
-                <span class="help">{{ task.feedback_details }}</span>
-                {% endif %}
-            </td>
-            <td>
-                <a href="{% url 'tasks:update' task.id %}"><img src="{% static 'proposals/images/pencil.png' %}" title="{% trans 'Taak bewerken' %}"></a>
-                {% if session.tasks_number > 1 %}
-                <a href="{% url 'tasks:delete' task.id %}"><img src="{% static 'proposals/images/delete.png' %}" title="{% trans 'Taak verwijderen' %}"></a>
-                {% endif %}
-            </td>
-        </tr>
+            <tr>
+                <td>{{ task.name }}</td>
+                <td>{{ task.duration }}</td>
+                <td>{{ task.registrations.all|unordered_list }}</td>
+                <td class="task_feedback">
+                    <span class="label">{{ task.feedback|yesno:_("ja,nee") }}</span>
+                    {% if task.feedback %}
+                        <span class="help">{{ task.feedback_details }}</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="{% url 'tasks:update' task.id %}"><img src="{% static 'proposals/images/pencil.png' %}" title="{% trans 'Taak bewerken' %}"></a>
+                    {% if session.tasks_number > 1 %}
+                        <a href="{% url 'tasks:delete' task.id %}"><img src="{% static 'proposals/images/delete.png' %}" title="{% trans 'Taak verwijderen' %}"></a>
+                    {% endif %}
+                </td>
+            </tr>
         {% endfor %}
     </tbody>
 </table>
 
 <script>
-$(function() {
-    let elements = $('.task_feedback');
-    elements.each(function () {
-        let label = $(this).find('.label');
-        let help = $(this).find('.help');
-        if (help.length > 0) {
-            label.after(' <img src="{% static 'main/images/information.png' %}">');
-            label.next().qtip({
-                content: {
-                    text: help.html(),
-                },
-                hide: {
-                    fixed: true,
-                    delay: 500,
-                },
-            });
-            help.remove();
-        }
-    });
+    $(function() {
+        let elements = $('.task_feedback');
+        elements.each(function () {
+            let label = $(this).find('.label');
+            let help = $(this).find('.help');
+            if (help.length > 0) {
+                label.after(' <img src="{% static 'main/images/information.png' %}">');
+                label.next().qtip({
+                    content: {
+                        text: help.html(),
+                    },
+                    hide: {
+                        fixed: true,
+                        delay: 500,
+                    },
+                });
+                help.remove();
+            }
+        });
 
-});
+    });
 </script>

--- a/tasks/templates/tasks/task_start.html
+++ b/tasks/templates/tasks/task_start.html
@@ -8,14 +8,14 @@
 {% endblock %}
 
 {% block html_head %}
-<script>
-$(function() {
-    depends_on_value('is_copy', 'True', 'parent_session');
-    depends_on_value('is_copy', 'False', 'tasks_number');
+    <script>
+        $(function() {
+            depends_on_value('is_copy', 'True', 'parent_session');
+            depends_on_value('is_copy', 'False', 'tasks_number');
 
-    $('input[name=tasks_number]').parents('tr').insertAfter($('input[name=is_copy]').parents('tr'));
-});
-</script>
+            $('input[name=tasks_number]').parents('tr').insertAfter($('input[name=is_copy]').parents('tr'));
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -35,7 +35,7 @@ $(function() {
                     {% trans "Voor elke taak stellen we in de komende schermen steeds dezelfde vragen." %}
                 </p>
                 {% with proposal=session.study.proposal study=session.study %}
-                {% include "base/form_buttons.html" %}
+                    {% include "base/form_buttons.html" %}
                 {% endwith %}
             </form>
         </div>

--- a/tasks/templates/tasks/task_title.html
+++ b/tasks/templates/tasks/task_title.html
@@ -1,17 +1,17 @@
 {% load i18n %}
 
 {% with order=task.order session_order=task.session.order study_order=task.session.study.order study_name=task.session.study.name studies_number=task.session.study.proposal.studies_number %}
-{% if studies_number > 1 %}
-<h3>
-    {% blocktrans %}
-    Traject {{ study_order }} (<em>{{ study_name }}</em>), sessie {{ session_order }}, taak {{ order }}
-    {% endblocktrans %}
-</h3>
-{% else %}
-<h3>
-    {% blocktrans %}
-    Sessie {{ session_order }}, taak {{ order }}
-    {% endblocktrans %}
-</h3>
-{% endif %}
+    {% if studies_number > 1 %}
+        <h3>
+            {% blocktrans %}
+                Traject {{ study_order }} (<em>{{ study_name }}</em>), sessie {{ session_order }}, taak {{ order }}
+            {% endblocktrans %}
+        </h3>
+    {% else %}
+        <h3>
+            {% blocktrans %}
+                Sessie {{ session_order }}, taak {{ order }}
+            {% endblocktrans %}
+        </h3>
+    {% endif %}
 {% endwith %}


### PR DESCRIPTION
Run djhtml on all top-level directories tracked by git, except docs. No options were given to djhtml, resulting in the following defaults: four space indents and all CSS and JS are included.

Please give this a once-over to try and spot any weirdness and (parts of) files that should be excluded.

I'm leaving this as a draft until translations are fixed. Most template blocktranslations that did not use `trimmed` have to be adjusted.