### PR TITLE
HOTFIX: allow secretary-induced changes to update the canonical PDF

### DIFF
--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -372,6 +372,16 @@ class ProposalUpdateDataManagement(GroupRequiredMixin, generic.UpdateView):
     form_class = ProposalUpdateDataManagementForm
     group_required = settings.GROUP_SECRETARY
 
+    def form_valid(self, form):
+        ret = super().form_valid(form)
+        # Always regenerate the PDF after updating the DMP
+        # This is necessary, as the canonical PDF protection might already
+        # have kicked in if the secretary changes the documents later than
+        # we initially expected.
+        self.object.generate_pdf(force_overwrite=True)
+
+        return ret
+
     def get_success_url(self):
         """Continue to the URL specified in the 'next' POST parameter"""
         return reverse('reviews:detail', args=[self.object.latest_review().pk])

--- a/studies/views/study_views.py
+++ b/studies/views/study_views.py
@@ -159,6 +159,16 @@ class StudyUpdateAttachments(braces.GroupRequiredMixin, generic.UpdateView):
     form_class = StudyUpdateAttachmentsForm
     group_required = settings.GROUP_SECRETARY
 
+    def form_valid(self, form):
+        ret = super().form_valid(form)
+        # Always regenerate the PDF after updating any study documents
+        # This is necessary, as the canonical PDF protection might already
+        # have kicked in if the secretary changes the documents later than
+        # we initially expected.
+        self.object.proposal.generate_pdf(force_overwrite=True)
+
+        return ret
+
     def get_success_url(self):
         """Continue to the URL specified in the 'next' POST parameter"""
         return self.request.POST.get('next', '/')


### PR DESCRIPTION
**This PR targets acceptation, in order to quickly deploy this fix**

This is a band-aid fix for #617, which only ensures the PDF is regenerated if the secretary updates one of the uploaded documents.

There is still the question why there were problems with this, but having taken a quick look at the code I think I know. I'll update that issue with my theory. (Which will still warrant this change btw).