### PR TITLE
fix: fix broken tests due to invalid fixture names

### DIFF
--- a/proposals/templates/proposals/proposal_pdf.html
+++ b/proposals/templates/proposals/proposal_pdf.html
@@ -11,7 +11,6 @@
         @font-face {
             font-family: "Open Sans";
             src: url('proposals/static/proposals/pdf_font/OpenSans-Regular.ttf');
-            font-weight: 400;
         }
 
         @font-face {
@@ -23,7 +22,6 @@
         @font-face {
             font-family: "Open Sans";
             src: url('proposals/static/proposals/pdf_font/OpenSans-Italic.ttf');
-            font-weight: 400;
             font-style: italic;
         }
 

--- a/proposals/tests/misc_tests.py
+++ b/proposals/tests/misc_tests.py
@@ -26,7 +26,7 @@ class MiscProposalTestCase(TestCase):
         "compensations",
         "recruitments",
         "settings",
-        "registrations",
+        "00_registrations",
         "groups",
         "institutions",
     ]

--- a/proposals/tests/proposal_submission_tests.py
+++ b/proposals/tests/proposal_submission_tests.py
@@ -1,7 +1,8 @@
+import logging
+
 from django.contrib.auth.models import User, Group, AnonymousUser
 from django.conf import settings
 from django.test import TestCase
-from django.core.management import call_command
 
 from main.tests import BaseViewTestCase
 from proposals.models import Proposal, Relation
@@ -37,6 +38,11 @@ class BaseProposalTestCase(TestCase):
     def setUp(self):
         self.setup_users()
         self.setup_proposal()
+
+        # Disable logging warnings and all levels below
+        # Our (pdf) code logs warnings that are not relevant to the tests
+        # ERROR and CRITICAL are still logged
+        logging.disable(logging.WARN)
 
     def setup_users(self):
         self.secretary = User.objects.create_user(

--- a/proposals/tests/proposal_submission_tests.py
+++ b/proposals/tests/proposal_submission_tests.py
@@ -28,8 +28,8 @@ class BaseProposalTestCase(TestCase):
         "recruitments",
         "specialdetails",
         "traits",
-        "registrationkinds",
-        "registrations",
+        "00_registrations",
+        "01_registrationkinds",
         "testing/test_users",
         "testing/test_proposals",
     ]

--- a/reviews/tests.py
+++ b/reviews/tests.py
@@ -30,8 +30,8 @@ class BaseReviewTestCase(TestCase):
     fixtures = [
         "relations",
         "compensations",
-        "registrations",
-        "registrationkinds",
+        "00_registrations",
+        "01_registrationkinds",
         "agegroups",
         "groups",
         "institutions",


### PR DESCRIPTION
My bad; should've caught this when I made this change. 

Edit:
I also cleaned up the test-runner output with the other two commits:
 
The first removes the 'font-weight' spam. Turns out our PDF generator has a pretty strange CSS parser that does not allow `font-weight: 400` (as 400 is the default) in the font definition. Any other CSS parser thinks this is fine, if redundant, but well... 


The 'Not saving PDF' warning spam is disabled by disabling all log levels below WARNING (inclusive) for the proposal-submit tests only. 