### PR TITLE
Feature/break up page 1

### DIFF
--- a/main/templates/base/fetc_form_base.html
+++ b/main/templates/base/fetc_form_base.html
@@ -3,7 +3,9 @@
 {% block content %}
     <div class="uu-container">
         {# A block one can use to insert content before the stepper/form container #}
-        {% block pre-form-container-content %}{% endblock %}
+        <div class="col-12 text-center">
+            {% block pre-form-container-content %}{% endblock %}
+        </div>
 
         {# todo: responsive design #}
         <div class="col-3">

--- a/main/templates/base/fetc_form_base.html
+++ b/main/templates/base/fetc_form_base.html
@@ -4,7 +4,8 @@
     <div class="uu-container">
         {# A block one can use to insert content before the stepper/form container #}
         {% include "proposals/practice_or_supervisor_warning.html" %}
-            {% block pre-form-container-content %}{% endblock %}
+        {% block pre-form-container-content %}{% endblock %}
+
         {# todo: responsive design #}
         <div class="col-3">
             {% block stepper %}

--- a/main/templates/base/fetc_form_base.html
+++ b/main/templates/base/fetc_form_base.html
@@ -3,10 +3,8 @@
 {% block content %}
     <div class="uu-container">
         {# A block one can use to insert content before the stepper/form container #}
-        <div class="col-12 text-center">
+        {% include "proposals/practice_or_supervisor_warning.html" %}
             {% block pre-form-container-content %}{% endblock %}
-
-        </div>
         {# todo: responsive design #}
         <div class="col-3">
             {% block stepper %}

--- a/main/templates/base/fetc_form_base.html
+++ b/main/templates/base/fetc_form_base.html
@@ -5,8 +5,8 @@
         {# A block one can use to insert content before the stepper/form container #}
         <div class="col-12 text-center">
             {% block pre-form-container-content %}{% endblock %}
-        </div>
 
+        </div>
         {# todo: responsive design #}
         <div class="col-3">
             {% block stepper %}

--- a/main/views.py
+++ b/main/views.py
@@ -480,7 +480,9 @@ class UserAllowedMixin(SingleObjectMixin):
             if self.request.user not in supervisor:
                 raise PermissionDenied
         else:
-            if self.request.user not in applicants | supervisor:
+            if (self.request.user not in applicants | supervisor and
+                self.request.user != proposal.created_by
+                ):
                 raise PermissionDenied
 
         return obj

--- a/main/views.py
+++ b/main/views.py
@@ -480,9 +480,10 @@ class UserAllowedMixin(SingleObjectMixin):
             if self.request.user not in supervisor:
                 raise PermissionDenied
         else:
-            if (self.request.user not in applicants | supervisor and
-                self.request.user != proposal.created_by
-                ):
+            if (
+                self.request.user not in applicants | supervisor
+                and self.request.user != proposal.created_by
+            ):
                 raise PermissionDenied
 
         return obj

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -33,33 +33,146 @@ from cdh.core.forms import (
     TemplatedModelForm,
 )
 
-
 class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
     class Meta:
         model = Proposal
         fields = [
-            "is_pre_approved",
+            "title",
+            "date_start",
             "institution",
+        ]
+        widgets = {
+            "date_start": DateInput(),
+            "institution": BootstrapRadioSelect(),
+        }
+        error_messages = {
+            "title": {
+                "unique": _("Er bestaat al een aanvraag met deze titel."),
+            },
+        }
+
+    def __init__(self, *args, **kwargs):
+        """
+        - Make sure all non-revision/non-amendment studies have an unique name
+        """
+
+        super(ProposalForm, self).__init__(*args, **kwargs)
+        self.fields["institution"].empty_label = None
+
+        # Only revisions or amendments are allowed to have a title that's not
+        # unique.
+        if not self.instance or not self.instance.is_revision:
+            self.fields["title"].validators.append(UniqueTitleValidator(self.instance))
+
+    def clean(self):
+        cleaned_data = super(ProposalForm, self).clean()
+
+        self.mark_soft_required(cleaned_data, "date_start")
+
+class ResearcherForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+    class Meta:
+        model = Proposal
+        fields = [
             "relation",
             "student_program",
             "student_context",
             "student_context_details",
             "student_justification",
             "supervisor",
+        ]
+        widgets = {
+            "relation": BootstrapRadioSelect(),
+            "student_context": BootstrapRadioSelect(),
+            "supervisor": SearchableSelectWidget(),
+        }
+
+    def __init__(self, *args, **kwargs):
+        """
+        - Remove empty label from relation field
+        - Don't allow to pick yourself or a superuser as supervisor, unless you already are
+        - Add a None-option for supervisor
+        - If this is a practice Proposal, limit the relation choices
+        """
+
+        super(ResearcherForm, self).__init__(*args, **kwargs)
+        self.fields["relation"].empty_label = None
+        self.fields["student_context"].empty_label = None
+
+        supervisors = get_user_model().objects.exclude(pk=self.user.pk)
+
+        instance = kwargs.get("instance")
+
+        # If you are already defined as a supervisor, we have to set it to you
+        if instance is not None and instance.supervisor == self.user:
+            supervisors = [self.user]
+
+        self.fields["supervisor"].choices = [
+            (None, _("Selecteer..."))
+        ] + get_users_as_list(supervisors)
+
+        if instance.in_course:
+            self.fields["relation"].queryset = Relation.objects.filter(
+                check_in_course=True
+            )
+            self.fields["supervisor"].label = _("Docent")
+            self.fields["supervisor"].help_text = _(
+                "Vul hier de docent van \
+de cursus in waarbinnen je deze portal moet doorlopen. De docent kan na afloop \
+de aanvraag inkijken in de portal. De studie zal niet in het semipublieke archief \
+van het FETC-GW worden opgenomen."
+            )
+
+        if instance.is_pre_assessment:
+            self.fields["relation"].queryset = Relation.objects.filter(
+                check_pre_assessment=True
+            )
+
+    def clean(self):
+        """
+        Check for conditional requirements:
+        - If relation needs supervisor, make sure supervisor is set
+        - If relation needs supervisor, make sure supervisor is a different person
+        """
+        cleaned_data = super(ResearcherForm, self).clean()
+
+        relation = cleaned_data.get("relation")
+        supervisor = cleaned_data.get("supervisor")
+
+        if relation:
+            if relation.needs_supervisor and not supervisor:
+                error = forms.ValidationError(
+                    _("Je dient een promotor/begeleider op te geven."), code="required"
+                )
+                self.add_error("supervisor", error)
+
+            if relation.needs_supervisor and supervisor == self.user and self.instance.status != Proposal.Statuses.SUBMITTED_TO_SUPERVISOR:
+                error = forms.ValidationError(
+                    _("Je kunt niet jezelf als promotor/begeleider opgeven.")
+                )
+                self.add_error("supervisor", error)
+
+            if relation.check_in_course:
+                self.mark_soft_required(cleaned_data, "student_context")
+                self.mark_soft_required(cleaned_data, "student_justification")
+
+        self.check_dependency_singular(
+            cleaned_data, "relation", "check_in_course", "student_program"
+        )
+        self.check_dependency_singular(
+            cleaned_data, "student_context", "needs_details", "student_context_details"
+        )
+        self.check_dependency_singular(
+            cleaned_data, "relation", "check_in_course", "student_justification"
+        )
+
+class OtherResearchersForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+    class Meta:
+        model = Proposal
+        fields = [
             "other_applicants",
             "applicants",
             "other_stakeholders",
             "stakeholders",
-            "date_start",
-            "title",
-            "summary",
-            "pre_assessment_pdf",
-            "funding",
-            "funding_details",
-            "funding_name",
-            "pre_approval_institute",
-            "pre_approval_pdf",
-            "self_assessment",
         ]
         labels = {
             "other_stakeholders": mark_safe_lazy(
@@ -72,171 +185,50 @@ class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalMode
             ),
         }
         widgets = {
-            "is_pre_approved": BootstrapRadioSelect(choices=YES_NO),
-            "institution": BootstrapRadioSelect(),
-            "relation": BootstrapRadioSelect(),
-            "student_context": BootstrapRadioSelect(),
             "other_applicants": BootstrapRadioSelect(choices=YES_NO),
             "other_stakeholders": BootstrapRadioSelect(choices=YES_NO),
-            "date_start": DateInput(),
-            "summary": forms.Textarea(attrs={"cols": 50}),
-            "funding": BootstrapCheckboxSelectMultiple(),
             "applicants": SearchableSelectWidget(),
-            "supervisor": SearchableSelectWidget(),
-        }
-        error_messages = {
-            "title": {
-                "unique": _("Er bestaat al een aanvraag met deze titel."),
-            },
         }
 
     _soft_validation_fields = [
-        "relation",
         "other_applicants",
         "other_stakeholders",
         "stakeholders",
-        "summary",
-        "pre_assessment_pdf",
-        "funding",
-        "funding_details",
-        "funding_name",
-        "pre_approval_institute",
-        "pre_approval_pdf",
-        "self_assessment",
     ]
 
     def __init__(self, *args, **kwargs):
         """
-        - Remove empty label from relation field
-        - Make sure all non-revision/non-amendment studies have an unique name
-        - Don't allow to pick yourself or a superuser as supervisor, unless you already are
-        - Add a None-option for supervisor
         - Don't allow to pick a superuser as applicant
-        - If this is a practice Proposal, limit the relation choices
-        - Remove summary for preliminary assessment Proposals
-        - Set pre_assessment_pdf required for preliminary assessment Proposals, otherwise remove
         """
-        in_course = kwargs.pop("in_course", False)
-        is_pre_approved = kwargs.pop("is_pre_approved", False)
-
-        # First, try to determine this value from the kwargs. Otherwise, try
-        # to get it from the instance. If that fails, assume False
-        self.is_pre_assessment = kwargs.pop(
-            "is_pre_assessment",
-            getattr(kwargs.get("instance"), "is_pre_assessment", False),
-        )
-
-        super(ProposalForm, self).__init__(*args, **kwargs)
-        self.fields["relation"].empty_label = None
-        self.fields["institution"].empty_label = None
-        self.fields["student_context"].empty_label = None
+        super(OtherResearchersForm, self).__init__(*args, **kwargs)
+        self.instance = kwargs.get("instance")
 
         # Needed to set the widget into multiple mode
         # TODO: write a DSC widget that has this enabled by default
         self.fields["applicants"].widget.allow_multiple_selected = True
 
-        # Only revisions or amendments are allowed to have a title that's not
-        # unique.
-        if not self.instance or not self.instance.is_revision:
-            self.fields["title"].validators.append(UniqueTitleValidator(self.instance))
-
         applicants = get_user_model().objects.all()
-
-        supervisors = applicants.exclude(pk=self.user.pk)
-
-        instance = kwargs.get("instance")
 
         self.fields["other_stakeholders"].label = mark_safe(
             self.fields["other_stakeholders"].label
         )
 
-        # If you are already defined as a supervisor, we have to set it to you
-        if instance is not None and instance.supervisor == self.user:
-            supervisors = [self.user]
-
-        self.fields["supervisor"].choices = [
-            (None, _("Selecteer..."))
-        ] + get_users_as_list(supervisors)
-
         self.fields["applicants"].choices = get_users_as_list(applicants)
-
-        if in_course:
-            self.fields["relation"].queryset = Relation.objects.filter(
-                check_in_course=True
-            )
-            self.fields["supervisor"].label = _("Docent")
-            self.fields["supervisor"].help_text = _(
-                "Vul hier de docent van \
-de cursus in waarbinnen je deze portal moet doorlopen. De docent kan na afloop \
-de aanvraag inkijken in de portal. De studie zal niet in het semipublieke archief \
-van het FETC-GW worden opgenomen."
-            )
-
-        if self.is_pre_assessment:
-            self.fields["relation"].queryset = Relation.objects.filter(
-                check_pre_assessment=True
-            )
-            self.fields["pre_assessment_pdf"].required = True
-            del self.fields["summary"]
-            del self.fields["funding"]
-            del self.fields["funding_details"]
-            del self.fields["funding_name"]
-        else:
-            del self.fields["pre_assessment_pdf"]
-
-        if is_pre_approved:
-            self.fields["pre_approval_institute"].required = True
-            self.fields["pre_approval_pdf"].required = True
-        else:
-            del self.fields["is_pre_approved"]
-            del self.fields["pre_approval_institute"]
-            del self.fields["pre_approval_pdf"]
 
     def clean(self):
         """
         Check for conditional requirements:
-        - If relation needs supervisor, make sure supervisor is set
-        - If relation needs supervisor, make sure supervisor is a different person
         - If other_applicants is checked, make sure applicants are set
         - If other_stakeholders is checked, make sure stakeholders is not empty
-        - Maximum number of words for summary
-        - If this is a pre approved proposal, make sure people say yes to that question
-        - If this is a pre approved proposal, make sure people fill in the correct fields
         - Make sure the user is listed in applicants
         """
-        cleaned_data = super(ProposalForm, self).clean()
-
-        if not self.is_pre_assessment:
-            self.mark_soft_required(cleaned_data, "funding")
-            self.mark_soft_required(cleaned_data, "summary")
-
-        self.mark_soft_required(cleaned_data, "relation")
-        self.mark_soft_required(cleaned_data, "date_start")
-
-        relation = cleaned_data.get("relation")
-        supervisor = cleaned_data.get("supervisor")
-
-        if relation and relation.needs_supervisor and not supervisor:
-            error = forms.ValidationError(
-                _("Je dient een promotor/begeleider op te geven."), code="required"
-            )
-            self.add_error("supervisor", error)
-
-        if relation and relation.needs_supervisor and supervisor == self.user:
-            error = forms.ValidationError(
-                _("Je kunt niet jezelf als promotor/begeleider opgeven.")
-            )
-            self.add_error("supervisor", error)
-
-        if relation.check_in_course:
-            self.mark_soft_required(cleaned_data, "student_context")
-            self.mark_soft_required(cleaned_data, "student_justification")
+        cleaned_data = super(OtherResearchersForm, self).clean()
 
         other_applicants = cleaned_data.get("other_applicants")
         applicants = cleaned_data.get("applicants")
 
         # Always make sure the applicant is actually in the applicants list
-        if self.user not in applicants and self.user != supervisor:
+        if self.user not in applicants and self.user != self.instance.supervisor:
             error = forms.ValidationError(
                 _("Je hebt jezelf niet als onderzoekers geselecteerd."), code="required"
             )
@@ -246,6 +238,80 @@ van het FETC-GW worden opgenomen."
                 _("Je hebt geen andere onderzoekers geselecteerd."), code="required"
             )
             self.add_error("applicants", error)
+
+        self.check_dependency(cleaned_data, "other_stakeholders", "stakeholders")
+
+class FundingForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+    class Meta:
+        model = Proposal
+        fields = [
+            "funding",
+            "funding_details",
+            "funding_name",
+        ]
+        widgets = {
+            "funding": BootstrapCheckboxSelectMultiple(),
+        }
+        error_messages = {
+            "title": {
+                "unique": _("Er bestaat al een aanvraag met deze titel."),
+            },
+        }
+
+    _soft_validation_fields = [
+        "funding",
+        "funding_details",
+        "funding_name",
+    ]
+
+    def clean(self):
+        cleaned_data = super(FundingForm, self).clean()
+
+        self.check_dependency_multiple(
+            cleaned_data, "funding", "needs_details", "funding_details"
+        )
+        self.check_dependency_multiple(
+            cleaned_data, "funding", "needs_name", "funding_name"
+        )
+
+class ResearchGoalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+    class Meta:
+        model = Proposal
+        fields = [
+            "summary",
+            "pre_assessment_pdf",
+            "self_assessment",
+        ]
+        widgets = {
+            "summary": forms.Textarea(attrs={"cols": 50}),
+        }
+
+    _soft_validation_fields = [
+        "summary",
+        "pre_assessment_pdf",
+        "self_assessment",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        """
+        - Remove summary for preliminary assessment Proposals
+        - Set pre_assessment_pdf required for preliminary assessment Proposals, otherwise remove
+        """
+
+        super(ResearchGoalForm, self).__init__(*args, **kwargs)
+        self.instance = kwargs.get("instance")
+
+        if self.instance.is_pre_assessment:
+            self.fields["pre_assessment_pdf"].required = True
+            del self.fields["summary"]
+        else:
+            del self.fields["pre_assessment_pdf"]
+
+    def clean(self):
+        cleaned_data = super(ResearchGoalForm, self).clean()
+
+        if not self.instance.is_pre_assessment:
+            self.mark_soft_required(cleaned_data, "summary")
 
         # Add an error if self_assessment is missing
         self_assessment = cleaned_data.get("self_assessment")
@@ -260,6 +326,47 @@ van het FETC-GW worden opgenomen."
                     code="required",
                 ),
             )
+
+class PreApprovedForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+    class Meta:
+        model = Proposal
+        fields = [
+            "is_pre_approved",
+            "pre_approval_institute",
+            "pre_approval_pdf",
+        ]
+        widgets = {
+            "is_pre_approved": BootstrapRadioSelect(choices=YES_NO),
+        }
+
+    _soft_validation_fields = [
+        "pre_approval_institute",
+        "pre_approval_pdf",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        """
+        - Set pre_assessment_pdf required for preliminary assessment Proposals, otherwise remove
+        """
+
+        super(PreApprovedForm, self).__init__(*args, **kwargs)
+
+        instance = kwargs.get("instance")
+
+        if instance.is_pre_approved:
+            self.fields["pre_approval_institute"].required = True
+            self.fields["pre_approval_pdf"].required = True
+        else:
+            del self.fields["is_pre_approved"]
+            del self.fields["pre_approval_institute"]
+            del self.fields["pre_approval_pdf"]
+
+    def clean(self):
+        """
+        - If this is a pre approved proposal, make sure people say yes to that question
+        - If this is a pre approved proposal, make sure people fill in the correct fields
+        """
+        cleaned_data = super(PreApprovedForm, self).clean()
 
         if "is_pre_approved" in cleaned_data:
             if not cleaned_data["is_pre_approved"]:
@@ -276,24 +383,6 @@ van het FETC-GW worden opgenomen."
             self.check_dependency(
                 cleaned_data, "is_pre_approved", "pre_approval_institute"
             )
-
-        self.check_dependency(cleaned_data, "other_stakeholders", "stakeholders")
-        self.check_dependency_multiple(
-            cleaned_data, "funding", "needs_details", "funding_details"
-        )
-        self.check_dependency_multiple(
-            cleaned_data, "funding", "needs_name", "funding_name"
-        )
-        self.check_dependency_singular(
-            cleaned_data, "relation", "check_in_course", "student_program"
-        )
-        self.check_dependency_singular(
-            cleaned_data, "student_context", "needs_details", "student_context_details"
-        )
-        self.check_dependency_singular(
-            cleaned_data, "relation", "check_in_course", "student_justification"
-        )
-
 
 class ProposalStartPracticeForm(TemplatedForm):
     practice_reason = forms.ChoiceField(

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -33,6 +33,7 @@ from cdh.core.forms import (
     TemplatedModelForm,
 )
 
+
 class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
     class Meta:
         model = Proposal
@@ -69,7 +70,10 @@ class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalMode
 
         self.mark_soft_required(cleaned_data, "date_start")
 
-class ResearcherForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+
+class ResearcherForm(
+    UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm
+):
     class Meta:
         model = Proposal
         fields = [
@@ -145,7 +149,11 @@ van het FETC-GW worden opgenomen."
                 )
                 self.add_error("supervisor", error)
 
-            if relation.needs_supervisor and supervisor == self.user and self.instance.status != Proposal.Statuses.SUBMITTED_TO_SUPERVISOR:
+            if (
+                relation.needs_supervisor
+                and supervisor == self.user
+                and self.instance.status != Proposal.Statuses.SUBMITTED_TO_SUPERVISOR
+            ):
                 error = forms.ValidationError(
                     _("Je kunt niet jezelf als promotor/begeleider opgeven.")
                 )
@@ -165,7 +173,10 @@ van het FETC-GW worden opgenomen."
             cleaned_data, "relation", "check_in_course", "student_justification"
         )
 
-class OtherResearchersForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+
+class OtherResearchersForm(
+    UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm
+):
     class Meta:
         model = Proposal
         fields = [
@@ -241,6 +252,7 @@ class OtherResearchersForm(UserKwargModelFormMixin, SoftValidationMixin, Conditi
 
         self.check_dependency(cleaned_data, "other_stakeholders", "stakeholders")
 
+
 class FundingForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
     class Meta:
         model = Proposal
@@ -274,7 +286,10 @@ class FundingForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModel
             cleaned_data, "funding", "needs_name", "funding_name"
         )
 
-class ResearchGoalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+
+class ResearchGoalForm(
+    UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm
+):
     class Meta:
         model = Proposal
         fields = [
@@ -327,7 +342,10 @@ class ResearchGoalForm(UserKwargModelFormMixin, SoftValidationMixin, Conditional
                 ),
             )
 
-class PreApprovedForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
+
+class PreApprovedForm(
+    UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm
+):
     class Meta:
         model = Proposal
         fields = [
@@ -383,6 +401,7 @@ class PreApprovedForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalM
             self.check_dependency(
                 cleaned_data, "is_pre_approved", "pre_approval_institute"
             )
+
 
 class ProposalStartPracticeForm(TemplatedForm):
     practice_reason = forms.ChoiceField(

--- a/proposals/mixins.py
+++ b/proposals/mixins.py
@@ -18,15 +18,9 @@ from .utils.proposal_utils import pdf_link_callback
 class ProposalMixin(UserFormKwargsMixin):
     model = Proposal
     form_class = ProposalForm
-    success_message = _("Aanvraag %(title)s bewerkt")
 
     def get_next_url(self):
-        """If the Proposal has a Wmo model attached, go to update, else, go to create"""
-        proposal = self.object
-        if hasattr(proposal, "wmo"):
-            return reverse("proposals:wmo_update", args=(proposal.pk,))
-        else:
-            return reverse("proposals:wmo_create", args=(proposal.pk,))
+        return reverse("proposals:researcher", args=(self.object.pk,))
 
 
 class ProposalContextMixin:

--- a/proposals/templates/proposals/funding_form.html
+++ b/proposals/templates/proposals/funding_form.html
@@ -17,10 +17,6 @@
     </script>
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Informatie over financiering" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/funding_form.html
+++ b/proposals/templates/proposals/funding_form.html
@@ -1,0 +1,26 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load static %}
+{% load i18n %}
+
+{% block header_title %}
+    {% trans "Informatie over financiering" %} - {{ block.super }}
+{% endblock %}
+
+{% block html_head %}
+    {{ block.super }}
+    <script>
+        $(function () {
+            check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
+            check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
+        });
+    </script>
+{% endblock %}
+
+{% block pre-form-container-content %}
+    {% include "./practice_or_supervisor_warning.html" %}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Informatie over financiering" %}</h3>
+{% endblock %}

--- a/proposals/templates/proposals/other_researchers_form.html
+++ b/proposals/templates/proposals/other_researchers_form.html
@@ -1,0 +1,26 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load static %}
+{% load i18n %}
+
+{% block header_title %}
+    {% trans "Informatie over betrokken onderzoekers" %} - {{ block.super }}
+{% endblock %}
+
+{% block html_head %}
+    {{ block.super }}
+    <script>
+        $(function () {
+            depends_on_value('other_applicants', 'True', 'applicants');
+            depends_on_value('other_stakeholders', 'True', 'stakeholders');
+        });
+    </script>
+{% endblock %}
+
+{% block pre-form-container-content %}
+    {% include "./practice_or_supervisor_warning.html" %}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Informatie over betrokken onderzoekers" %}</h3>
+{% endblock %}

--- a/proposals/templates/proposals/other_researchers_form.html
+++ b/proposals/templates/proposals/other_researchers_form.html
@@ -17,10 +17,6 @@
     </script>
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Informatie over betrokken onderzoekers" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/practice_or_supervisor_warning.html
+++ b/proposals/templates/proposals/practice_or_supervisor_warning.html
@@ -2,15 +2,19 @@
 {% load static %}
 
 {% if not create and is_supervisor %}
-    <div class="alert alert-info">
-        {% blocktrans trimmed %}
-            Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je
-            het formulier invult alsof jij die student/PhD kandidaat bent.
-        {% endblocktrans %}
+    <div class="col-12 text-center">
+        <div class="alert alert-info">
+            {% blocktrans trimmed %}
+                Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je
+                het formulier invult alsof jij die student/PhD kandidaat bent.
+            {% endblocktrans %}
+        </div>
     </div>
 {% endif %}
 {% if is_practice %}
-    <div class="alert alert-info">
-        {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+    <div class="col-12 text-center">
+        <div class="alert alert-info">
+            {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+        </div>
     </div>
 {% endif %}

--- a/proposals/templates/proposals/practice_or_supervisor_warning.html
+++ b/proposals/templates/proposals/practice_or_supervisor_warning.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% load static %}
+
+{% if not create and is_supervisor %}
+    <div class="alert alert-info">
+        {% blocktrans trimmed %}
+            Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je
+            het formulier invult alsof jij die student/PhD kandidaat bent.
+        {% endblocktrans %}
+    </div>
+{% endif %}
+{% if is_practice %}
+    <div class="alert alert-info">
+        {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
+    </div>
+{% endif %}

--- a/proposals/templates/proposals/pre_approved_form.html
+++ b/proposals/templates/proposals/pre_approved_form.html
@@ -1,0 +1,16 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load static %}
+{% load i18n %}
+
+{% block header_title %}
+    {% trans "Informatie over eerdere toetsing" %} - {{ block.super }}
+{% endblock %}
+
+{% block pre-form-container-content %}
+    {% include "./practice_or_supervisor_warning.html" %}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Informatie over eerdere toesting" %}</h3>
+{% endblock %}

--- a/proposals/templates/proposals/pre_approved_form.html
+++ b/proposals/templates/proposals/pre_approved_form.html
@@ -7,10 +7,6 @@
     {% trans "Informatie over eerdere toetsing" %} - {{ block.super }}
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Informatie over eerdere toesting" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -53,10 +53,6 @@
     </script>
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Algemene informatie over de aanvraag" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/proposal_form.html
+++ b/proposals/templates/proposals/proposal_form.html
@@ -9,28 +9,7 @@
 
 {% block html_head %}
     {{ block.super }}
-    <script type="text/javascript"
-            charset="utf8"
-            src="{% static 'proposals/js/word_counter.js' %}"></script>
     <script>
-        $(function () {
-            check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
-            check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
-            check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
-            depends_on_value('other_applicants', 'True', 'applicants');
-            depends_on_value('other_stakeholders', 'True', 'stakeholders');
-            check_field_required('funding', 'needs_details', 'funding_details', 'proposals');
-            check_field_required('funding', 'needs_name', 'funding_name', 'proposals');
-        });
-        $(function () {
-            // adds running wordcounter for the summary and self_assessment text fields
-            let translated_string = " {% trans 'Aantal woorden:' %} "
-            wordCounter("summary", translated_string)
-            wordCounter("self_assessment", translated_string)
-        });
-
         $(function () {
             /* Find date start input */
             let date_start_input = $("#id_date_start")
@@ -75,19 +54,7 @@
 {% endblock %}
 
 {% block pre-form-container-content %}
-    {% if not create and is_supervisor %}
-        <div class="alert alert-info">
-            {% blocktrans trimmed %}
-                Je past nu een aanvraag aan van een student/PhD kandidaat onder jouw supervisie. Let er op dat je
-                het formulier invult alsof jij die student/PhD kandidaat bent.
-            {% endblocktrans %}
-        </div>
-    {% endif %}
-    {% if is_practice %}
-        <div class="alert alert-info">
-            {% trans "Je bewerkt op het moment een oefenaanvraag. Deze kan niet ter beoordeling door de FETC-GW worden ingediend." %}
-        </div>
-    {% endif %}
+    {% include "./practice_or_supervisor_warning.html" %}
 {% endblock %}
 
 {% block pre-form-text %}

--- a/proposals/templates/proposals/research_goal_form.html
+++ b/proposals/templates/proposals/research_goal_form.html
@@ -10,16 +10,16 @@
 {% block html_head %}
     {{ block.super }}
     <script type="text/javascript"
-    charset="utf8"
-    src="{% static 'proposals/js/word_counter.js' %}"></script>
-<script>
+            charset="utf8"
+            src="{% static 'proposals/js/word_counter.js' %}"></script>
+    <script>
     $(function () {
         // adds running wordcounter for the summary and self_assessment text fields
         let translated_string = " {% trans 'Aantal woorden:' %} "
         wordCounter("summary", translated_string)
         wordCounter("self_assessment", translated_string)
     });
-</script>
+    </script>
 {% endblock %}
 
 {% block pre-form-container-content %}

--- a/proposals/templates/proposals/research_goal_form.html
+++ b/proposals/templates/proposals/research_goal_form.html
@@ -22,10 +22,6 @@
     </script>
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Informatie over het onderzoeksdoel" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/research_goal_form.html
+++ b/proposals/templates/proposals/research_goal_form.html
@@ -1,0 +1,31 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load static %}
+{% load i18n %}
+
+{% block header_title %}
+    {% trans "Informatie over het onderzoeksdoel" %} - {{ block.super }}
+{% endblock %}
+
+{% block html_head %}
+    {{ block.super }}
+    <script type="text/javascript"
+    charset="utf8"
+    src="{% static 'proposals/js/word_counter.js' %}"></script>
+<script>
+    $(function () {
+        // adds running wordcounter for the summary and self_assessment text fields
+        let translated_string = " {% trans 'Aantal woorden:' %} "
+        wordCounter("summary", translated_string)
+        wordCounter("self_assessment", translated_string)
+    });
+</script>
+{% endblock %}
+
+{% block pre-form-container-content %}
+    {% include "./practice_or_supervisor_warning.html" %}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Informatie over het onderzoeksdoel" %}</h3>
+{% endblock %}

--- a/proposals/templates/proposals/researcher_form.html
+++ b/proposals/templates/proposals/researcher_form.html
@@ -20,10 +20,6 @@
     </script>
 {% endblock %}
 
-{% block pre-form-container-content %}
-    {% include "./practice_or_supervisor_warning.html" %}
-{% endblock %}
-
 {% block pre-form-text %}
     <h3>{% trans "Informatie over de onderzoeker" %}</h3>
 {% endblock %}

--- a/proposals/templates/proposals/researcher_form.html
+++ b/proposals/templates/proposals/researcher_form.html
@@ -1,0 +1,29 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load static %}
+{% load i18n %}
+
+{% block header_title %}
+    {% trans "Informatie over de onderzoeker" %} - {{ block.super }}
+{% endblock %}
+
+{% block html_head %}
+    {{ block.super }}
+    <script>
+        $(function () {
+            check_field_required('relation', 'needs_supervisor', 'supervisor', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_program', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_context', 'proposals');
+            check_field_required('relation', 'check_in_course', 'student_justification', 'proposals');
+            check_field_required('student_context', 'needs_details', 'student_context_details', 'proposals', 'studentcontext');
+        });
+    </script>
+{% endblock %}
+
+{% block pre-form-container-content %}
+    {% include "./practice_or_supervisor_warning.html" %}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Informatie over de onderzoeker" %}</h3>
+{% endblock %}

--- a/proposals/urls.py
+++ b/proposals/urls.py
@@ -12,6 +12,11 @@ from .views.proposal_views import (
     ProposalUpdate,
     ProposalDelete,
     ProposalStart,
+    ProposalResearcherFormView,
+    ProposalOtherResearchersFormView,
+    ProposalFundingFormView,
+    ProposalResearchGoalFormView,
+    ProposalPreApprovedFormView,
     ProposalDataManagement,
     ProposalSubmit,
     ProposalSubmitted,
@@ -21,12 +26,11 @@ from .views.proposal_views import (
     ProposalDifference,
     ProposalAsPdf,
     ProposalCreatePreAssessment,
-    ProposalUpdatePreAssessment,
+    ProposalUpdate,
     ProposalStartPreAssessment,
     ProposalSubmitPreAssessment,
     ProposalSubmittedPreAssessment,
     ProposalCreatePractice,
-    ProposalUpdatePractice,
     ProposalStartPractice,
     ChangeArchiveStatusView,
     ProposalsExportView,
@@ -34,7 +38,6 @@ from .views.proposal_views import (
     ProposalCreatePreApproved,
     ProposalSubmittedPreApproved,
     ProposalSubmitPreApproved,
-    ProposalUpdatePreApproved,
     ProposalUsersOnlyArchiveView,
     ProposalCopyAmendment,
     ProposalsPublicArchiveView,
@@ -118,25 +121,7 @@ urlpatterns = [
             ]
         ),
     ),
-    path(
-        "update/<int:pk>/",
-        include(
-            [
-                path("", ProposalUpdate.as_view(), name="update"),
-                path("pre/", ProposalUpdatePreAssessment.as_view(), name="update_pre"),
-                path(
-                    "practice/",
-                    ProposalUpdatePractice.as_view(),
-                    name="update_practice",
-                ),
-                path(
-                    "pre_approved/",
-                    ProposalUpdatePreApproved.as_view(),
-                    name="update_pre_approved",
-                ),
-            ]
-        ),
-    ),
+    path("update/<int:pk>/", ProposalUpdate.as_view(), name="update"),
     path("delete/<int:pk>/", ProposalDelete.as_view(), name="delete"),
     path(
         "start/",
@@ -154,6 +139,31 @@ urlpatterns = [
                 ),
             ]
         ),
+    ),
+    path(
+        "researcher/<int:pk>/",
+        ProposalResearcherFormView.as_view(),
+        name="researcher",
+    ),
+    path(
+        "other_researchers/<int:pk>/",
+        ProposalOtherResearchersFormView.as_view(),
+        name="other_researchers",
+    ),
+    path(
+        "funding/<int:pk>/",
+        ProposalFundingFormView.as_view(),
+        name="funding",
+    ),
+    path(
+        "research_goal/<int:pk>/",
+        ProposalResearchGoalFormView.as_view(),
+        name="research_goal",
+    ),
+    path(
+        "pre_approved/<int:pk>/",
+        ProposalPreApprovedFormView.as_view(),
+        name="pre_approved",
     ),
     path(
         "data_management/<int:pk>/",

--- a/proposals/utils/proposal_utils.py
+++ b/proposals/utils/proposal_utils.py
@@ -40,13 +40,44 @@ def available_urls(proposal):
     """
     urls = list()
 
-    if proposal.is_pre_assessment:
+    urls.append(
+        AvailableURL(
+            url=reverse("proposals:update", args=(proposal.pk,)),
+            title=_("Algemene informatie over de aanvraag"),
+        )
+    )
+
+    urls.append(
+        AvailableURL(
+            url=reverse("proposals:researcher", args=(proposal.pk,)),
+            title=_("Informatie over de onderzoeker"),
+        )
+    )
+
+
+    urls.append(
+        AvailableURL(
+            url=reverse("proposals:other_researchers", args=(proposal.pk,)),
+            title=_("Informatie over betrokken onderzoekers"),
+        )
+    )
+
+    if not proposal.is_pre_assessment:
         urls.append(
             AvailableURL(
-                url=reverse("proposals:update_pre", args=(proposal.pk,)),
-                title=_("Algemene informatie over de aanvraag"),
+                url=reverse("proposals:funding", args=(proposal.pk,)),
+                title=_("Informatie over financiering"),
             )
         )
+    
+    urls.append(
+        AvailableURL(
+            url=reverse("proposals:research_goal", args=(proposal.pk,)),
+            title=_("Informatie over het onderzoeksdoel"),
+        )
+    )
+
+    if proposal.is_pre_assessment:
 
         wmo_url = AvailableURL(title=_("Ethische toetsing nodig door een METC?"))
         if hasattr(proposal, "wmo"):
@@ -64,8 +95,8 @@ def available_urls(proposal):
     elif proposal.is_pre_approved:
         urls.append(
             AvailableURL(
-                url=reverse("proposals:update_pre_approved", args=(proposal.pk,)),
-                title=_("Algemene informatie over de aanvraag"),
+                url=reverse("proposals:pre_approved", args=(proposal.pk,)),
+                title=_("Informatie over eerdere toetsing"),
             )
         )
 
@@ -76,18 +107,6 @@ def available_urls(proposal):
         )
         urls.append(submit_url)
     else:
-        update_url = (
-            "proposals:update_practice"
-            if proposal.is_practice()
-            else "proposals:update"
-        )
-        urls.append(
-            AvailableURL(
-                url=reverse(update_url, args=(proposal.pk,)),
-                title=_("Algemeen"),
-            )
-        )
-
         wmo_url = AvailableURL(title=_("METC"))
         if hasattr(proposal, "wmo"):
             wmo_url.url = reverse("proposals:wmo_update", args=(proposal.wmo.pk,))

--- a/proposals/utils/proposal_utils.py
+++ b/proposals/utils/proposal_utils.py
@@ -54,7 +54,6 @@ def available_urls(proposal):
         )
     )
 
-
     urls.append(
         AvailableURL(
             url=reverse("proposals:other_researchers", args=(proposal.pk,)),
@@ -69,7 +68,7 @@ def available_urls(proposal):
                 title=_("Informatie over financiering"),
             )
         )
-    
+
     urls.append(
         AvailableURL(
             url=reverse("proposals:research_goal", args=(proposal.pk,)),

--- a/proposals/utils/validate_proposal.py
+++ b/proposals/utils/validate_proposal.py
@@ -61,11 +61,11 @@ def _build_forms(proposal: Proposal) -> OrderedDict:
 
     if not proposal.is_pre_assessment:
         forms["Funding"] = (
-        FundingForm,
-        reverse("proposal:funding", args=[proposal.pk]),
-        _("Informatie over financiering"),
-        proposal,
-    )
+            FundingForm,
+            reverse("proposal:funding", args=[proposal.pk]),
+            _("Informatie over financiering"),
+            proposal,
+        )
 
     forms["ResearchGoal"] = (
         ResearchGoalForm,
@@ -79,11 +79,11 @@ def _build_forms(proposal: Proposal) -> OrderedDict:
 
     if proposal.is_pre_approved:
         forms["PreApproved"] = (
-        PreApprovedForm,
-        reverse("proposal:pre_approved", args=[proposal.pk]),
-        _("Informatie over eerdere toetsing"),
-        proposal,
-    )
+            PreApprovedForm,
+            reverse("proposal:pre_approved", args=[proposal.pk]),
+            _("Informatie over eerdere toetsing"),
+            proposal,
+        )
 
     # For pre approved proposals, we're done already!
     if proposal.is_pre_approved:

--- a/proposals/utils/validate_proposal.py
+++ b/proposals/utils/validate_proposal.py
@@ -15,6 +15,11 @@ from studies.forms import StudyForm, StudyDesignForm, SessionStartForm
 from tasks.forms import TaskStartForm, TaskEndForm, TaskForm
 from ..forms import (
     ProposalForm,
+    ResearcherForm,
+    OtherResearchersForm,
+    FundingForm,
+    ResearchGoalForm,
+    PreApprovedForm,
     WmoForm,
     StudyStartForm,
     WmoApplicationForm,
@@ -33,38 +38,52 @@ def _build_forms(proposal: Proposal) -> OrderedDict:
     wmo_update_url = "proposals:wmo_update"
     wmo_application_url = "proposals:wmo_application"
 
-    # Get the correct URL for the
-    if proposal.is_pre_assessment:
-        forms["start"] = (
-            ProposalForm,
-            reverse("proposals:update_pre", args=[proposal.pk]),
-            _("Algemene informatie over de aanvraag"),
-            proposal,
-        )
+    forms["start"] = (
+        ProposalForm,
+        reverse("proposals:update", args=[proposal.pk]),
+        _("Algemene informatie over de aanvraag"),
+        proposal,
+    )
 
-        wmo_create_url = "proposals:wmo_create_pro"
-        wmo_update_url = "proposals:wmo_update_pro"
-    elif proposal.is_pre_approved:
-        forms["start"] = (
-            ProposalForm,
-            reverse("proposals:update_pre_approved", args=[proposal.pk]),
-            _("Algemene informatie over de aanvraag"),
-            proposal,
-        )
-    elif proposal.is_practice():
-        forms["start"] = (
-            ProposalForm,
-            reverse("proposals:update_practice", args=[proposal.pk]),
-            _("Algemene informatie over de aanvraag"),
-            proposal,
-        )
-    else:
-        forms["start"] = (
-            ProposalForm,
-            reverse("proposals:update", args=[proposal.pk]),
-            _("Algemene informatie over de aanvraag"),
-            proposal,
-        )
+    forms["Researcher"] = (
+        ResearcherForm,
+        reverse("proposal:researcher", args=[proposal.pk]),
+        _("Informatie over de onderzoeker"),
+        proposal,
+    )
+
+    forms["OtherResearchers"] = (
+        OtherResearchersForm,
+        reverse("proposal:other_researchers", args=[proposal.pk]),
+        _("Informatie over betrokken onderzoekers"),
+        proposal,
+    )
+
+    if not proposal.is_pre_assessment:
+        forms["Funding"] = (
+        FundingForm,
+        reverse("proposal:funding", args=[proposal.pk]),
+        _("Informatie over financiering"),
+        proposal,
+    )
+
+    forms["ResearchGoal"] = (
+        ResearchGoalForm,
+        reverse("proposal:research_goal", args=[proposal.pk]),
+        _("Informatie over het onderzoeksdoel"),
+        proposal,
+    )
+
+    if proposal.is_pre_assessment:
+        wmo_update_url = "proposals:wmo_update_pre"
+
+    if proposal.is_pre_approved:
+        forms["PreApproved"] = (
+        PreApprovedForm,
+        reverse("proposal:pre_approved", args=[proposal.pk]),
+        _("Informatie over eerdere toetsing"),
+        proposal,
+    )
 
     # For pre approved proposals, we're done already!
     if proposal.is_pre_approved:

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -254,7 +254,7 @@ class ProposalCreate(ProposalMixin, AllowErrorsOnBackbuttonMixin, CreateView):
         form.instance.reviewing_committee = form.instance.institution.reviewing_chamber
         obj = form.save()
         obj.applicants.set([self.request.user])
-        obj.save()        
+        obj.save()
         return super(ProposalCreate, self).form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -369,8 +369,11 @@ class ProposalStart(generic.TemplateView):
         context = super(ProposalStart, self).get_context_data(**kwargs)
         context["secretary"] = get_secretary()
         return context
-    
-class ProposalResearcherFormView(UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+
+
+class ProposalResearcherFormView(
+    UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView
+):
     model = Proposal
     form_class = ResearcherForm
     template_name = "proposals/researcher_form.html"
@@ -380,8 +383,11 @@ class ProposalResearcherFormView(UserFormKwargsMixin, ProposalContextMixin, Allo
 
     def get_back_url(self):
         return reverse("proposals:update", args=(self.object.pk,))
-    
-class ProposalOtherResearchersFormView(UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+
+
+class ProposalOtherResearchersFormView(
+    UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView
+):
     model = Proposal
     form_class = OtherResearchersForm
     template_name = "proposals/other_researchers_form.html"
@@ -395,8 +401,11 @@ class ProposalOtherResearchersFormView(UserFormKwargsMixin, ProposalContextMixin
 
     def get_back_url(self):
         return reverse("proposals:researcher", args=(self.object.pk,))
-    
-class ProposalFundingFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+
+
+class ProposalFundingFormView(
+    ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView
+):
     model = Proposal
     form_class = FundingForm
     template_name = "proposals/funding_form.html"
@@ -407,7 +416,10 @@ class ProposalFundingFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin
     def get_back_url(self):
         return reverse("proposals:other_researchers", args=(self.object.pk,))
 
-class ProposalResearchGoalFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+
+class ProposalResearchGoalFormView(
+    ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView
+):
     model = Proposal
     form_class = ResearchGoalForm
     template_name = "proposals/research_goal_form.html"
@@ -432,7 +444,10 @@ class ProposalResearchGoalFormView(ProposalContextMixin, AllowErrorsOnBackbutton
         else:
             return reverse("proposals:funding", args=(self.object.pk,))
 
-class ProposalPreApprovedFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+
+class ProposalPreApprovedFormView(
+    ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView
+):
     model = Proposal
     form_class = PreApprovedForm
     template_name = "proposals/pre_approved_form.html"
@@ -445,7 +460,8 @@ class ProposalPreApprovedFormView(ProposalContextMixin, AllowErrorsOnBackbuttonM
     def get_back_url(self):
         """Return to the Proposal Form page"""
         return reverse("proposals:research_goal", args=(self.object.pk,))
-    
+
+
 class TranslatedConsentFormsView(UpdateView):
     model = Proposal
     form_class = TranslatedConsentForms
@@ -764,6 +780,7 @@ class ProposalCreatePreAssessment(ProposalCreate):
         form.instance.is_pre_assessment = True
         return super(ProposalCreatePreAssessment, self).form_valid(form)
 
+
 class ProposalSubmitPreAssessment(ProposalSubmit):
     def get_next_url(self):
         """After submission, go to the thank-you view"""
@@ -847,4 +864,3 @@ class ProposalCreatePractice(ProposalCreate):
             self.kwargs["reason"] == Proposal.PracticeReasons.EXPLORATION
         )
         return super(ProposalCreatePractice, self).form_valid(form)
-

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -35,13 +35,17 @@ from ..forms import (
     ProposalConfirmationForm,
     ProposalCopyForm,
     ProposalDataManagementForm,
-    ProposalForm,
     ProposalStartPracticeForm,
     ProposalSubmitForm,
     RevisionProposalCopyForm,
     AmendmentProposalCopyForm,
     ProposalUpdateDataManagementForm,
     ProposalUpdateDateStartForm,
+    ResearcherForm,
+    OtherResearchersForm,
+    FundingForm,
+    ResearchGoalForm,
+    PreApprovedForm,
     TranslatedConsentForms,
 )
 from ..models import Proposal, Wmo
@@ -236,17 +240,21 @@ class ChangeArchiveStatusView(GroupRequiredMixin, generic.RedirectView):
 class ProposalCreate(ProposalMixin, AllowErrorsOnBackbuttonMixin, CreateView):
     # Note: template_name is auto-generated to proposal_form.html
 
-    def get_initial(self):
-        """Sets initial applicant to current User"""
-        initial = super(ProposalCreate, self).get_initial()
-        initial["applicants"] = [self.request.user]
-        return initial
+    success_message = _("Aanvraag %(title)s aangemaakt")
 
     def form_valid(self, form):
-        """Sets created_by to current user and generates a reference number"""
+        """
+        - Sets created_by to current user
+        - Generates a reference number
+        - Sets reviewing committee
+        - Adds user to applicants
+        """
         form.instance.created_by = self.request.user
         form.instance.reference_number = generate_ref_number()
         form.instance.reviewing_committee = form.instance.institution.reviewing_chamber
+        obj = form.save()
+        obj.applicants.set([self.request.user])
+        obj.save()        
         return super(ProposalCreate, self).form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -361,8 +369,83 @@ class ProposalStart(generic.TemplateView):
         context = super(ProposalStart, self).get_context_data(**kwargs)
         context["secretary"] = get_secretary()
         return context
+    
+class ProposalResearcherFormView(UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+    model = Proposal
+    form_class = ResearcherForm
+    template_name = "proposals/researcher_form.html"
 
+    def get_next_url(self):
+        return reverse("proposals:other_researchers", args=(self.object.pk,))
 
+    def get_back_url(self):
+        return reverse("proposals:update", args=(self.object.pk,))
+    
+class ProposalOtherResearchersFormView(UserFormKwargsMixin, ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+    model = Proposal
+    form_class = OtherResearchersForm
+    template_name = "proposals/other_researchers_form.html"
+
+    def get_next_url(self):
+        proposal = self.object
+        if proposal.is_pre_assessment:
+            return reverse("proposals:research_goal", args=(self.object.pk,))
+        else:
+            return reverse("proposals:funding", args=(self.object.pk,))
+
+    def get_back_url(self):
+        return reverse("proposals:researcher", args=(self.object.pk,))
+    
+class ProposalFundingFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+    model = Proposal
+    form_class = FundingForm
+    template_name = "proposals/funding_form.html"
+
+    def get_next_url(self):
+        return reverse("proposals:research_goal", args=(self.object.pk,))
+
+    def get_back_url(self):
+        return reverse("proposals:other_researchers", args=(self.object.pk,))
+
+class ProposalResearchGoalFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+    model = Proposal
+    form_class = ResearchGoalForm
+    template_name = "proposals/research_goal_form.html"
+
+    def get_next_url(self):
+        proposal = self.object
+        if proposal.is_pre_assessment:
+            pre_suffix = "_pre"
+        else:
+            pre_suffix = ""
+        if proposal.is_pre_approved:
+            return reverse("proposals:pre_approved", args=(self.object.pk,))
+        elif hasattr(proposal, "wmo"):
+            return reverse(f"proposals:wmo_update{pre_suffix}", args=(proposal.pk,))
+        else:
+            return reverse(f"proposals:wmo_create{pre_suffix}", args=(proposal.pk,))
+
+    def get_back_url(self):
+        proposal = self.object
+        if proposal.is_pre_assessment:
+            return reverse("proposals:other_researchers", args=(self.object.pk,))
+        else:
+            return reverse("proposals:funding", args=(self.object.pk,))
+
+class ProposalPreApprovedFormView(ProposalContextMixin, AllowErrorsOnBackbuttonMixin, UpdateView):
+    model = Proposal
+    form_class = PreApprovedForm
+    template_name = "proposals/pre_approved_form.html"
+
+    def get_next_url(self):
+        """Go to the Other Researcher page"""
+
+        return reverse("proposals:submit_pre_approved", args=(self.object.pk,))
+
+    def get_back_url(self):
+        """Return to the Proposal Form page"""
+        return reverse("proposals:research_goal", args=(self.object.pk,))
+    
 class TranslatedConsentFormsView(UpdateView):
     model = Proposal
     form_class = TranslatedConsentForms
@@ -675,32 +758,11 @@ class ProposalStartPreAssessment(ProposalStart):
     template_name = "proposals/proposal_start_pre_assessment.html"
 
 
-class PreAssessmentMixin(ProposalMixin):
-    def get_form_kwargs(self):
-        """Sets is_pre_assessment as a form kwarg"""
-        kwargs = super(PreAssessmentMixin, self).get_form_kwargs()
-        kwargs["is_pre_assessment"] = True
-        return kwargs
-
-    def get_next_url(self):
-        """If the Proposal has a Wmo model attached, go to update, else, go to create"""
-        proposal = self.object
-        if hasattr(proposal, "wmo"):
-            return reverse("proposals:wmo_update_pre", args=(proposal.pk,))
-        else:
-            return reverse("proposals:wmo_create_pre", args=(proposal.pk,))
-
-
-class ProposalCreatePreAssessment(PreAssessmentMixin, ProposalCreate):
+class ProposalCreatePreAssessment(ProposalCreate):
     def form_valid(self, form):
         """Sets is_pre_assessment to True"""
         form.instance.is_pre_assessment = True
         return super(ProposalCreatePreAssessment, self).form_valid(form)
-
-
-class ProposalUpdatePreAssessment(PreAssessmentMixin, ProposalUpdate):
-    pass
-
 
 class ProposalSubmitPreAssessment(ProposalSubmit):
     def get_next_url(self):
@@ -725,29 +787,12 @@ class ProposalStartPreApproved(ProposalStart):
     template_name = "proposals/proposal_start_pre_approved.html"
 
 
-class PreApprovedMixin(ProposalMixin):
-    def get_form_kwargs(self):
-        """Sets is_pre_approved as a form kwarg"""
-        kwargs = super(PreApprovedMixin, self).get_form_kwargs()
-        kwargs["is_pre_approved"] = True
-        return kwargs
-
-    def get_next_url(self):
-        proposal = self.object
-        return reverse("proposals:submit_pre_approved", args=(proposal.pk,))
-
-
-class ProposalCreatePreApproved(PreApprovedMixin, ProposalCreate):
-    template_name = "proposals/proposal_form_pre_approved.html"
+class ProposalCreatePreApproved(ProposalCreate):
 
     def form_valid(self, form):
         """Sets is_pre_approved to True"""
         form.instance.is_pre_approved = True
         return super(ProposalCreatePreApproved, self).form_valid(form)
-
-
-class ProposalUpdatePreApproved(PreApprovedMixin, ProposalUpdate):
-    pass
 
 
 class ProposalSubmitPreApproved(ProposalSubmit):
@@ -757,7 +802,7 @@ class ProposalSubmitPreApproved(ProposalSubmit):
 
     def get_back_url(self):
         """Return to the update page"""
-        return reverse("proposals:update_pre_approved", args=(self.object.pk,))
+        return reverse("proposals:pre_approved", args=(self.object.pk,))
 
 
 class ProposalSubmittedPreApproved(ProposalSubmitted):
@@ -793,12 +838,6 @@ class ProposalCreatePractice(ProposalCreate):
         context["is_practice"] = True
         return context
 
-    def get_form_kwargs(self):
-        """Sets in_course as a form kwarg"""
-        kwargs = super(ProposalCreatePractice, self).get_form_kwargs()
-        kwargs["in_course"] = self.kwargs["reason"] == Proposal.PracticeReasons.COURSE
-        return kwargs
-
     def form_valid(self, form):
         """Sets in_course and is_exploration"""
         form.instance.in_course = (
@@ -809,10 +848,3 @@ class ProposalCreatePractice(ProposalCreate):
         )
         return super(ProposalCreatePractice, self).form_valid(form)
 
-
-class ProposalUpdatePractice(ProposalUpdate):
-    def get_form_kwargs(self):
-        """Sets in_course as a form kwarg"""
-        kwargs = super(ProposalUpdatePractice, self).get_form_kwargs()
-        kwargs["in_course"] = self.object.in_course
-        return kwargs

--- a/proposals/views/wmo_views.py
+++ b/proposals/views/wmo_views.py
@@ -42,9 +42,9 @@ class WmoMixin(AllowErrorsOnBackbuttonMixin, object):
         """Return to the Proposal overview, or practice overview if we are in practice mode"""
         proposal = self.get_proposal()
         url = (
-            "proposals:update_practice"
-            if proposal.is_practice()
-            else "proposals:update"
+            "proposals:pre_approved"
+            if proposal.is_pre_approved
+            else "proposals:research_goal"
         )
         return reverse(url, args=(proposal.pk,))
 
@@ -119,7 +119,7 @@ class PreAssessmentMixin(object):
 
     def get_back_url(self):
         """Different return URL for pre-assessment Proposals"""
-        return reverse("proposals:update_pre", args=(self.object.proposal.pk,))
+        return reverse("proposals:update", args=(self.object.proposal.pk,))
 
 
 class WmoCreatePreAssessment(PreAssessmentMixin, WmoCreate):

--- a/reviews/views.py
+++ b/reviews/views.py
@@ -555,20 +555,9 @@ class DecisionUpdateView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # Supervisors get the chance to update the proposal, but we have
-        # multiple update views for different types of proposals.
-        if self.object.review.proposal.is_pre_approved:
-            context["update_url"] = reverse(
-                "proposals:update_pre_approved", args=[self.object.review.proposal.pk]
-            )
-        elif self.object.review.proposal.is_pre_assessment:
-            context["update_url"] = reverse(
-                "proposals:update_pre", args=[self.object.review.proposal.pk]
-            )
-        else:
-            context["update_url"] = reverse(
-                "proposals:update", args=[self.object.review.proposal.pk]
-            )
+        context["update_url"] = reverse(
+            "proposals:update", args=[self.object.review.proposal.pk]
+        )
 
         return context
 


### PR DESCRIPTION
Well, here it is: the long awaited break up of page 1. It took me a while to wrap my head around it ... I've had a meeting with the secretary about the desired new architecture and we landed on this. I think it make quite a lot of sense like this, breaking up the giant start page, actually allowed for a lot of simplification. Notably in the forms and the views. For instance, we now just have one `UpdateView`, instead of different versions for different proposal types, which is quite nice.

I think this is mostly self explanatory. There are some big commits here, but that was kindoff unavoidable.

Regarding 5b3b043, This template was not displaying pre form messages correctly. This solution works well for me, but I am open to other suggestions.

I am pretty happy with how this turned out, so I am eager to hear your thoughts :)