### PR TITLE
Log errors during faculty processing

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -163,6 +163,6 @@ class SamlUserProxy(User):
                     continue
 
                 faculty_obj.users.add(self)
-            except Exception as e:
-                logger.error(f"Error processing faculty for user: {e}", exc_info=True)
+            except:  # noQA
+                logger.error(f"Error processing faculty for user", exc_info=True)
                 continue

--- a/main/models.py
+++ b/main/models.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 logger = logging.getLogger("ethics.main")
 
+
 class YesNoDoubt(models.TextChoices):
     YES = "Y", _("ja")
     NO = "N", _("nee")

--- a/main/models.py
+++ b/main/models.py
@@ -1,8 +1,11 @@
+import logging
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
+logger = logging.getLogger("ethics.main")
 
 class YesNoDoubt(models.TextChoices):
     YES = "Y", _("ja")
@@ -159,6 +162,6 @@ class SamlUserProxy(User):
                     continue
 
                 faculty_obj.users.add(self)
-            except:
-                # Just ignore any errors...
+            except Exception as e:
+                logger.error(f"Error processing faculty for user: {e}", exc_info=True)
                 continue


### PR DESCRIPTION
**Note: this targets acceptation to hasten deployment**

I took a look at how prevalent #611 is... it's bad. Over 85% of new users this year do not have a faculty attached.

Before I start accusing ITS, I want to see if we're at fault. So, this PR adds a log call to the except we've been ignoring. This should show up in Sentry. 