### PR TITLE
Revise attachments while preserving older versions

### DIFF
--- a/attachments/templates/attachments/attachment_model.html
+++ b/attachments/templates/attachments/attachment_model.html
@@ -1,5 +1,2 @@
-
-
 <a href="{% url "proposals:download_attachment_original" proposal_pk=proposal.pk attachment_pk=attachment.pk %}">
-
-{{attachment.upload.original_filename}}</a>
+{{ attachment.upload.original_filename }}</a>

--- a/attachments/templates/attachments/base_single_attachment.html
+++ b/attachments/templates/attachments/base_single_attachment.html
@@ -1,14 +1,8 @@
-
-
 <div class="attachment-row row m-0">
-    <div class="attachment-outer {{ac.get_outer_css_classes}}">
-        <div class="attachment-upper-border">
-            {{ac.get_origin_display}} asdf
-        </div>
+    <div class="attachment-outer {{ ac.get_outer_css_classes }}">
+        <div class="attachment-upper-border">{{ ac.get_origin_display }} asdf</div>
         <div class="attachment-content m-2">
-            <h4>
-                Attachment kind
-            </h4>
+            <h4>Attachment kind</h4>
             <pre>attachment_filename.docx</pre>
             <div class="attachment-buttons btn-row">
                 {% for action in container.get_actions %}
@@ -18,4 +12,3 @@
         </div>
     </div>
 </div>
-

--- a/attachments/templates/attachments/slot.html
+++ b/attachments/templates/attachments/slot.html
@@ -1,12 +1,9 @@
 {% load i18n %}
 
 <div class="row mt-4 mb-4">
-
-    <div class="col-2 align-middle">
-        {{ slot.desiredness }}
-    </div>
+    <div class="col-2 align-middle">{{ slot.desiredness }}</div>
     <div class="col-7 align-middle">
-        <h5>{{slot.kind.name}}</h5>
+        <h5>{{ slot.kind.name }}</h5>
         {% if slot.attachment %}
             {% include slot.attachment with proposal=proposal %}
         {% else %}
@@ -16,13 +13,9 @@
     </div>
     <div class="col-3 align-middle">
         {% if slot.attachment %}
-            <a class="btn btn-primary" href="{{slot.get_edit_url}}">
-                {% trans "Wijzig" %}
-            </a>
+            <a class="btn btn-primary" href="{{ slot.get_edit_url }}">{% trans "Wijzig" %}</a>
         {% else %}
-            <a class="btn btn-primary" href="{{slot.get_attach_url}}">
-                {% trans "Voeg toe" %}
-            </a>
+            <a class="btn btn-primary" href="{{ slot.get_attach_url }}">{% trans "Voeg toe" %}</a>
         {% endif %}
     </div>
 </div>

--- a/proposals/copy.py
+++ b/proposals/copy.py
@@ -69,13 +69,14 @@ def copy_proposal(original_proposal, is_revision, created_by_user):
 
     return copy_proposal
 
+
 def copy_attachments(old, new):
     for att in old.attachments.all():
         att.attached_to.add(new)
         att.save()
     for old_study, new_study in zip(
-            old.study_set.all(),
-            new.study_set.all(),
+        old.study_set.all(),
+        new.study_set.all(),
     ):
         for att in old_study.attachments.all():
             att.attached_to.add(new_study)

--- a/proposals/copy.py
+++ b/proposals/copy.py
@@ -65,6 +65,18 @@ def copy_proposal(original_proposal, is_revision, created_by_user):
         copy_study_to_proposal(copy_proposal, study)
 
     if not copy_proposal.is_pre_approved:
-        copy_documents_to_proposal(original_proposal.pk, copy_proposal)
+        copy_attachments(original_proposal, copy_proposal)
 
     return copy_proposal
+
+def copy_attachments(old, new):
+    for att in old.attachments.all():
+        att.attached_to.add(new)
+        att.save()
+    for old_study, new_study in zip(
+            old.study_set.all(),
+            new.study_set.all(),
+    ):
+        for att in old_study.attachments.all():
+            att.attached_to.add(new_study)
+            att.save()

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -818,24 +818,6 @@ class ProposalSubmitForm(ConditionalModelForm):
             ):
                 self.add_error("inform_local_staff", _("Dit veld is verplicht."))
 
-            for study in self.instance.study_set.all():
-                documents = Documents.objects.get(study=study)
-
-                if not documents.informed_consent:
-                    self.add_error(
-                        "comments",
-                        _(
-                            "Toestemmingsverklaring voor traject {} nog niet toegevoegd."
-                        ).format(study.order),
-                    )
-                if not documents.briefing:
-                    self.add_error(
-                        "comments",
-                        _(
-                            "Informatiebrief voor traject {} nog niet toegevoegd."
-                        ).format(study.order),
-                    )
-
             if cleaned_data["embargo"] is None:
                 self.add_error("embargo", _("Dit veld is verplicht."))
 

--- a/proposals/templates/proposals/attach_form.html
+++ b/proposals/templates/proposals/attach_form.html
@@ -1,4 +1,5 @@
 {% extends "base/fetc_form_base.html" %}
+
 {% load i18n %}
 {% load static %}
 
@@ -15,7 +16,7 @@
             {% endblocktrans %}
         {% else %}
             {% blocktrans trimmed %}
-                Je bewerkt het volgende bestand: 
+                Je bewerkt het volgende bestand:
             {% endblocktrans %}
             <p>{% include object with proposal=view.get_proposal %}</p>
             {% blocktrans trimmed %}
@@ -26,39 +27,34 @@
     <p class="ml-5">
         {% if study %}
             {% blocktrans with order=study.order name=study.name trimmed %}
-                Traject {{order}}: <em>{{name}}</em> van
+                Traject {{ order }}: <em>{{ name }}</em> van
             {% endblocktrans %}
         {% endif %}
         {% trans "de aanvraag" %} <em>{{ proposal.title }}</em>.
     </p>
     {% if not view.editing %}
-    {% blocktrans with name=kind_name trimmed %}
-        Je gaat hier een {{name}} aan toevoegen. Wil je een ander soort bestand toevoegen? Ga dan terug naar de vorige pagina.
-    {% endblocktrans %}
+        {% blocktrans with name=kind_name trimmed %}
+            Je gaat hier een {{ name }} aan toevoegen. Wil je een ander soort bestand toevoegen? Ga dan terug naar de vorige pagina.
+        {% endblocktrans %}
     {% endif %}
-
-
-    </p>
+</p>
 {% endblock %}
 
 {% block form-buttons %}
-
     <div class="mt-4 mb-3 w-100 d-flex">
-
-        <a class="btn btn-secondary" href="{% url "proposals:attachments" pk=proposal.pk %}">
+        <a class="btn btn-secondary"
+           href="{% url "proposals:attachments" pk=proposal.pk %}">
             {% trans '<< Ga terug' %}
         </a>
-{% if view.editing %}
-        <a class="btn btn-danger" href="{% url "proposals:detach_file" attachment_pk=form.instance.pk proposal_pk=view.get_proposal.pk %}">
-            {% trans 'Bestand verwijderen' %}
-        </a>
-{% endif %}
-
+        {% if view.editing %}
+            <a class="btn btn-danger"
+               href="{% url "proposals:detach_file" attachment_pk=form.instance.pk proposal_pk=view.get_proposal.pk %}">
+                {% trans 'Bestand verwijderen' %}
+            </a>
+        {% endif %}
         <input class="btn btn-primary continue-button ms-auto"
                type="submit"
                name="save"
                value="{% trans "Opslaan" %}" />
-
     </div>
-
 {% endblock %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -4,23 +4,24 @@
 {% load i18n %}
 
 {% block header_title %}
-{% trans "Informatie over betrokken onderzoekers" %} - {{ block.super }}
+    {% trans "Informatie over betrokken onderzoekers" %} - {{ block.super }}
 {% endblock %}
-
 
 {% block pre-form-text %}
-<h2>{% trans "Documenten" %}</h2>
-<h3 class="mt-4">{% trans "Algemeen" %}</h3>
-{% for slot in proposal_slots %}
-    {% include slot %}
-{% endfor %}
-{% for study, slots in study_slots.items %}
-    <hr />
-    <h3>{% trans "Traject " %} {{ study.order }} {% if study.name %}: <em>{{ study.name }}</em> {% endif %}</h3>
-    {% for slot in slots %}
-        {% include slot with manager=manager %}
+    <h2>{% trans "Documenten" %}</h2>
+    <h3 class="mt-4">{% trans "Algemeen" %}</h3>
+    {% for slot in proposal_slots %}
+        {% include slot %}
     {% endfor %}
-{% endfor %}
-{% block auto-form-render %}
-{% endblock %}
+    {% for study, slots in study_slots.items %}
+        <hr />
+        <h3>
+            {% trans "Traject " %} {{ study.order }}
+            {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
+        </h3>
+        {% for slot in slots %}
+            {% include slot with manager=manager %}
+        {% endfor %}
+    {% endfor %}
+    {% block auto-form-render %}{% endblock %}
 {% endblock %}

--- a/proposals/templates/proposals/detach_form.html
+++ b/proposals/templates/proposals/detach_form.html
@@ -1,0 +1,32 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load i18n %}
+{% load static %}
+
+{% block header_title %}
+    {% trans "Verwijder een bestand" %} - {{ block.super }}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Verwijder een bestand" %}</h3>
+    <p>
+        {% blocktrans trimmed %}
+            Je verwijdert het volgende bestand:
+        {% endblocktrans %}
+        {% include object with proposal=proposal %}
+    </p>
+</p>
+{% endblock %}
+
+{% block form-buttons %}
+    <div class="mt-4 mb-3 w-100 d-flex">
+        <a class="btn btn-secondary"
+           href="{% url "proposals:attachments" pk=proposal.pk %}">
+            {% trans '<< Ga terug' %}
+        </a>
+        <input class="btn btn-danger continue-button ms-auto"
+               type="submit"
+               name="save"
+               value="{% trans "Verwijderen" %}" />
+    </div>
+{% endblock %}

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -43,31 +43,44 @@ class AttachForm(
         # Set the kind if enforced by the view.
         if self.kind:
             self.instance.kind = self.kind.db_name
-        # Check we're not editing an attachment that is still in use
-        # by another object.
-        if self.instance.attached_to.count() > 1:
-            # Saving this instance might remove historical data. So
-            # we create a "revision" of sorts. First we save the old
-            # pk:
-            old_pk = self.instance.pk + 0
-            # The following means this instance will get saved under a
-            # new pk, effectively creating a copy.
-            self.instance.pk = None
-            self.instance.id = None
-            self.instance._state.adding = True
+        # Check if we're creating a new attachment
+        if self.instance._state.adding is True:
+            # If we're creating, we need to save before we can
+            # adjust M2M attributes.
             self.instance.save()
-            # Retrieve and fix the old attachment.
-            instance_manager = type(self.instance).objects
-            old_attachment = instance_manager.get(pk=old_pk)
-            old_attachment.attached_to.remove(self.other_object)
-            self.instance.parent = old_attachment
-            # Clear the attached_to set, we add other_object back
-            # afterwards.
-            self.instance.attached_to.set([])
+        else:
+            # Check we're not editing an attachment that is still in use
+            # by another object.
+            if self.instance.attached_to.count() > 1:
+                # Saving this instance might remove historical data. So
+                # we create a revision.
+                return self.save_revision()
         # Attach the instance to the owner object.
         self.instance.attached_to.add(
             self.other_object,
         )
+        return super().save()
+
+    def save_revision(self,):
+        # Remember the old pk
+        # Adding zero creates a new copy of the integer
+        old_pk = self.instance.pk + 0
+        # The following means this instance will get saved under a
+        # new pk, effectively creating a copy.
+        self.instance.pk = None
+        self.instance.id = None
+        self.instance._state.adding = True
+        self.instance.save()
+        # Retrieve and detach it from the current other_object.
+        instance_manager = type(self.instance).objects
+        old_attachment = instance_manager.get(pk=old_pk)
+        old_attachment.attached_to.remove(self.other_object)
+        old_attachment.save()
+        # Remove all other instances in the attached_to
+        # of the copy except for the current other_object.
+        self.instance.attached_to.set([self.other_object])
+        # Set the old attachment as our parent.
+        self.instance.parent = old_attachment
         return super().save()
 
 

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -39,7 +39,9 @@ class AttachForm(
         if not extra:
             del self.fields["kind"]
 
-    def save(self,):
+    def save(
+        self,
+    ):
         # Set the kind if enforced by the view.
         if self.kind:
             self.instance.kind = self.kind.db_name
@@ -61,7 +63,9 @@ class AttachForm(
         )
         return super().save()
 
-    def save_revision(self,):
+    def save_revision(
+        self,
+    ):
         # Remember the old pk
         # Adding zero creates a new copy of the integer
         old_pk = self.instance.pk + 0
@@ -75,7 +79,6 @@ class AttachForm(
         instance_manager = type(self.instance).objects
         old_attachment = instance_manager.get(pk=old_pk)
         old_attachment.attached_to.remove(self.other_object)
-        old_attachment.save()
         # Remove all other instances in the attached_to
         # of the copy except for the current other_object.
         self.instance.attached_to.set([self.other_object])


### PR DESCRIPTION
If you edit an attachment that is already attached to something else, the portal will instead seamlessly save a copy so older proposals don't change.

To test:

Revise an application with an Attachment attached. Modify the attachment in the revision, and note that it gets a new pk while keeping all attributes that you would expect. The old application and its attachment will remain unchanged.

If this looks simple know that I played around with this a lot before getting it right, and the whole rest of the attachments system is pretty much built around this part being easy. Still proud of it, though!