### PR TITLE
fix: prevent submission on back actions

### DIFF
--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -481,7 +481,8 @@ class ProposalSubmit(
         # Checks for practice proposals and starting the right
         # kind of review happen over there.
         proposal = form.instance
-        start_review(proposal)
+        if 'save_back' not in self.request.POST and 'js-redirect-submit' not in self.request.POST:
+            start_review(proposal)
         return success_response
 
     def get_next_url(self):


### PR DESCRIPTION
Cherry-pick from #603 

This PR re-introduces a check that prevents proposal submission by clicking the back button. This was accidentally removed during a refactor of the start review logic. 

As this problem is blocking, it must be merged before #593 is. 