### PR TITLE
Feature/email secretary after decisions

### DIFF
--- a/reviews/models.py
+++ b/reviews/models.py
@@ -114,6 +114,8 @@ class Review(models.Model):
             # For a review by commission:
             else:
                 # Set the stage to CLOSING
+                from reviews.utils import notify_secretary_all_decisions
+                notify_secretary_all_decisions(self)
                 self.stage = self.CLOSING
                 self.save()
         else:

--- a/reviews/templates/mail/all_decisions_notify.txt
+++ b/reviews/templates/mail/all_decisions_notify.txt
@@ -1,0 +1,14 @@
+{% extends "mail/base-internal.txt" %}
+
+{% block content %}
+Alle beoordelingen zijn toegevoegd bij de aanvraag {{ proposal.reference_number }}.
+
+De review is klaar om afgesloten te worden.
+
+Overzicht beoordelingen:
+{% for decision in decisions %}
+Beoordelaar: {{ decision.reviewer.get_full_name }}
+Beoordeling: {{ decision.get_go_display }}
+Opmerkingen: {{ decision.comments|default:"geen"|safe }}
+{% endfor %}
+{% endblock %}

--- a/reviews/templates/mail/all_decisions_notify.txt
+++ b/reviews/templates/mail/all_decisions_notify.txt
@@ -1,7 +1,7 @@
 {% extends "mail/base-internal.txt" %}
 
 {% block content %}
-Alle beoordelingen zijn toegevoegd bij de aanvraag {{ proposal.reference_number }}.
+Alle beoordelingen zijn toegevoegd bij de aanvraag {{ review.proposal.reference_number }}.
 
 De review is klaar om afgesloten te worden.
 
@@ -9,6 +9,10 @@ Overzicht beoordelingen:
 {% for decision in decisions %}
 Beoordelaar: {{ decision.reviewer.get_full_name }}
 Beoordeling: {{ decision.get_go_display }}
-Opmerkingen: {{ decision.comments|default:"geen"|safe }}
 {% endfor %}
+
+Detailpagina: {{ review_detail_page }}
+
+Review afsluiten: {{ close_review_page }}
+
 {% endblock %}

--- a/reviews/templates/reviews/review_table.html
+++ b/reviews/templates/reviews/review_table.html
@@ -14,7 +14,7 @@
     <tbody>
         {% for decision in review.decision_set.all %}
         <tr>
-            <td>{{ decision.reviewer }}</td>
+            <td>{{ decision.reviewer.get_full_name }}</td>
             <td>{{ decision.get_go_display|default:_("open") }}</td>
             <td data-order="{{ decision.date_decision|date:'c' }}">{{ decision.date_decision|date:"j F Y, G:i" }}</td>
             <td>{{ decision.comments }}</td>

--- a/reviews/tests.py
+++ b/reviews/tests.py
@@ -247,8 +247,8 @@ class CommissionTestCase(BaseReviewTestCase):
         self.assertEqual(review.go, False)  # no go
 
         notify_secretary(decisions[1])
-        self.assertEqual(len(mail.outbox), 3)
-        self.assertIn(c, mail.outbox[2].body)
+        self.assertEqual(len(mail.outbox), 4)
+        self.assertIn(c, mail.outbox[3].body)
 
         decisions[1].go = Decision.APPROVED
         decisions[1].save()

--- a/reviews/utils/review_utils.py
+++ b/reviews/utils/review_utils.py
@@ -326,7 +326,7 @@ def notify_secretary_all_decisions(review):
         + (reverse("reviews:close", args=[review.pk])),
     }
     msg_plain = render_to_string("mail/all_decisions_notify.txt", params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, ["fetc-gw@uu.nl"])
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, [settings.EMAIL_FROM])
 
     # Reset the current language
     activate(current_language)

--- a/reviews/utils/review_utils.py
+++ b/reviews/utils/review_utils.py
@@ -52,62 +52,39 @@ def start_supervisor_phase(proposal):
     decision = Decision.objects.create(review=review, reviewer=proposal.supervisor)
     reference = proposal.committee_prefixed_refnum()
 
-    subject = _("FETC-GW {}: bevestiging indienen concept-aanmelding".format(reference))
+    subject = _('FETC-GW {}: bevestiging indienen concept-aanmelding'.format(reference))
     params = {
-        "proposal": proposal,
-        "title": proposal.title,
-        "supervisor": proposal.supervisor.get_full_name(),
-        "secretary": get_secretary().get_full_name(),
-        "pdf_url": settings.BASE_URL + proposal.pdf.url,
+        'proposal': proposal,
+        'title': proposal.title,
+        'supervisor': proposal.supervisor.get_full_name(),
+        'secretary': get_secretary().get_full_name(),
+        'pdf_url': settings.BASE_URL + proposal.pdf.url,
     }
-    msg_plain = render_to_string("mail/concept_creator.txt", params)
-    msg_html = render_to_string("mail/concept_creator.html", params)
-    send_mail(
-        subject,
-        msg_plain,
-        settings.EMAIL_FROM,
-        [proposal.created_by.email],
-        html_message=msg_html,
-    )
+    msg_plain = render_to_string('mail/concept_creator.txt', params)
+    msg_html = render_to_string('mail/concept_creator.html', params)
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.created_by.email], html_message=msg_html)
 
     if proposal.other_applicants:
-        params["creator"] = proposal.created_by.get_full_name()
-        msg_plain = render_to_string("mail/concept_other_applicants.txt", params)
-        msg_html = render_to_string("mail/concept_other_applicants.html", params)
+        params['creator'] = proposal.created_by.get_full_name()
+        msg_plain = render_to_string('mail/concept_other_applicants.txt', params)
+        msg_html = render_to_string('mail/concept_other_applicants.html', params)
         applicants_to_remove = [proposal.created_by, proposal.supervisor]
-        other_applicants_emails = [
-            applicant.email
-            for applicant in proposal.applicants.all()
-            if applicant not in applicants_to_remove
-        ]
-        send_mail(
-            subject,
-            msg_plain,
-            settings.EMAIL_FROM,
-            other_applicants_emails,
-            html_message=msg_html,
-        )
+        other_applicants_emails = [applicant.email for applicant in proposal.applicants.all() if applicant not in applicants_to_remove]
+        send_mail(subject, msg_plain, settings.EMAIL_FROM, other_applicants_emails, html_message=msg_html)
 
-    subject = _("FETC-GW {}: beoordelen als eindverantwoordelijke".format(reference))
+    subject = _('FETC-GW {}: beoordelen als eindverantwoordelijke'.format(reference))
     params = {
-        "proposal": proposal,
-        "creator": proposal.created_by.get_full_name(),
-        "proposal_url": settings.BASE_URL
-        + reverse("reviews:decide", args=(decision.pk,)),
-        "secretary": get_secretary().get_full_name(),
-        "revision": proposal.is_revision,
-        "revision_type": proposal.type(),
-        "my_supervised": settings.BASE_URL + reverse("proposals:my_supervised"),
+        'proposal': proposal,
+        'creator': proposal.created_by.get_full_name(),
+        'proposal_url': settings.BASE_URL + reverse('reviews:decide', args=(decision.pk,)),
+        'secretary': get_secretary().get_full_name(),
+        'revision': proposal.is_revision,
+        'revision_type': proposal.type(),
+        'my_supervised': settings.BASE_URL + reverse('proposals:my_supervised'),
     }
-    msg_plain = render_to_string("mail/concept_supervisor.txt", params)
-    msg_html = render_to_string("mail/concept_supervisor.html", params)
-    send_mail(
-        subject,
-        msg_plain,
-        settings.EMAIL_FROM,
-        [proposal.supervisor.email],
-        html_message=msg_html,
-    )
+    msg_plain = render_to_string('mail/concept_supervisor.txt', params)
+    msg_html = render_to_string('mail/concept_supervisor.html', params)
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.supervisor.email], html_message=msg_html)
 
     return review
 
@@ -133,9 +110,7 @@ def start_assignment_phase(proposal):
     review.short_route = short_route
 
     if short_route:
-        review.date_should_end = timezone.now() + timezone.timedelta(
-            weeks=settings.SHORT_ROUTE_WEEKS
-        )
+        review.date_should_end = timezone.now() + timezone.timedelta(weeks=settings.SHORT_ROUTE_WEEKS)
     review.save()
 
     proposal.date_submitted = timezone.now()
@@ -147,58 +122,36 @@ def start_assignment_phase(proposal):
 
     notify_secretary_assignment(review)
 
-    subject = _(
-        "FETC-GW {}: aanmelding ontvangen".format(proposal.committee_prefixed_refnum())
-    )
+    subject = _('FETC-GW {}: aanmelding ontvangen'.format(proposal.committee_prefixed_refnum()))
     params = {
-        "secretary": secretary.get_full_name(),
-        "review_date": review.date_should_end,
-        "pdf_url": settings.BASE_URL + proposal.pdf.url,
-        "title": proposal.title,
+        'secretary': secretary.get_full_name(),
+        'review_date': review.date_should_end,
+        'pdf_url': settings.BASE_URL + proposal.pdf.url,
+        'title': proposal.title,
     }
     if review.short_route:
-        msg_plain = render_to_string("mail/submitted_shortroute.txt", params)
-        msg_html = render_to_string("mail/submitted_shortroute.html", params)
+        msg_plain = render_to_string('mail/submitted_shortroute.txt', params)
+        msg_html = render_to_string('mail/submitted_shortroute.html', params)
     else:
-        msg_plain = render_to_string("mail/submitted_longroute.txt", params)
-        msg_html = render_to_string("mail/submitted_longroute.html", params)
+        msg_plain = render_to_string('mail/submitted_longroute.txt', params)
+        msg_html = render_to_string('mail/submitted_longroute.html', params)
     recipients = [proposal.created_by.email]
     if proposal.relation.needs_supervisor:
         recipients.append(proposal.supervisor.email)
-    send_mail(
-        subject, msg_plain, settings.EMAIL_FROM, recipients, html_message=msg_html
-    )
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, recipients, html_message=msg_html)
 
     if proposal.supervisor is None and proposal.other_applicants:
-        params["creator"] = proposal.created_by.get_full_name()
+        params['creator'] = proposal.created_by.get_full_name()
         if review.short_route:
-            msg_plain = render_to_string(
-                "mail/submitted_shortroute_other_applicants.txt", params
-            )
-            msg_html = render_to_string(
-                "mail/submitted_shortroute_other_applicants.html", params
-            )
+            msg_plain = render_to_string('mail/submitted_shortroute_other_applicants.txt', params)
+            msg_html = render_to_string('mail/submitted_shortroute_other_applicants.html', params)
         else:
-            msg_plain = render_to_string(
-                "mail/submitted_longroute_other_applicants.txt", params
-            )
-            msg_html = render_to_string(
-                "mail/submitted_longroute_other_applicants.html", params
-            )
+            msg_plain = render_to_string('mail/submitted_longroute_other_applicants.txt', params)
+            msg_html = render_to_string('mail/submitted_longroute_other_applicants.html', params)
         applicants_to_remove = [proposal.created_by]
-        other_applicants_emails = [
-            applicant.email
-            for applicant in proposal.applicants.all()
-            if applicant not in applicants_to_remove
-        ]
+        other_applicants_emails = [applicant.email for applicant in proposal.applicants.all() if applicant not in applicants_to_remove]
 
-        send_mail(
-            subject,
-            msg_plain,
-            settings.EMAIL_FROM,
-            other_applicants_emails,
-            html_message=msg_html,
-        )
+        send_mail(subject, msg_plain, settings.EMAIL_FROM, other_applicants_emails, html_message=msg_html)
 
     if proposal.inform_local_staff:
         notify_local_staff(proposal)
@@ -220,7 +173,7 @@ def remind_reviewers():
         review__short_route=True,
         review__date_should_end__gte=today,
         review__date_should_end__lte=next_two_days,
-        go="",  # Checks if the decision has already been done; we don't
+        go='',  # Checks if the decision has already been done; we don't
         # check for None as the field cannot be None according to the field
         # definition
     )
@@ -231,20 +184,13 @@ def remind_reviewers():
             proposal.committee_prefixed_refnum(),
         )
         params = {
-            "creator": proposal.created_by.get_full_name(),
-            "proposal_url": settings.BASE_URL
-            + reverse("reviews:decide", args=(decision.pk,)),
-            "secretary": get_secretary().get_full_name(),
+            'creator': proposal.created_by.get_full_name(),
+            'proposal_url': settings.BASE_URL + reverse('reviews:decide', args=(decision.pk,)),
+            'secretary': get_secretary().get_full_name(),
         }
-        msg_plain = render_to_string("mail/reminder.txt", params)
-        msg_html = render_to_string("mail/reminder.html", params)
-        send_mail(
-            subject,
-            msg_plain,
-            settings.EMAIL_FROM,
-            [decision.reviewer.email],
-            html_message=msg_html,
-        )
+        msg_plain = render_to_string('mail/reminder.txt', params)
+        msg_html = render_to_string('mail/reminder.html', params)
+        send_mail(subject, msg_plain, settings.EMAIL_FROM, [decision.reviewer.email], html_message=msg_html)
 
 
 def start_review_pre_assessment(proposal):
@@ -260,9 +206,7 @@ def start_review_pre_assessment(proposal):
     review = Review.objects.create(proposal=proposal, date_start=timezone.now())
     review.stage = Review.ASSIGNMENT
     review.short_route = True
-    review.date_should_end = timezone.now() + timezone.timedelta(
-        weeks=settings.PREASSESSMENT_ROUTE_WEEKS
-    )
+    review.date_should_end = timezone.now() + timezone.timedelta(weeks=settings.PREASSESSMENT_ROUTE_WEEKS)
     review.save()
 
     proposal.date_submitted = timezone.now()
@@ -272,36 +216,27 @@ def start_review_pre_assessment(proposal):
     secretary = get_secretary()
     Decision.objects.create(review=review, reviewer=secretary)
 
-    subject = _(
-        "FETC-GW {}: nieuwe aanvraag voor voortoetsing".format(
-            proposal.committee_prefixed_refnum(),
+    subject = _('FETC-GW {}: nieuwe aanvraag voor voortoetsing'.format(
+        proposal.committee_prefixed_refnum(),
         )
-    )
-
+                )
+                
     params = {
-        "secretary": secretary.get_full_name(),
-        "proposal": proposal,
-        "proposal_pdf": settings.BASE_URL + proposal.pdf.url,
+        'secretary': secretary.get_full_name(),
+        'proposal': proposal,
+        'proposal_pdf': settings.BASE_URL + proposal.pdf.url,
     }
-    msg_plain = render_to_string("mail/pre_assessment_secretary.txt", params)
-    msg_html = render_to_string("mail/pre_assessment_secretary.html", params)
-    send_mail(
-        subject,
-        msg_plain,
-        settings.EMAIL_FROM,
-        [secretary.email],
-        html_message=msg_html,
-    )
+    msg_plain = render_to_string('mail/pre_assessment_secretary.txt', params)
+    msg_html = render_to_string('mail/pre_assessment_secretary.html', params)
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email], html_message=msg_html)
 
-    subject = _(
-        "FETC-GW {}: bevestiging indienen aanvraag voor voortoetsing".format(
-            proposal.committee_prefixed_refnum(),
-        )
-    )
+    subject = _('FETC-GW {}: bevestiging indienen aanvraag voor voortoetsing'.format(
+        proposal.committee_prefixed_refnum(),)
+                )
     params = {
-        "secretary": secretary.get_full_name(),
+        'secretary': secretary.get_full_name(),
     }
-    msg_plain = render_to_string("mail/pre_assessment_creator.txt", params)
+    msg_plain = render_to_string('mail/pre_assessment_creator.txt', params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.created_by.email])
 
 
@@ -310,32 +245,28 @@ def start_review_route(review, commission_users, use_short_route):
     Creates Decisions and sends notification e-mail to the selected Reviewers
     """
 
-    template = (
-        "mail/assignment_shortroute.txt"
-        if use_short_route
-        else "mail/assignment_longroute.txt"
-    )
+    template = 'mail/assignment_shortroute.txt' if use_short_route else 'mail/assignment_longroute.txt'
 
     was_revised = review.proposal.is_revision
 
     if was_revised:
-        subject = "FETC-GW {}: gereviseerde aanvraag ter beoordeling"
+        subject = 'FETC-GW {}: gereviseerde aanvraag ter beoordeling'
     else:
-        subject = "FETC-GW {}: nieuwe aanvraag ter beoordeling"
+        subject = 'FETC-GW {}: nieuwe aanvraag ter beoordeling'
         # These emails are Dutch-only, therefore intentionally untranslated
 
-    subject = subject.format(
-        review.proposal.committee_prefixed_refnum(),
-    )
+    subject = subject.format(review.proposal.committee_prefixed_refnum(),
+                             )
 
     for user in commission_users:
+
         Decision.objects.create(review=review, reviewer=user)
         params = {
-            "secretary": get_secretary().get_full_name(),
-            "reviewer": user.get_full_name(),
-            "review_date": review.date_should_end,
-            "is_pre_assessment": review.proposal.is_pre_assessment,
-            "was_revised": was_revised,
+            'secretary': get_secretary().get_full_name(),
+            'reviewer': user.get_full_name(),
+            'review_date': review.date_should_end,
+            'is_pre_assessment': review.proposal.is_pre_assessment,
+            'was_revised': was_revised,
         }
         msg_plain = render_to_string(template, params)
         send_mail(subject, msg_plain, settings.EMAIL_FROM, [user.email])
@@ -348,14 +279,12 @@ def notify_secretary_assignment(review):
     secretary = get_secretary()
     proposal = review.proposal
     committee = review.proposal.reviewing_committee
-    subject = _("FETC-GW {}: nieuwe aanvraag ingediend").format(
-        proposal.committee_prefixed_refnum()
-    )
+    subject = _('FETC-GW {}: nieuwe aanvraag ingediend').format(proposal.committee_prefixed_refnum())
     params = {
-        "secretary": secretary.get_full_name(),
-        "review": review,
+        'secretary': secretary.get_full_name(),
+        'review': review,
     }
-    msg_plain = render_to_string("mail/submitted.txt", params)
+    msg_plain = render_to_string('mail/submitted.txt', params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
 
 
@@ -365,16 +294,15 @@ def notify_secretary(decision):
     """
     secretary = get_secretary()
     proposal = decision.review.proposal
-    subject = _("FETC-GW {}: nieuwe beoordeling toegevoegd").format(
+    subject = _('FETC-GW {}: nieuwe beoordeling toegevoegd').format(
         proposal.committee_prefixed_refnum(),
     )
     params = {
-        "secretary": secretary.get_full_name(),
-        "decision": decision,
+        'secretary': secretary.get_full_name(),
+        'decision': decision,
     }
-    msg_plain = render_to_string("mail/decision_notify.txt", params)
+    msg_plain = render_to_string('mail/decision_notify.txt', params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
-
 
 def notify_secretary_all_decisions(review):
     """
@@ -392,26 +320,23 @@ def notify_secretary_all_decisions(review):
     msg_plain = render_to_string("mail/all_decisions_notify.txt", params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
 
-
 def notify_supervisor_nogo(decision):
     secretary = get_secretary()
     proposal = decision.review.proposal
     supervisor = proposal.supervisor
     receivers = set(applicant for applicant in proposal.applicants.all())
-    subject = _(
-        "FETC-GW {}: eindverantwoordelijke heeft je aanvraag beoordeeld".format(
-            proposal.committee_prefixed_refnum(),
-        )
+    subject = _('FETC-GW {}: eindverantwoordelijke heeft je aanvraag beoordeeld'.format(
+        proposal.committee_prefixed_refnum(),)
     )
     params = {
-        "secretary": secretary.get_full_name(),
-        "decision": decision,
-        "supervisor": supervisor,
+        'secretary': secretary.get_full_name(),
+        'decision': decision,
+        'supervisor': supervisor,
     }
 
     for applicant in receivers:
-        params["applicant"] = applicant
-        msg_plain = render_to_string("mail/supervisor_decision.txt", params)
+        params['applicant'] = applicant
+        msg_plain = render_to_string('mail/supervisor_decision.txt', params)
         send_mail(subject, msg_plain, settings.EMAIL_FROM, [applicant.email])
 
 
@@ -424,66 +349,40 @@ def auto_review(proposal: Proposal):
     reasons = []
 
     for study in proposal.study_set.all():
+
         if study.legally_incapable:
-            reasons.append(
-                _("De aanvraag bevat het gebruik van wilsonbekwame volwassenen.")
-            )
+            reasons.append(_('De aanvraag bevat het gebruik van wilsonbekwame volwassenen.'))
 
         if study.deception in [YES, DOUBT]:
-            reasons.append(_("De aanvraag bevat het gebruik van misleiding."))
+            reasons.append(_('De aanvraag bevat het gebruik van misleiding.'))
 
         if study.hierarchy:
-            reasons.append(
-                _(
-                    "Er bestaat een hiërarchische relatie tussen de onderzoeker(s) en deelnemer(s)"
-                )
-            )
+            reasons.append(_('Er bestaat een hiërarchische relatie tussen de onderzoeker(s) en deelnemer(s)'))
 
         if study.has_special_details:
-            reasons.append(_("Het onderzoek verzamelt bijzondere persoonsgegevens."))
+            reasons.append(_('Het onderzoek verzamelt bijzondere persoonsgegevens.'))
 
         if study.has_traits:
-            reasons.append(
-                _(
-                    "Het onderzoek selecteert deelnemers op bijzondere kenmerken die wellicht verhoogde kwetsbaarheid met zich meebrengen."
-                )
-            )
+            reasons.append(_('Het onderzoek selecteert deelnemers op bijzondere kenmerken die wellicht verhoogde kwetsbaarheid met zich meebrengen.'))
 
         for task in Task.objects.filter(session__study=study):
             reasons.extend(auto_review_task(study, task))
 
         if study.stressful in [YES, DOUBT]:
-            reasons.append(
-                _(
-                    "De onderzoeker geeft aan dat (of twijfelt erover of) het onderzoek op onderdelen of \
-als geheel zodanig belastend is dat deze ondanks de verkregen informed consent vragen zou kunnen oproepen."
-                )
-            )
+            reasons.append(_('De onderzoeker geeft aan dat (of twijfelt erover of) het onderzoek op onderdelen of \
+als geheel zodanig belastend is dat deze ondanks de verkregen informed consent vragen zou kunnen oproepen.'))
 
         if study.risk in [YES, DOUBT]:
-            reasons.append(
-                _(
-                    "De onderzoeker geeft aan dat (of twijfelt erover of) de risico's op psychische of \
-fysieke schade bij deelname aan het onderzoek meer dan minimaal zijn."
-                )
-            )
+            reasons.append(_('De onderzoeker geeft aan dat (of twijfelt erover of) de risico\'s op psychische of \
+fysieke schade bij deelname aan het onderzoek meer dan minimaal zijn.'))
 
         if study.has_sessions:
             for session in study.session_set.all():
                 for age_group in study.age_groups.all():
                     if session.net_duration() > age_group.max_net_duration:
-                        reasons.append(
-                            _(
-                                "De totale duur van de taken in sessie {s}, exclusief pauzes \
+                        reasons.append(_('De totale duur van de taken in sessie {s}, exclusief pauzes \
 en andere niet-taak elementen ({d} minuten), is groter dan het streefmaximum ({max_d} minuten) \
-voor de leeftijdsgroep {ag}."
-                            ).format(
-                                s=session.order,
-                                ag=age_group,
-                                d=session.net_duration(),
-                                max_d=age_group.max_net_duration,
-                            )
-                        )
+voor de leeftijdsgroep {ag}.').format(s=session.order, ag=age_group, d=session.net_duration(), max_d=age_group.max_net_duration))
 
     return reasons
 
@@ -498,30 +397,18 @@ def auto_review_observation(observation):
 
     if observation.settings_requires_review():
         for setting in observation.settings_requires_review():
-            reasons.append(
-                _(
-                    "Het onderzoek observeert deelnemers in de volgende setting: {s}"
-                ).format(s=setting)
-            )
+            reasons.append(_('Het onderzoek observeert deelnemers in de volgende setting: {s}').format(s=setting))
 
     if observation.is_nonpublic_space:
         if not observation.has_advanced_consent:
-            reasons.append(
-                _(
-                    "Het onderzoek observeert deelnemers in een niet-publieke ruimte en werkt met informed consent achteraf."
-                )
-            )
+            reasons.append(_('Het onderzoek observeert deelnemers in een niet-publieke ruimte en werkt met informed consent achteraf.'))
         if observation.is_anonymous:
-            reasons.append(
-                _(
-                    'De onderzoeker begeeft zich "under cover" in een beheerde niet-publieke ruimte (bijv. een digitale gespreksgroep), en neemt actief aan de discussie deel en/of verzamelt data die te herleiden zijn tot individuele personen.'
-                )
-            )
+            reasons.append(_('De onderzoeker begeeft zich "under cover" in een beheerde niet-publieke ruimte (bijv. een digitale gespreksgroep), en neemt actief aan de discussie deel en/of verzamelt data die te herleiden zijn tot individuele personen.'))
 
     for registration in observation.registrations.all():
         if registration.requires_review:
             reasons.append(
-                _("De aanvraag bevat het gebruik van {}").format(
+                _('De aanvraag bevat het gebruik van {}').format(
                     registration.description
                 )
             )
@@ -541,15 +428,8 @@ def auto_review_task(study, task):
         if registration.requires_review:
             if registration.age_min:
                 for age_group in study.age_groups.all():
-                    if (
-                        age_group.age_max is not None
-                        and age_group.age_max < registration.age_min
-                    ):
-                        reasons.append(
-                            _(
-                                "De aanvraag bevat psychofysiologische metingen bij kinderen onder de {} jaar."
-                            ).format(registration.age_min)
-                        )
+                    if age_group.age_max is not None and age_group.age_max < registration.age_min:
+                        reasons.append(_('De aanvraag bevat psychofysiologische metingen bij kinderen onder de {} jaar.').format(registration.age_min))
                         break
 
     return reasons
@@ -558,7 +438,7 @@ def auto_review_task(study, task):
 def discontinue_review(review):
     """
     Set continuation to discontinued on the given review,
-    and set DECISION_MADE on its proposal."""
+    and set DECISION_MADE on its proposal. """
 
     # Set review continuation
     review.continuation = review.DISCONTINUED
@@ -583,17 +463,21 @@ def assign_reviewers(review, list_of_users, route):
     obsolete_reviewers = current_reviewers - list_of_users
 
     if review.proposal.is_revision:
-        # Revisions should end in one week.
-        review.date_should_end = timezone.now() + timezone.timedelta(weeks=1)
+        #Revisions should end in one week.
+        review.date_should_end = timezone.now() + \
+            timezone.timedelta(
+                weeks=1
+            )
     elif review.date_should_end is not None:
-        # if the date_end_variable gets assigned through auto review
-        # the review keeps this date
+        #if the date_end_variable gets assigned through auto review
+        #the review keeps this date
         pass
     elif route == True:
-        # The short route reviews should take two weeks.
-        review.date_should_end = timezone.now() + timezone.timedelta(
-            weeks=settings.SHORT_ROUTE_WEEKS
-        )
+        #The short route reviews should take two weeks.
+        review.date_should_end = timezone.now() + \
+            timezone.timedelta(
+                weeks=settings.SHORT_ROUTE_WEEKS
+            )
     elif route == False:
         # We have no desired end date for long track reviews
         review.date_should_end = None
@@ -602,14 +486,14 @@ def assign_reviewers(review, list_of_users, route):
     start_review_route(review, new_reviewers, route)
 
     # Remove the Decision for obsolete reviewers
-    Decision.objects.filter(review=review, reviewer__in=obsolete_reviewers).delete()
+    Decision.objects.filter(review=review,
+                            reviewer__in=obsolete_reviewers).delete()
 
     review.save()
 
     # Finally, update the review process
     # This prevents it waiting for removed reviewers
     review.update_go()
-
 
 def straight_to_revision(review):
     """This action by the secretary in ReviewAssignForm bypasses

--- a/reviews/utils/review_utils.py
+++ b/reviews/utils/review_utils.py
@@ -309,7 +309,7 @@ def notify_secretary_all_decisions(review):
     Notifies a secretary all Decisions have been made for a certain review
     """
     secretary = get_secretary()
-    subject = _("FETC-GW {}: alle beoordelingen toegevoegd").format(
+    subject = "FETC-GW {}: alle beoordelingen toegevoegd".format(
         review.proposal.committee_prefixed_refnum(),
     )
     params = {
@@ -318,7 +318,7 @@ def notify_secretary_all_decisions(review):
         "decisions": review.decision_set.all()
     }
     msg_plain = render_to_string("mail/all_decisions_notify.txt", params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, ['fetc-gw@uu.nl'])
 
 def notify_supervisor_nogo(decision):
     secretary = get_secretary()

--- a/reviews/utils/review_utils.py
+++ b/reviews/utils/review_utils.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.urls import reverse
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import activate, get_language, ugettext_lazy as _
 from django.utils import timezone
 
 from main.models import YES, DOUBT
@@ -308,17 +308,29 @@ def notify_secretary_all_decisions(review):
     """
     Notifies a secretary all Decisions have been made for a certain review
     """
+    # Change language to Dutch for this e-mail, but save the current language to reset it later
+    current_language = get_language()
+    activate("nl")
+
     secretary = get_secretary()
     subject = "FETC-GW {}: alle beoordelingen toegevoegd".format(
         review.proposal.committee_prefixed_refnum(),
     )
     params = {
         "secretary": secretary.get_full_name(),
-        "proposal": review.proposal,
-        "decisions": review.decision_set.all()
+        "review": review,
+        "decisions": review.decision_set.all(),
+        "review_detail_page": settings.BASE_URL
+        + (reverse("reviews:detail", args=[review.pk])),
+        "close_review_page": settings.BASE_URL
+        + (reverse("reviews:close", args=[review.pk])),
     }
     msg_plain = render_to_string("mail/all_decisions_notify.txt", params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, ['fetc-gw@uu.nl'])
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, ["fetc-gw@uu.nl"])
+
+    # Reset the current language
+    activate(current_language)
+
 
 def notify_supervisor_nogo(decision):
     secretary = get_secretary()

--- a/reviews/utils/review_utils.py
+++ b/reviews/utils/review_utils.py
@@ -52,39 +52,62 @@ def start_supervisor_phase(proposal):
     decision = Decision.objects.create(review=review, reviewer=proposal.supervisor)
     reference = proposal.committee_prefixed_refnum()
 
-    subject = _('FETC-GW {}: bevestiging indienen concept-aanmelding'.format(reference))
+    subject = _("FETC-GW {}: bevestiging indienen concept-aanmelding".format(reference))
     params = {
-        'proposal': proposal,
-        'title': proposal.title,
-        'supervisor': proposal.supervisor.get_full_name(),
-        'secretary': get_secretary().get_full_name(),
-        'pdf_url': settings.BASE_URL + proposal.pdf.url,
+        "proposal": proposal,
+        "title": proposal.title,
+        "supervisor": proposal.supervisor.get_full_name(),
+        "secretary": get_secretary().get_full_name(),
+        "pdf_url": settings.BASE_URL + proposal.pdf.url,
     }
-    msg_plain = render_to_string('mail/concept_creator.txt', params)
-    msg_html = render_to_string('mail/concept_creator.html', params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.created_by.email], html_message=msg_html)
+    msg_plain = render_to_string("mail/concept_creator.txt", params)
+    msg_html = render_to_string("mail/concept_creator.html", params)
+    send_mail(
+        subject,
+        msg_plain,
+        settings.EMAIL_FROM,
+        [proposal.created_by.email],
+        html_message=msg_html,
+    )
 
     if proposal.other_applicants:
-        params['creator'] = proposal.created_by.get_full_name()
-        msg_plain = render_to_string('mail/concept_other_applicants.txt', params)
-        msg_html = render_to_string('mail/concept_other_applicants.html', params)
+        params["creator"] = proposal.created_by.get_full_name()
+        msg_plain = render_to_string("mail/concept_other_applicants.txt", params)
+        msg_html = render_to_string("mail/concept_other_applicants.html", params)
         applicants_to_remove = [proposal.created_by, proposal.supervisor]
-        other_applicants_emails = [applicant.email for applicant in proposal.applicants.all() if applicant not in applicants_to_remove]
-        send_mail(subject, msg_plain, settings.EMAIL_FROM, other_applicants_emails, html_message=msg_html)
+        other_applicants_emails = [
+            applicant.email
+            for applicant in proposal.applicants.all()
+            if applicant not in applicants_to_remove
+        ]
+        send_mail(
+            subject,
+            msg_plain,
+            settings.EMAIL_FROM,
+            other_applicants_emails,
+            html_message=msg_html,
+        )
 
-    subject = _('FETC-GW {}: beoordelen als eindverantwoordelijke'.format(reference))
+    subject = _("FETC-GW {}: beoordelen als eindverantwoordelijke".format(reference))
     params = {
-        'proposal': proposal,
-        'creator': proposal.created_by.get_full_name(),
-        'proposal_url': settings.BASE_URL + reverse('reviews:decide', args=(decision.pk,)),
-        'secretary': get_secretary().get_full_name(),
-        'revision': proposal.is_revision,
-        'revision_type': proposal.type(),
-        'my_supervised': settings.BASE_URL + reverse('proposals:my_supervised'),
+        "proposal": proposal,
+        "creator": proposal.created_by.get_full_name(),
+        "proposal_url": settings.BASE_URL
+        + reverse("reviews:decide", args=(decision.pk,)),
+        "secretary": get_secretary().get_full_name(),
+        "revision": proposal.is_revision,
+        "revision_type": proposal.type(),
+        "my_supervised": settings.BASE_URL + reverse("proposals:my_supervised"),
     }
-    msg_plain = render_to_string('mail/concept_supervisor.txt', params)
-    msg_html = render_to_string('mail/concept_supervisor.html', params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.supervisor.email], html_message=msg_html)
+    msg_plain = render_to_string("mail/concept_supervisor.txt", params)
+    msg_html = render_to_string("mail/concept_supervisor.html", params)
+    send_mail(
+        subject,
+        msg_plain,
+        settings.EMAIL_FROM,
+        [proposal.supervisor.email],
+        html_message=msg_html,
+    )
 
     return review
 
@@ -110,7 +133,9 @@ def start_assignment_phase(proposal):
     review.short_route = short_route
 
     if short_route:
-        review.date_should_end = timezone.now() + timezone.timedelta(weeks=settings.SHORT_ROUTE_WEEKS)
+        review.date_should_end = timezone.now() + timezone.timedelta(
+            weeks=settings.SHORT_ROUTE_WEEKS
+        )
     review.save()
 
     proposal.date_submitted = timezone.now()
@@ -122,36 +147,58 @@ def start_assignment_phase(proposal):
 
     notify_secretary_assignment(review)
 
-    subject = _('FETC-GW {}: aanmelding ontvangen'.format(proposal.committee_prefixed_refnum()))
+    subject = _(
+        "FETC-GW {}: aanmelding ontvangen".format(proposal.committee_prefixed_refnum())
+    )
     params = {
-        'secretary': secretary.get_full_name(),
-        'review_date': review.date_should_end,
-        'pdf_url': settings.BASE_URL + proposal.pdf.url,
-        'title': proposal.title,
+        "secretary": secretary.get_full_name(),
+        "review_date": review.date_should_end,
+        "pdf_url": settings.BASE_URL + proposal.pdf.url,
+        "title": proposal.title,
     }
     if review.short_route:
-        msg_plain = render_to_string('mail/submitted_shortroute.txt', params)
-        msg_html = render_to_string('mail/submitted_shortroute.html', params)
+        msg_plain = render_to_string("mail/submitted_shortroute.txt", params)
+        msg_html = render_to_string("mail/submitted_shortroute.html", params)
     else:
-        msg_plain = render_to_string('mail/submitted_longroute.txt', params)
-        msg_html = render_to_string('mail/submitted_longroute.html', params)
+        msg_plain = render_to_string("mail/submitted_longroute.txt", params)
+        msg_html = render_to_string("mail/submitted_longroute.html", params)
     recipients = [proposal.created_by.email]
     if proposal.relation.needs_supervisor:
         recipients.append(proposal.supervisor.email)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, recipients, html_message=msg_html)
+    send_mail(
+        subject, msg_plain, settings.EMAIL_FROM, recipients, html_message=msg_html
+    )
 
     if proposal.supervisor is None and proposal.other_applicants:
-        params['creator'] = proposal.created_by.get_full_name()
+        params["creator"] = proposal.created_by.get_full_name()
         if review.short_route:
-            msg_plain = render_to_string('mail/submitted_shortroute_other_applicants.txt', params)
-            msg_html = render_to_string('mail/submitted_shortroute_other_applicants.html', params)
+            msg_plain = render_to_string(
+                "mail/submitted_shortroute_other_applicants.txt", params
+            )
+            msg_html = render_to_string(
+                "mail/submitted_shortroute_other_applicants.html", params
+            )
         else:
-            msg_plain = render_to_string('mail/submitted_longroute_other_applicants.txt', params)
-            msg_html = render_to_string('mail/submitted_longroute_other_applicants.html', params)
+            msg_plain = render_to_string(
+                "mail/submitted_longroute_other_applicants.txt", params
+            )
+            msg_html = render_to_string(
+                "mail/submitted_longroute_other_applicants.html", params
+            )
         applicants_to_remove = [proposal.created_by]
-        other_applicants_emails = [applicant.email for applicant in proposal.applicants.all() if applicant not in applicants_to_remove]
+        other_applicants_emails = [
+            applicant.email
+            for applicant in proposal.applicants.all()
+            if applicant not in applicants_to_remove
+        ]
 
-        send_mail(subject, msg_plain, settings.EMAIL_FROM, other_applicants_emails, html_message=msg_html)
+        send_mail(
+            subject,
+            msg_plain,
+            settings.EMAIL_FROM,
+            other_applicants_emails,
+            html_message=msg_html,
+        )
 
     if proposal.inform_local_staff:
         notify_local_staff(proposal)
@@ -173,7 +220,7 @@ def remind_reviewers():
         review__short_route=True,
         review__date_should_end__gte=today,
         review__date_should_end__lte=next_two_days,
-        go='',  # Checks if the decision has already been done; we don't
+        go="",  # Checks if the decision has already been done; we don't
         # check for None as the field cannot be None according to the field
         # definition
     )
@@ -184,13 +231,20 @@ def remind_reviewers():
             proposal.committee_prefixed_refnum(),
         )
         params = {
-            'creator': proposal.created_by.get_full_name(),
-            'proposal_url': settings.BASE_URL + reverse('reviews:decide', args=(decision.pk,)),
-            'secretary': get_secretary().get_full_name(),
+            "creator": proposal.created_by.get_full_name(),
+            "proposal_url": settings.BASE_URL
+            + reverse("reviews:decide", args=(decision.pk,)),
+            "secretary": get_secretary().get_full_name(),
         }
-        msg_plain = render_to_string('mail/reminder.txt', params)
-        msg_html = render_to_string('mail/reminder.html', params)
-        send_mail(subject, msg_plain, settings.EMAIL_FROM, [decision.reviewer.email], html_message=msg_html)
+        msg_plain = render_to_string("mail/reminder.txt", params)
+        msg_html = render_to_string("mail/reminder.html", params)
+        send_mail(
+            subject,
+            msg_plain,
+            settings.EMAIL_FROM,
+            [decision.reviewer.email],
+            html_message=msg_html,
+        )
 
 
 def start_review_pre_assessment(proposal):
@@ -206,7 +260,9 @@ def start_review_pre_assessment(proposal):
     review = Review.objects.create(proposal=proposal, date_start=timezone.now())
     review.stage = Review.ASSIGNMENT
     review.short_route = True
-    review.date_should_end = timezone.now() + timezone.timedelta(weeks=settings.PREASSESSMENT_ROUTE_WEEKS)
+    review.date_should_end = timezone.now() + timezone.timedelta(
+        weeks=settings.PREASSESSMENT_ROUTE_WEEKS
+    )
     review.save()
 
     proposal.date_submitted = timezone.now()
@@ -216,27 +272,36 @@ def start_review_pre_assessment(proposal):
     secretary = get_secretary()
     Decision.objects.create(review=review, reviewer=secretary)
 
-    subject = _('FETC-GW {}: nieuwe aanvraag voor voortoetsing'.format(
-        proposal.committee_prefixed_refnum(),
+    subject = _(
+        "FETC-GW {}: nieuwe aanvraag voor voortoetsing".format(
+            proposal.committee_prefixed_refnum(),
         )
-                )
-                
-    params = {
-        'secretary': secretary.get_full_name(),
-        'proposal': proposal,
-        'proposal_pdf': settings.BASE_URL + proposal.pdf.url,
-    }
-    msg_plain = render_to_string('mail/pre_assessment_secretary.txt', params)
-    msg_html = render_to_string('mail/pre_assessment_secretary.html', params)
-    send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email], html_message=msg_html)
+    )
 
-    subject = _('FETC-GW {}: bevestiging indienen aanvraag voor voortoetsing'.format(
-        proposal.committee_prefixed_refnum(),)
-                )
     params = {
-        'secretary': secretary.get_full_name(),
+        "secretary": secretary.get_full_name(),
+        "proposal": proposal,
+        "proposal_pdf": settings.BASE_URL + proposal.pdf.url,
     }
-    msg_plain = render_to_string('mail/pre_assessment_creator.txt', params)
+    msg_plain = render_to_string("mail/pre_assessment_secretary.txt", params)
+    msg_html = render_to_string("mail/pre_assessment_secretary.html", params)
+    send_mail(
+        subject,
+        msg_plain,
+        settings.EMAIL_FROM,
+        [secretary.email],
+        html_message=msg_html,
+    )
+
+    subject = _(
+        "FETC-GW {}: bevestiging indienen aanvraag voor voortoetsing".format(
+            proposal.committee_prefixed_refnum(),
+        )
+    )
+    params = {
+        "secretary": secretary.get_full_name(),
+    }
+    msg_plain = render_to_string("mail/pre_assessment_creator.txt", params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [proposal.created_by.email])
 
 
@@ -245,28 +310,32 @@ def start_review_route(review, commission_users, use_short_route):
     Creates Decisions and sends notification e-mail to the selected Reviewers
     """
 
-    template = 'mail/assignment_shortroute.txt' if use_short_route else 'mail/assignment_longroute.txt'
+    template = (
+        "mail/assignment_shortroute.txt"
+        if use_short_route
+        else "mail/assignment_longroute.txt"
+    )
 
     was_revised = review.proposal.is_revision
 
     if was_revised:
-        subject = 'FETC-GW {}: gereviseerde aanvraag ter beoordeling'
+        subject = "FETC-GW {}: gereviseerde aanvraag ter beoordeling"
     else:
-        subject = 'FETC-GW {}: nieuwe aanvraag ter beoordeling'
+        subject = "FETC-GW {}: nieuwe aanvraag ter beoordeling"
         # These emails are Dutch-only, therefore intentionally untranslated
 
-    subject = subject.format(review.proposal.committee_prefixed_refnum(),
-                             )
+    subject = subject.format(
+        review.proposal.committee_prefixed_refnum(),
+    )
 
     for user in commission_users:
-
         Decision.objects.create(review=review, reviewer=user)
         params = {
-            'secretary': get_secretary().get_full_name(),
-            'reviewer': user.get_full_name(),
-            'review_date': review.date_should_end,
-            'is_pre_assessment': review.proposal.is_pre_assessment,
-            'was_revised': was_revised,
+            "secretary": get_secretary().get_full_name(),
+            "reviewer": user.get_full_name(),
+            "review_date": review.date_should_end,
+            "is_pre_assessment": review.proposal.is_pre_assessment,
+            "was_revised": was_revised,
         }
         msg_plain = render_to_string(template, params)
         send_mail(subject, msg_plain, settings.EMAIL_FROM, [user.email])
@@ -279,12 +348,14 @@ def notify_secretary_assignment(review):
     secretary = get_secretary()
     proposal = review.proposal
     committee = review.proposal.reviewing_committee
-    subject = _('FETC-GW {}: nieuwe aanvraag ingediend').format(proposal.committee_prefixed_refnum())
+    subject = _("FETC-GW {}: nieuwe aanvraag ingediend").format(
+        proposal.committee_prefixed_refnum()
+    )
     params = {
-        'secretary': secretary.get_full_name(),
-        'review': review,
+        "secretary": secretary.get_full_name(),
+        "review": review,
     }
-    msg_plain = render_to_string('mail/submitted.txt', params)
+    msg_plain = render_to_string("mail/submitted.txt", params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
 
 
@@ -294,14 +365,31 @@ def notify_secretary(decision):
     """
     secretary = get_secretary()
     proposal = decision.review.proposal
-    subject = _('FETC-GW {}: nieuwe beoordeling toegevoegd').format(
+    subject = _("FETC-GW {}: nieuwe beoordeling toegevoegd").format(
         proposal.committee_prefixed_refnum(),
     )
     params = {
-        'secretary': secretary.get_full_name(),
-        'decision': decision,
+        "secretary": secretary.get_full_name(),
+        "decision": decision,
     }
-    msg_plain = render_to_string('mail/decision_notify.txt', params)
+    msg_plain = render_to_string("mail/decision_notify.txt", params)
+    send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
+
+
+def notify_secretary_all_decisions(review):
+    """
+    Notifies a secretary all Decisions have been made for a certain review
+    """
+    secretary = get_secretary()
+    subject = _("FETC-GW {}: alle beoordelingen toegevoegd").format(
+        review.proposal.committee_prefixed_refnum(),
+    )
+    params = {
+        "secretary": secretary.get_full_name(),
+        "proposal": review.proposal,
+        "decisions": review.decision_set.all()
+    }
+    msg_plain = render_to_string("mail/all_decisions_notify.txt", params)
     send_mail(subject, msg_plain, settings.EMAIL_FROM, [secretary.email])
 
 
@@ -310,18 +398,20 @@ def notify_supervisor_nogo(decision):
     proposal = decision.review.proposal
     supervisor = proposal.supervisor
     receivers = set(applicant for applicant in proposal.applicants.all())
-    subject = _('FETC-GW {}: eindverantwoordelijke heeft je aanvraag beoordeeld'.format(
-        proposal.committee_prefixed_refnum(),)
+    subject = _(
+        "FETC-GW {}: eindverantwoordelijke heeft je aanvraag beoordeeld".format(
+            proposal.committee_prefixed_refnum(),
+        )
     )
     params = {
-        'secretary': secretary.get_full_name(),
-        'decision': decision,
-        'supervisor': supervisor,
+        "secretary": secretary.get_full_name(),
+        "decision": decision,
+        "supervisor": supervisor,
     }
 
     for applicant in receivers:
-        params['applicant'] = applicant
-        msg_plain = render_to_string('mail/supervisor_decision.txt', params)
+        params["applicant"] = applicant
+        msg_plain = render_to_string("mail/supervisor_decision.txt", params)
         send_mail(subject, msg_plain, settings.EMAIL_FROM, [applicant.email])
 
 
@@ -334,40 +424,66 @@ def auto_review(proposal: Proposal):
     reasons = []
 
     for study in proposal.study_set.all():
-
         if study.legally_incapable:
-            reasons.append(_('De aanvraag bevat het gebruik van wilsonbekwame volwassenen.'))
+            reasons.append(
+                _("De aanvraag bevat het gebruik van wilsonbekwame volwassenen.")
+            )
 
         if study.deception in [YES, DOUBT]:
-            reasons.append(_('De aanvraag bevat het gebruik van misleiding.'))
+            reasons.append(_("De aanvraag bevat het gebruik van misleiding."))
 
         if study.hierarchy:
-            reasons.append(_('Er bestaat een hiërarchische relatie tussen de onderzoeker(s) en deelnemer(s)'))
+            reasons.append(
+                _(
+                    "Er bestaat een hiërarchische relatie tussen de onderzoeker(s) en deelnemer(s)"
+                )
+            )
 
         if study.has_special_details:
-            reasons.append(_('Het onderzoek verzamelt bijzondere persoonsgegevens.'))
+            reasons.append(_("Het onderzoek verzamelt bijzondere persoonsgegevens."))
 
         if study.has_traits:
-            reasons.append(_('Het onderzoek selecteert deelnemers op bijzondere kenmerken die wellicht verhoogde kwetsbaarheid met zich meebrengen.'))
+            reasons.append(
+                _(
+                    "Het onderzoek selecteert deelnemers op bijzondere kenmerken die wellicht verhoogde kwetsbaarheid met zich meebrengen."
+                )
+            )
 
         for task in Task.objects.filter(session__study=study):
             reasons.extend(auto_review_task(study, task))
 
         if study.stressful in [YES, DOUBT]:
-            reasons.append(_('De onderzoeker geeft aan dat (of twijfelt erover of) het onderzoek op onderdelen of \
-als geheel zodanig belastend is dat deze ondanks de verkregen informed consent vragen zou kunnen oproepen.'))
+            reasons.append(
+                _(
+                    "De onderzoeker geeft aan dat (of twijfelt erover of) het onderzoek op onderdelen of \
+als geheel zodanig belastend is dat deze ondanks de verkregen informed consent vragen zou kunnen oproepen."
+                )
+            )
 
         if study.risk in [YES, DOUBT]:
-            reasons.append(_('De onderzoeker geeft aan dat (of twijfelt erover of) de risico\'s op psychische of \
-fysieke schade bij deelname aan het onderzoek meer dan minimaal zijn.'))
+            reasons.append(
+                _(
+                    "De onderzoeker geeft aan dat (of twijfelt erover of) de risico's op psychische of \
+fysieke schade bij deelname aan het onderzoek meer dan minimaal zijn."
+                )
+            )
 
         if study.has_sessions:
             for session in study.session_set.all():
                 for age_group in study.age_groups.all():
                     if session.net_duration() > age_group.max_net_duration:
-                        reasons.append(_('De totale duur van de taken in sessie {s}, exclusief pauzes \
+                        reasons.append(
+                            _(
+                                "De totale duur van de taken in sessie {s}, exclusief pauzes \
 en andere niet-taak elementen ({d} minuten), is groter dan het streefmaximum ({max_d} minuten) \
-voor de leeftijdsgroep {ag}.').format(s=session.order, ag=age_group, d=session.net_duration(), max_d=age_group.max_net_duration))
+voor de leeftijdsgroep {ag}."
+                            ).format(
+                                s=session.order,
+                                ag=age_group,
+                                d=session.net_duration(),
+                                max_d=age_group.max_net_duration,
+                            )
+                        )
 
     return reasons
 
@@ -382,18 +498,30 @@ def auto_review_observation(observation):
 
     if observation.settings_requires_review():
         for setting in observation.settings_requires_review():
-            reasons.append(_('Het onderzoek observeert deelnemers in de volgende setting: {s}').format(s=setting))
+            reasons.append(
+                _(
+                    "Het onderzoek observeert deelnemers in de volgende setting: {s}"
+                ).format(s=setting)
+            )
 
     if observation.is_nonpublic_space:
         if not observation.has_advanced_consent:
-            reasons.append(_('Het onderzoek observeert deelnemers in een niet-publieke ruimte en werkt met informed consent achteraf.'))
+            reasons.append(
+                _(
+                    "Het onderzoek observeert deelnemers in een niet-publieke ruimte en werkt met informed consent achteraf."
+                )
+            )
         if observation.is_anonymous:
-            reasons.append(_('De onderzoeker begeeft zich "under cover" in een beheerde niet-publieke ruimte (bijv. een digitale gespreksgroep), en neemt actief aan de discussie deel en/of verzamelt data die te herleiden zijn tot individuele personen.'))
+            reasons.append(
+                _(
+                    'De onderzoeker begeeft zich "under cover" in een beheerde niet-publieke ruimte (bijv. een digitale gespreksgroep), en neemt actief aan de discussie deel en/of verzamelt data die te herleiden zijn tot individuele personen.'
+                )
+            )
 
     for registration in observation.registrations.all():
         if registration.requires_review:
             reasons.append(
-                _('De aanvraag bevat het gebruik van {}').format(
+                _("De aanvraag bevat het gebruik van {}").format(
                     registration.description
                 )
             )
@@ -413,8 +541,15 @@ def auto_review_task(study, task):
         if registration.requires_review:
             if registration.age_min:
                 for age_group in study.age_groups.all():
-                    if age_group.age_max is not None and age_group.age_max < registration.age_min:
-                        reasons.append(_('De aanvraag bevat psychofysiologische metingen bij kinderen onder de {} jaar.').format(registration.age_min))
+                    if (
+                        age_group.age_max is not None
+                        and age_group.age_max < registration.age_min
+                    ):
+                        reasons.append(
+                            _(
+                                "De aanvraag bevat psychofysiologische metingen bij kinderen onder de {} jaar."
+                            ).format(registration.age_min)
+                        )
                         break
 
     return reasons
@@ -423,7 +558,7 @@ def auto_review_task(study, task):
 def discontinue_review(review):
     """
     Set continuation to discontinued on the given review,
-    and set DECISION_MADE on its proposal. """
+    and set DECISION_MADE on its proposal."""
 
     # Set review continuation
     review.continuation = review.DISCONTINUED
@@ -448,21 +583,17 @@ def assign_reviewers(review, list_of_users, route):
     obsolete_reviewers = current_reviewers - list_of_users
 
     if review.proposal.is_revision:
-        #Revisions should end in one week.
-        review.date_should_end = timezone.now() + \
-            timezone.timedelta(
-                weeks=1
-            )
+        # Revisions should end in one week.
+        review.date_should_end = timezone.now() + timezone.timedelta(weeks=1)
     elif review.date_should_end is not None:
-        #if the date_end_variable gets assigned through auto review
-        #the review keeps this date
+        # if the date_end_variable gets assigned through auto review
+        # the review keeps this date
         pass
     elif route == True:
-        #The short route reviews should take two weeks.
-        review.date_should_end = timezone.now() + \
-            timezone.timedelta(
-                weeks=settings.SHORT_ROUTE_WEEKS
-            )
+        # The short route reviews should take two weeks.
+        review.date_should_end = timezone.now() + timezone.timedelta(
+            weeks=settings.SHORT_ROUTE_WEEKS
+        )
     elif route == False:
         # We have no desired end date for long track reviews
         review.date_should_end = None
@@ -471,14 +602,14 @@ def assign_reviewers(review, list_of_users, route):
     start_review_route(review, new_reviewers, route)
 
     # Remove the Decision for obsolete reviewers
-    Decision.objects.filter(review=review,
-                            reviewer__in=obsolete_reviewers).delete()
+    Decision.objects.filter(review=review, reviewer__in=obsolete_reviewers).delete()
 
     review.save()
 
     # Finally, update the review process
     # This prevents it waiting for removed reviewers
     review.update_go()
+
 
 def straight_to_revision(review):
     """This action by the secretary in ReviewAssignForm bypasses


### PR DESCRIPTION
Some fixes for a two small issues. 

the fix for #581 is pretty self explanatory.

For the issue #563, I updated the `update_go()` of `Review`, as Ty suggested. Please check if this is in the correct spot ... In my testing this works as expected.

Furthermore, I'd appreciate feedback on the text of the e-mail. It's pretty bare bones, but gets the job done, with an overview of all decisions.

PS. I accidentally blacked review_utils.py, but undid it, because it made the diff unreadable.