### PR TITLE
fix: ensure faculty is saved on user create

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -162,6 +162,9 @@ class SamlUserProxy(User):
                 if faculty_obj.users.filter(pk=self.pk).exists():
                     continue
 
+                # Save the user to ensure the user is saved before adding the faculty
+                self.save()
+
                 faculty_obj.users.add(self)
             except:  # noQA
                 logger.error(f"Error processing faculty for user", exc_info=True)


### PR DESCRIPTION
Re #611 

Note: once again this PR targets acceptation, as I deem this fix important enough to deploy quickly. It can be cleanly applied to develop too tho, if that's what ya'll prefer

I've tested if the problem is related to the first login, and while I was skeptical it really was this problem, it does seem to be. So, this PR adds one line of code to ensure the user model is saved first. As this 'field' is the last to be 'set', it should be save to do. (And even if that's not the case, our try/catch will prevent any real problems for the user).

I'm still a bit mystified why the percentage of users without a faculty set is this high if it's only a problem for initial logins... But this fix should at least aleviate the problem a bit. 