### PR TITLE
fix: apply is_committee_review to filter in get_committee_decisions()

### DIFF
--- a/reviews/models.py
+++ b/reviews/models.py
@@ -80,6 +80,7 @@ class Review(models.Model):
 
                     start_assignment_phase(self.proposal)
                     self.stage = self.Stages.CLOSED
+                    self.save()
                 # On NO-GO, reset the Proposal status
                 else:
                     # See comment above

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -160,10 +160,15 @@ class CommitteeMembersWorkloadView(
 
         decisions = self.get_committee_decisions()
 
+        # This is done to include in the base_filter, decisions which are taken
+        # today. The comparison was having some troubles due to different
+        #time formats.
+        end_date = self.end_date + timedelta(days=1)
+
         reviewers = get_user_model().objects.filter(decision__in=decisions)
         base_filter = Q(
             decision__review__date_start__gt=self.start_date,
-            decision__review__date_start__lt=self.end_date,
+            decision__review__date_start__lte=end_date,
         )
         return reviewers.annotate(
             total=Count("decision", filter=base_filter),

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -132,7 +132,8 @@ class CommitteeMembersWorkloadView(
 
     def get_committee_decisions(self):
         decisions = Decision.objects.filter(
-            review__proposal__reviewing_committee=self.committee
+            review__proposal__reviewing_committee=self.committee,
+            review__is_committee_review = True,
         ).select_related(
             "reviewer",
             "review",
@@ -163,7 +164,6 @@ class CommitteeMembersWorkloadView(
         base_filter = Q(
             decision__review__date_start__gt=self.start_date,
             decision__review__date_start__lt=self.end_date,
-            decision__review__stage__gt=Review.Stages.SUPERVISOR,
         )
         return reviewers.annotate(
             total=Count("decision", filter=base_filter),

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -162,7 +162,7 @@ class CommitteeMembersWorkloadView(
 
         # This is done to include in the base_filter, decisions which are taken
         # today. The comparison was having some troubles due to different
-        #time formats.
+        # time formats.
         end_date = self.end_date + timedelta(days=1)
 
         reviewers = get_user_model().objects.filter(decision__in=decisions)

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -133,7 +133,7 @@ class CommitteeMembersWorkloadView(
     def get_committee_decisions(self):
         decisions = Decision.objects.filter(
             review__proposal__reviewing_committee=self.committee,
-            review__is_committee_review = True,
+            review__is_committee_review=True,
         ).select_related(
             "reviewer",
             "review",


### PR DESCRIPTION
Fixes #632. So, because supervisor reviews now get closed, the filter for getting the queryset for `CommitteeMembersWorkloadView` was not working properly anymore. However, it was an easy fix using the ol' `is_committee_review` attribute. This will make Desiree happy, so hopefully we can deploy this quick-ish.