### PR TITLE
fix: create and implement attachment filename generator

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -2,11 +2,9 @@ from django.db import models
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext as _
 from main.utils import renderable
+from attachments.utils import attachment_filename_generator
 
 from cdh.files.db import FileField as CDHFileField
-
-# Create your models here.
-
 
 class Attachment(models.Model, renderable):
 
@@ -21,6 +19,7 @@ class Attachment(models.Model, renderable):
     upload = CDHFileField(
         verbose_name=_("Bestand"),
         help_text=_("Selecteer hier het bestand om toe te voegen."),
+        filename_generator=attachment_filename_generator,
     )
     parent = models.ForeignKey(
         "attachments.attachment",
@@ -41,10 +40,6 @@ class Attachment(models.Model, renderable):
     )
     name = models.CharField(
         max_length=50,
-        default="",
-        help_text=_(
-            "Geef je bestand een omschrijvende naam, het liefst " "maar enkele woorden."
-        ),
     )
     comments = models.TextField(
         max_length=2000,

--- a/attachments/templates/attachments/attachment_model.html
+++ b/attachments/templates/attachments/attachment_model.html
@@ -1,2 +1,2 @@
 <a href="{% url "proposals:download_attachment_original" proposal_pk=proposal.pk attachment_pk=attachment.pk %}">
-{{ attachment.upload.original_filename }}</a>
+{{ attachment.upload }}</a>


### PR DESCRIPTION
So here is a little filename generator. It took me a bit long to figure out, but with some tips from Ty, I got it to work. It did not quite make sense to use the old FilenameFactory, as the filename generator of cdh FileField, expects something different. 

So this function just receives the FileWrapper ... From there I search for the relevant ProposalAttachment or StudyAttachment and get the relevant info from there. This is a bit quick and dirty ... But it works for now.

Although there is some overlapping code between this and the FilenameFactory ... they are just different enough, that I thought let's just have them coexsist ... I guess that can be a helper function that removes the overlap, but this does not seem like a huge win to me, both for efficiency, or readability.

I have not though through all the possibilities for attachments resulting in the same filename ... I think I will first start implementing the slots and checkers a bit more, to get a grasp of all the possibilities for things like this to occur ... As a starting point, this is ok imo.