### PR TITLE
fix: remove explicit protocol prefix from file links

### DIFF
--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -158,7 +158,7 @@ MENU_SELECT_PARENTS = True
 MENU_HIDE_EMPTY = False
 
 # Base URL
-BASE_URL = "127.0.0.1:8000"
+BASE_URL = "https://127.0.0.1:8000"
 
 # CSRF Setting
 CSRF_FAILURE_VIEW = "main.error_views.csrf_failure"

--- a/proposals/utils/pdf_diff_logic.py
+++ b/proposals/utils/pdf_diff_logic.py
@@ -286,7 +286,7 @@ class RowValue:
     def handle_field_file(self, field_file):
         if field_file:
             output = format_html(
-                "<a href=https://{}>{}</a>",
+                '<a href="{}">{}</a>',
                 f"{settings.BASE_URL}{field_file.url}",
                 _("Download"),
             )


### PR DESCRIPTION
Fixes #636 

Also adds quotations around the URL.

The development `BASE_URL` in settings.py now also contains a `https://` for consistency with server deployments.