### PR TITLE
Give privileged groups archive access regardless of Humanities affiliation

### DIFF
--- a/fetc/saml_settings.example.py
+++ b/fetc/saml_settings.example.py
@@ -16,6 +16,7 @@ For detailed documentation on SAML and the CDH Federated Auth library, please
 consult the CDH Federated Authentication docs:
 https://centrefordigitalhumanities.github.io/Federated-Authentication-Docs/
 """
+
 import os
 
 # Import all default SAML settings from the library, we override some later

--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/1.8/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.8/ref/settings/
 """
+
 import os
 
 from django.core.exceptions import ImproperlyConfigured

--- a/fetc/urls.py
+++ b/fetc/urls.py
@@ -4,6 +4,7 @@ URL Configuration
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/1.8/topics/http/urls/
 """
+
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin

--- a/main/utils.py
+++ b/main/utils.py
@@ -11,6 +11,7 @@ import pdftotext
 from docx2txt import docx2txt
 
 from main.models import Faculty
+from fetc import constants
 
 YES_NO = [(True, _("ja")), (False, _("nee"))]
 
@@ -145,10 +146,11 @@ def can_view_archive(user):
     if user.is_superuser:
         return True
     privileged_groups = [
-        "AK",
-        "LK",
-        "Secretaris",
-        "Primaire secretaris",
+        constants.GROUP_CHAIR,
+        constants.GROUP_GENERAL_CHAMBER,
+        constants.GROUP_LINGUISTICS_CHAMBER,
+        constants.GROUP_SECRETARY,
+        constants.GROUP_PRIMARY_SECRETARY,
     ]
     user_groups = user.groups.values_list(
         "name",

--- a/main/utils.py
+++ b/main/utils.py
@@ -134,6 +134,27 @@ def get_document_contents(file: FieldFile) -> str:
 def is_member_of_faculty(user, faculty):
     return user.faculties.filter(internal_name=faculty).exists()
 
-
 def is_member_of_humanities(user):
     return is_member_of_faculty(user, Faculty.InternalNames.HUMANITIES)
+
+def can_view_archive(user):
+    if not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    privileged_groups = [
+        "AK",
+        "LK",
+        "Secretaris",
+        "Primaire secretaris",
+    ]
+    user_groups = user.groups.values_list(
+        "name",
+        flat=True,
+    )
+    for group in user_groups:
+        if group in privileged_groups:
+            return True
+    # If our tests are inconclusive,
+    # check for Humanities affiliation
+    return is_member_of_humanities(user)

--- a/main/utils.py
+++ b/main/utils.py
@@ -134,8 +134,10 @@ def get_document_contents(file: FieldFile) -> str:
 def is_member_of_faculty(user, faculty):
     return user.faculties.filter(internal_name=faculty).exists()
 
+
 def is_member_of_humanities(user):
     return is_member_of_faculty(user, Faculty.InternalNames.HUMANITIES)
+
 
 def can_view_archive(user):
     if not user.is_authenticated:

--- a/main/views.py
+++ b/main/views.py
@@ -32,7 +32,7 @@ from django.views.generic.detail import SingleObjectMixin
 
 from interventions.models import Intervention
 from main.models import Faculty, SystemMessage
-from main.utils import is_member_of_humanities
+from main.utils import is_member_of_humanities, can_view_archive
 from observations.models import Observation
 from proposals.models import Proposal
 from reviews.models import Review
@@ -325,6 +325,16 @@ class FacultyRequiredMixin(UserPassesTestMixin):
 
 class HumanitiesRequiredMixin(FacultyRequiredMixin):
     faculty_required = Faculty.InternalNames.HUMANITIES
+
+
+class HumanitiesOrPrivilegeRequiredMixin(HumanitiesRequiredMixin):
+    """
+    Checks for Humanities faculty affiliation, but also lets in users belonging
+    to a privileged set of groups.
+    """
+
+    def test_func(self, user):
+        return can_view_archive(user)
 
 
 class UserAllowedMixin(SingleObjectMixin):

--- a/main/views.py
+++ b/main/views.py
@@ -4,7 +4,8 @@ from urllib.parse import urlparse, urlunparse
 import ldap
 import os
 
-from braces.views import LoginRequiredMixin, GroupRequiredMixin
+from braces.views import LoginRequiredMixin, GroupRequiredMixin, \
+    UserPassesTestMixin
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
@@ -290,7 +291,7 @@ class AllowErrorsOnBackbuttonMixin(object):
             return super(AllowErrorsOnBackbuttonMixin, self).form_invalid(form)
 
 
-class FacultyRequiredMixin:
+class FacultyRequiredMixin(UserPassesTestMixin):
     """A clone of GroupRequiredMixin, but checking faculties instead"""
 
     faculty_required = None
@@ -315,16 +316,11 @@ class FacultyRequiredMixin:
         )
         return set(faculty).intersection(set(user_faculties))
 
-    def dispatch(self, request, *args, **kwargs):
-        self.request = request
+    def test_func(self, user):
         in_faculty = False
-        if request.user.is_authenticated:
+        if user.is_authenticated:
             in_faculty = self.check_membership(self.get_faculty_required())
-
-        if not in_faculty:
-            return self.handle_no_permission(request)
-
-        return super().dispatch(request, *args, **kwargs)
+        return in_faculty
 
 
 class HumanitiesRequiredMixin(FacultyRequiredMixin):

--- a/main/views.py
+++ b/main/views.py
@@ -4,8 +4,7 @@ from urllib.parse import urlparse, urlunparse
 import ldap
 import os
 
-from braces.views import LoginRequiredMixin, GroupRequiredMixin, \
-    UserPassesTestMixin
+from braces.views import LoginRequiredMixin, GroupRequiredMixin, UserPassesTestMixin
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages

--- a/main/views.py
+++ b/main/views.py
@@ -326,7 +326,7 @@ class HumanitiesRequiredMixin(FacultyRequiredMixin):
     faculty_required = Faculty.InternalNames.HUMANITIES
 
 
-class HumanitiesOrPrivilegeRequiredMixin(HumanitiesRequiredMixin):
+class HumanitiesOrPrivilegeRequiredMixin(UserPassesTestMixin):
     """
     Checks for Humanities faculty affiliation, but also lets in users belonging
     to a privileged set of groups.

--- a/proposals/menus.py
+++ b/proposals/menus.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from menu import Menu, MenuItem
 
-from main.utils import is_member_of_humanities, is_secretary
+from main.utils import is_secretary, can_view_archive
 
 new_proposal_menu = (
     MenuItem(
@@ -90,13 +90,13 @@ Menu.add_item(
 archive_menu = (
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Algemene Kamer"),
-        reverse("proposals:archive", args=["AK"]),
-        check=lambda x: is_member_of_humanities(x.user),
+        reverse("proposals:archive", args=['AK']),
+        check=lambda x: can_view_archive(x.user),
     ),
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Linguïstiek Kamer"),
-        reverse("proposals:archive", args=["LK"]),
-        check=lambda x: is_member_of_humanities(x.user),
+        reverse("proposals:archive", args=['LK']),
+        check=lambda x: can_view_archive(x.user),
     ),
     MenuItem(
         _("Site-export"),
@@ -113,6 +113,6 @@ Menu.add_item(
         "#",
         slug="archive",  # needed for sub-menu!
         children=archive_menu,
-        check=lambda x: x.user.is_authenticated and is_member_of_humanities(x.user),
-    ),
+        check=lambda x: can_view_archive(x.user),
+    )
 )

--- a/proposals/menus.py
+++ b/proposals/menus.py
@@ -90,12 +90,12 @@ Menu.add_item(
 archive_menu = (
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Algemene Kamer"),
-        reverse("proposals:archive", args=['AK']),
+        reverse("proposals:archive", args=["AK"]),
         check=lambda x: can_view_archive(x.user),
     ),
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Linguïstiek Kamer"),
-        reverse("proposals:archive", args=['LK']),
+        reverse("proposals:archive", args=["LK"]),
         check=lambda x: can_view_archive(x.user),
     ),
     MenuItem(
@@ -114,5 +114,5 @@ Menu.add_item(
         slug="archive",  # needed for sub-menu!
         children=archive_menu,
         check=lambda x: can_view_archive(x.user),
-    )
+    ),
 )

--- a/proposals/utils/validate_proposal.py
+++ b/proposals/utils/validate_proposal.py
@@ -4,6 +4,7 @@ forms and their validation code.
 
 Used for the submit page, to check if a user has completed the proposal.
 """
+
 from collections import OrderedDict
 
 from braces.forms import UserKwargModelFormMixin

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -171,9 +171,7 @@ onderzoeker of eindverantwoordelijke bij betrokken bent."
 
 
 class ProposalUsersOnlyArchiveView(
-    HumanitiesOrPrivilegeRequiredMixin,
-    CommitteeMixin,
-    BaseProposalsView
+    HumanitiesOrPrivilegeRequiredMixin, CommitteeMixin, BaseProposalsView
 ):
     template_name = "proposals/proposal_private_archive.html"
 

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -20,7 +20,7 @@ from main.views import (
     AllowErrorsOnBackbuttonMixin,
     CreateView,
     DeleteView,
-    HumanitiesRequiredMixin,
+    HumanitiesOrPrivilegeRequiredMixin,
     UpdateView,
     UserAllowedMixin,
 )
@@ -171,7 +171,9 @@ onderzoeker of eindverantwoordelijke bij betrokken bent."
 
 
 class ProposalUsersOnlyArchiveView(
-    HumanitiesRequiredMixin, CommitteeMixin, BaseProposalsView
+    HumanitiesOrPrivilegeRequiredMixin,
+    CommitteeMixin,
+    BaseProposalsView
 ):
     template_name = "proposals/proposal_private_archive.html"
 


### PR DESCRIPTION
Currently it's kind of weird that a secretary or chamber member can't view the archive if they're not in the humanities faculty. This PR resolves this by allowing privileged groups in.

Notes:

* I initially changed `FacultyRequiredMixin` to use `UserPassesTestMixin` to be able to chain it with the new mixin. But once I had written the utility function for the menus, I realized this was ultimately unnecessary. Because I do believe `UserPassesTestMixin` offers more flexibility, I left this change in. But I'm happy to revert it, there's an argument to be made for both methods.