### PR TITLE
Fix errors for StudyEndForm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ certs/
 fetc/ldap_settings.py
 fetc/saml_settings.py
 *.sqlite3
+debug_settings.py
 
 ### Coverage ###
 .coverage

--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -199,6 +199,7 @@ except ImportError:
 if DEBUG is True:
     try:
         from debug_settings import *
+
         print("Loaded debug_settings.py")
     except ImportError:
         print("No debug_settings.py found, proceeding...")

--- a/fetc/settings.py
+++ b/fetc/settings.py
@@ -194,3 +194,11 @@ try:
 
 except ImportError:
     print("Proceeding without SAML settings")
+
+# Debug / local development settings
+if DEBUG is True:
+    try:
+        from debug_settings import *
+        print("Loaded debug_settings.py")
+    except ImportError:
+        print("No debug_settings.py found, proceeding...")

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -373,6 +373,9 @@ class StudyEndForm(SoftValidationMixin, ConditionalModelForm):
             del self.fields["deception"]
             del self.fields["deception_details"]
 
+        self._errors = None
+        self.full_clean()
+
     def clean(self):
         """
         Check for conditional requirements:


### PR DESCRIPTION
If you create a study that has an intervention and/or an observation, but no sessions, there will always be an error in `StudyEndForm` ("Trajectory Overview"). This happens because the deception fields get removed *after* `super().__init__()` cleans and validates the form. So you'll have an error in a field you can't fill in.

This PR fixes that by cleaning the form again once all fields are set up.

Bonus feature: I got fed up of stashing and popping my fake local email settings every time so I set up a basic `debug_settings.py`. I've added it to gitignore so put anything in there you'd like.