### PR TITLE
Redirect supervisor to the right update page

### DIFF
--- a/reviews/templates/reviews/decision_form.html
+++ b/reviews/templates/reviews/decision_form.html
@@ -16,7 +16,6 @@
             <h2>{% trans "Aanvraag beoordelen" %}</h2>
             {% with proposal=decision.review.proposal %}
                 {% url 'proposals:pdf' proposal.id as pdf_url %}
-                {% url 'proposals:update' proposal.id as update_url %}
                 {% if user != proposal.supervisor %}
                     <p>
                         {% blocktrans trimmed with title=proposal.title refnum=proposal.reference_number chamber=proposal.reviewing_committee %}

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -547,6 +547,26 @@ class DecisionUpdateView(
     model = Decision
     form_class = DecisionForm
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # Supervisors get the chance to update the proposal, but we have
+        # multiple update views for different types of proposals.
+        if self.object.review.proposal.is_pre_approved:
+            context["update_url"] = reverse(
+                "proposals:update_pre_approved", args=[self.object.review.proposal.pk]
+            )
+        elif self.object.review.proposal.is_pre_assessment:
+            context["update_url"] = reverse(
+                "proposals:update_pre", args=[self.object.review.proposal.pk]
+            )
+        else:
+            context["update_url"] = reverse(
+                "proposals:update", args=[self.object.review.proposal.pk]
+            )
+
+        return context
+
     def get_success_url(self):
         obj = self.get_object()
         if obj.review.is_committee_review:


### PR DESCRIPTION
During initial triage of the issue, I saw that actually fixing the issue was easier than to write it. So here we go.

This PR makes sure supervisors get the right update link on their 'decide page'. Previously, it would always redirect to the general one. 

(I also moved the link-logic to python to keep the template sane).