### PR TITLE
Feat/supervisor decide on detail view

### DIFF
--- a/reviews/templates/reviews/action_explaination.html
+++ b/reviews/templates/reviews/action_explaination.html
@@ -49,10 +49,10 @@
         </li>
     </ul>
 </div>
-<div class="col-12 {% if request.user|is_secretary %}col-md-6{% endif %}">
-    <h3>{% trans "Uitleg secretaris" %}</h3>
-    <ul>
-        {% if request.user|is_secretary %}
+{% if request.user|is_secretary %}
+    <div class="col-12 {% if request.user|is_secretary %}col-md-6{% endif %}">
+        <ul>
+            <h3>{% trans "Uitleg secretaris" %}</h3>
             <li>
                 {% blocktrans trimmed %}
                     Klik op
@@ -107,6 +107,6 @@
                     van de bevestigingsbrief te veranderen.
                 {% endblocktrans %}
             </li>
-        {% endif %}
-    </ul>
-</div>
+        </ul>
+    </div>
+{% endif %}

--- a/reviews/templates/reviews/action_explaination.html
+++ b/reviews/templates/reviews/action_explaination.html
@@ -50,7 +50,7 @@
     </ul>
 </div>
 {% if request.user|is_secretary %}
-    <div class="col-12 {% if request.user|is_secretary %}col-md-6{% endif %}">
+    <div class="col-12 col-md-6">
         <ul>
             <h3>{% trans "Uitleg secretaris" %}</h3>
             <li>

--- a/reviews/utils/review_actions.py
+++ b/reviews/utils/review_actions.py
@@ -85,7 +85,7 @@ class DecideAction(ReviewAction):
         user = self.user
         review = self.review
 
-        if review.stage != review.Stages.COMMISSION:
+        if review.stage in (review.Stages.COMMISSION, review.Stages.SUPERVISOR):
             return False
 
         try:


### PR DESCRIPTION
Fixes #612. There is no supervisor decide button on the review detail page. Granted this is a super niche edge case, where someone, has to be both a member of a chamber AND the supervisor, but I guess this did occur. This should fix the issue.

I also noticed that the text "Uitleg secretaris" on action_explanation.html, was outside the if-statement which checks if a user is a secretary, so this always rendered, which I fixed too. I didn´t really feel this warranted creating an issue, so I just pushed this here. I will make an issue for documentation, if you would prefer.