### PR TITLE
Feature/extra attachments

### DIFF
--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -48,7 +48,7 @@ class DataManagementPlan(ProposalAttachmentKind):
 class OtherProposalAttachment(ProposalAttachmentKind):
 
     db_name = "other"
-    name = _("Overige bestanden")
+    name = _("Overig bestand")
     description = _("Voor alle overige soorten bestanden")
 
     def num_required(self):
@@ -71,3 +71,5 @@ PROPOSAL_ATTACHMENTS = [
 ]
 
 ATTACHMENTS = PROPOSAL_ATTACHMENTS + STUDY_ATTACHMENTS
+
+KIND_CHOICES = list(((kind.db_name, kind.name) for kind in ATTACHMENTS))

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -38,7 +38,7 @@ class Attachment(models.Model, renderable):
         # From Django 5 onwards we can define a callable to get
         # the choices which would be the preferred solution.
         default=("other", _("Overig bestand")),
-        verbose_name=_("Type bestand")
+        verbose_name=_("Type bestand"),
     )
     name = models.CharField(
         max_length=50,

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -37,7 +37,8 @@ class Attachment(models.Model, renderable):
         # whatever form needs them.
         # From Django 5 onwards we can define a callable to get
         # the choices which would be the preferred solution.
-        default=("", _("Gelieve selecteren")),
+        default=("other", _("Overig bestand")),
+        verbose_name=_("Type bestand")
     )
     name = models.CharField(
         max_length=50,

--- a/attachments/templates/attachments/slot.html
+++ b/attachments/templates/attachments/slot.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="row mt-4 mb-4">
+<div class="row mt-4 mb-4 p-3 border-3 border-bottom rounded {{classes}} bg-light">
     <div class="col-2 align-middle">{{ slot.desiredness }}</div>
     <div class="col-7 align-middle">
         <h5>{{ slot.kind.name }}</h5>
@@ -11,7 +11,7 @@
         {% endif %}
         {{ kind.reason }}
     </div>
-    <div class="col-3 align-middle">
+    <div class="col-3 align-middle text-end flex-end">
         {% if slot.attachment %}
             <a class="btn btn-primary" href="{{ slot.get_edit_url }}">{% trans "Wijzig" %}</a>
         {% else %}

--- a/attachments/templates/attachments/slot.html
+++ b/attachments/templates/attachments/slot.html
@@ -7,7 +7,7 @@
         {% if slot.attachment %}
             {% include slot.attachment with proposal=proposal %}
         {% else %}
-            Nog toe te voegen
+            {% trans "Nog toe te voegen" %}
         {% endif %}
         {{ kind.reason }}
     </div>

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -55,6 +55,15 @@ class AttachmentSlot(renderable):
         return False
 
     @property
+    def classes(self):
+        if self.required:
+            if self.attachment:
+                return "border-success"
+            else:
+                return "border-warning"
+        return ""
+
+    @property
     def desiredness(self):
         if self.force_desiredness:
             return self.force_desiredness
@@ -83,6 +92,7 @@ class AttachmentSlot(renderable):
         context = super().get_context_data(**kwargs)
         context["slot"] = self
         context["proposal"] = self.get_proposal()
+        context["classes"] = self.classes
         return context
 
     def get_proposal(self):

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -44,7 +44,8 @@ class AttachmentSlot(renderable):
     def match(self, exclude):
         """
         Tries to fill this slot with an existing attachment that is not
-        in the exclusion set of already matched attachments.
+        in the exclusion set of already matched attachments. Returns True
+        or False depending on if the slot was succesfully matched.
         """
         for instance in self.get_instances_for_slot():
             if instance not in exclude:

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -49,7 +49,9 @@ class AttachmentSlot(renderable):
         for instance in self.get_instances_for_slot():
             if instance not in exclude:
                 self.attachment = instance
-                break
+                self.kind = get_kind_from_str(instance.kind)
+                return True
+        return False
 
     @property
     def desiredness(self):

--- a/proposals/templates/proposals/attach_form.html
+++ b/proposals/templates/proposals/attach_form.html
@@ -33,11 +33,13 @@
         {% trans "de aanvraag" %} <em>{{ proposal.title }}</em>.
     </p>
     {% if not view.editing %}
-        {% blocktrans with name=kind.name trimmed %}
-            Je gaat hier een {{ name }} aan toevoegen. Wil je een ander soort bestand toevoegen? Ga dan terug naar de vorige pagina.
-        {% endblocktrans %}
+        {% if kind %}
+            {% blocktrans with name=kind.name trimmed %}
+                Je gaat hier een {{ name }} aan toevoegen. Wil je een ander soort bestand toevoegen? Ga dan terug naar de vorige pagina.
+            {% endblocktrans %}
+        {% endif %}
     {% endif %}
-</p>
+    </p>
 {% endblock %}
 
 {% block form-buttons %}

--- a/proposals/templates/proposals/attach_form.html
+++ b/proposals/templates/proposals/attach_form.html
@@ -33,7 +33,7 @@
         {% trans "de aanvraag" %} <em>{{ proposal.title }}</em>.
     </p>
     {% if not view.editing %}
-        {% blocktrans with name=kind_name trimmed %}
+        {% blocktrans with name=kind.name trimmed %}
             Je gaat hier een {{ name }} aan toevoegen. Wil je een ander soort bestand toevoegen? Ga dan terug naar de vorige pagina.
         {% endblocktrans %}
     {% endif %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -16,7 +16,8 @@
     <p class="text-center">
         <a href="{% url "proposals:attach_proposal" proposal.pk %}">Voeg extra bestand toe
             <img src="{% static 'proposals/images/add.png' %}"
-                 title="{% trans 'Toevoegen' %}" /></a>
+                 title="{% trans 'Toevoegen' %}" />
+        </a>
     </p>
     {% for study, slots in study_slots.items %}
         <hr />
@@ -27,11 +28,11 @@
         {% for slot in slots %}
             {% include slot with manager=manager %}
         {% endfor %}
-
         <p class="text-center">
             <a href="{% url "proposals:attach_study" proposal.pk %}">Voeg extra bestand toe
                 <img src="{% static 'proposals/images/add.png' %}"
-                     title="{% trans 'Toevoegen' %}" /></a>
+                     title="{% trans 'Toevoegen' %}" />
+            </a>
         </p>
     {% endfor %}
     {% block auto-form-render %}{% endblock %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -29,7 +29,7 @@
             {% include slot with manager=manager %}
         {% endfor %}
         <p class="text-center">
-            <a href="{% url "proposals:attach_study" proposal.pk %}">Voeg extra bestand toe
+            <a href="{% url "proposals:attach_study" study.pk %}">Voeg extra bestand toe
                 <img src="{% static 'proposals/images/add.png' %}"
                      title="{% trans 'Toevoegen' %}" />
             </a>

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -13,6 +13,11 @@
     {% for slot in proposal_slots %}
         {% include slot %}
     {% endfor %}
+    <p class="text-center">
+        <a href="{% url "proposals:attach_proposal" proposal.pk %}">Voeg extra bestand toe
+            <img src="{% static 'proposals/images/add.png' %}"
+                 title="{% trans 'Toevoegen' %}" /></a>
+    </p>
     {% for study, slots in study_slots.items %}
         <hr />
         <h3>
@@ -22,6 +27,12 @@
         {% for slot in slots %}
             {% include slot with manager=manager %}
         {% endfor %}
+
+        <p class="text-center">
+            <a href="{% url "proposals:attach_study" proposal.pk %}">Voeg extra bestand toe
+                <img src="{% static 'proposals/images/add.png' %}"
+                     title="{% trans 'Toevoegen' %}" /></a>
+        </p>
     {% endfor %}
     {% block auto-form-render %}{% endblock %}
 {% endblock %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -13,14 +13,14 @@
     {% for slot in proposal_slots %}
         {% include slot %}
     {% endfor %}
-    <p class="text-center">
-        <a href="{% url "proposals:attach_proposal" proposal.pk %}">Voeg extra bestand toe
-            <img src="{% static 'proposals/images/add.png' %}"
-                 title="{% trans 'Toevoegen' %}" />
-        </a>
-    </p>
-    {% for study, slots in study_slots.items %}
-        <hr />
+        <div class="text-center mb-5 mt-3">
+            <a class="btn btn-light align-bottom" href="{% url "proposals:attach_proposal" proposal.pk %}">
+                <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
+                     title="{% trans 'Toevoegen' %}" />
+                <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan aanvraag</h6>
+            </a>
+        </div>
+        {% for study, slots in study_slots.items %}
         <h3>
             {% trans "Traject " %} {{ study.order }}
             {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
@@ -28,12 +28,13 @@
         {% for slot in slots %}
             {% include slot with manager=manager %}
         {% endfor %}
-        <p class="text-center">
-            <a href="{% url "proposals:attach_study" study.pk %}">Voeg extra bestand toe
-                <img src="{% static 'proposals/images/add.png' %}"
+        <div class="text-center mb-5 mt-3">
+            <a class="btn btn-light align-bottom" href="{% url "proposals:attach_study" study.pk %}">
+                <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
                      title="{% trans 'Toevoegen' %}" />
+                <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan traject {{study.order}}</h6>
             </a>
-        </p>
+        </div>
     {% endfor %}
     {% block auto-form-render %}{% endblock %}
 {% endblock %}

--- a/proposals/templates/proposals/detach_form.html
+++ b/proposals/templates/proposals/detach_form.html
@@ -1,0 +1,36 @@
+{% extends "base/fetc_form_base.html" %}
+
+{% load i18n %}
+{% load static %}
+
+{% block header_title %}
+    {% trans "Verwijder een bestand" %} - {{ block.super }}
+{% endblock %}
+
+{% block pre-form-text %}
+    <h3>{% trans "Verwijder een bestand" %}</h3>
+    <p>
+        {% blocktrans trimmed %}
+            Je verwijdert het volgende bestand:
+        {% endblocktrans %}
+        {% include object with proposal=proposal %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+            Als je een nieuwe versie van dit document wil aanleveren, verwijder het dan niet, maar ga dan terug naar de vorige pagina en wijzig het daar. Zo blijft de geschiedenis van het document bewaard, en dat vergemakkelijkt het beoordeelproces aanzienlijk.
+        {% endblocktrans %}
+    </p>
+{% endblock %}
+
+{% block form-buttons %}
+    <div class="mt-4 mb-3 w-100 d-flex">
+        <a class="btn btn-secondary"
+           href="{% url "proposals:attachments" pk=proposal.pk %}">
+            {% trans '<< Ga terug' %}
+        </a>
+        <input class="btn btn-danger continue-button ms-auto"
+               type="submit"
+               name="save"
+               value="{% trans "Verwijderen" %}" />
+    </div>
+{% endblock %}

--- a/proposals/urls.py
+++ b/proposals/urls.py
@@ -184,18 +184,19 @@ urlpatterns = [
     ),
     path(
         "attach_proposal/<int:other_pk>/",
-        ProposalAttachView.as_view(owner_model=Proposal, extra=True),
+        ProposalAttachView.as_view(owner_model=Proposal, extra=True, editing=False),
         name="attach_proposal",
     ),
     path(
         "attach_study/<int:other_pk>/",
-        ProposalAttachView.as_view(owner_model=Study, extra=True),
+        ProposalAttachView.as_view(owner_model=Study, extra=True, editing=False),
         name="attach_study",
     ),
     path(
         "attach_proposal/<str:kind>/<int:other_pk>/",
         ProposalAttachView.as_view(
             owner_model=Proposal,
+            editing=False,
         ),
         name="attach_proposal",
     ),
@@ -203,6 +204,7 @@ urlpatterns = [
         "attach_study/<str:kind>/<int:other_pk>/",
         ProposalAttachView.as_view(
             owner_model=Study,
+            editing=False,
         ),
         name="attach_study",
     ),
@@ -213,7 +215,9 @@ urlpatterns = [
     ),
     path(
         "attachments/<int:other_pk>/edit/<int:attachment_pk>/",
-        ProposalUpdateAttachmentView.as_view(),
+        ProposalUpdateAttachmentView.as_view(
+            editing=True,
+        ),
         name="update_attachment",
     ),
     path(

--- a/proposals/urls.py
+++ b/proposals/urls.py
@@ -183,6 +183,16 @@ urlpatterns = [
         name="attachments",
     ),
     path(
+        "attach_proposal/<int:other_pk>/",
+        ProposalAttachView.as_view(owner_model=Proposal, extra=True),
+        name="attach_proposal",
+    ),
+    path(
+        "attach_study/<int:other_pk>/",
+        ProposalAttachView.as_view(owner_model=Study, extra=True),
+        name="attach_study",
+    ),
+    path(
         "attach_proposal/<str:kind>/<int:other_pk>/",
         ProposalAttachView.as_view(
             owner_model=Proposal,
@@ -194,16 +204,6 @@ urlpatterns = [
         ProposalAttachView.as_view(
             owner_model=Study,
         ),
-        name="attach_study",
-    ),
-    path(
-        "attach_proposal/extra/<int:other_pk>/",
-        ProposalAttachView.as_view(owner_model=Proposal, extra=True),
-        name="attach_proposal",
-    ),
-    path(
-        "attach_study/extra/<int:other_pk>/",
-        ProposalAttachView.as_view(owner_model=Study, extra=True),
         name="attach_study",
     ),
     path(

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -43,7 +43,9 @@ class Stepper(renderable):
         self.check_all(self.starting_checkers)
 
     @property
-    def attachment_slots(self,):
+    def attachment_slots(
+        self,
+    ):
         """
         Appends unmatched attachments as extra slots to the internal
         list _attachment_slots.
@@ -53,9 +55,7 @@ class Stepper(renderable):
         for obj in objects:
             success = True
             while success:
-                exclude = [
-                    s.attachment for s in self._attachment_slots
-                ] + [
+                exclude = [s.attachment for s in self._attachment_slots] + [
                     s.attachment for s in extra_slots
                 ]
                 empty_slot = AttachmentSlot(

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -51,10 +51,14 @@ class Stepper(renderable):
         list _attachment_slots.
         """
         extra_slots = []
+        # Get all attachable objects
         objects = [self.proposal] + list(self.proposal.study_set.all())
         for obj in objects:
             success = True
             while success:
+                # Keep appending extra slots as long as they can be matched to
+                # to an attachment for this object. We update the exclude list
+                # as we go to not duplicate them or end up in an infinite loop.
                 exclude = [s.attachment for s in self._attachment_slots] + [
                     s.attachment for s in extra_slots
                 ]

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -17,6 +17,8 @@ from observations.forms import ObservationForm
 from interventions.forms import InterventionForm
 
 from proposals.utils.validate_sessions_tasks import validate_sessions_tasks
+from attachments.utils import AttachmentSlot
+from attachments.kinds import desiredness
 
 
 class Stepper(renderable):
@@ -37,8 +39,33 @@ class Stepper(renderable):
         self.request = request
         self.items = []
         self.current_item_ancestors = []
-        self.attachment_slots = []
+        self._attachment_slots = []
         self.check_all(self.starting_checkers)
+
+    @property
+    def attachment_slots(self,):
+        """
+        Appends unmatched attachments as extra slots to the internal
+        list _attachment_slots.
+        """
+        extra_slots = []
+        objects = [self.proposal] + list(self.proposal.study_set.all())
+        for obj in objects:
+            success = True
+            while success:
+                exclude = [
+                    s.attachment for s in self._attachment_slots
+                ] + [
+                    s.attachment for s in extra_slots
+                ]
+                empty_slot = AttachmentSlot(
+                    obj,
+                    force_desiredness=desiredness.EXTRA,
+                )
+                success = empty_slot.match(exclude=exclude)
+                if success:
+                    extra_slots.append(empty_slot)
+        return self._attachment_slots + extra_slots
 
     def get_context_data(self):
         context = super().get_context_data()
@@ -167,9 +194,9 @@ class Stepper(renderable):
         here because the stepper has ownership of the already matched
         attachments to be excluded from matching.
         """
-        exclude = [slot.attachment for slot in self.attachment_slots]
+        exclude = [slot.attachment for slot in self._attachment_slots]
         slot.match(exclude)
-        self.attachment_slots.append(slot)
+        self._attachment_slots.append(slot)
 
     def has_multiple_studies(
         self,

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -103,6 +103,9 @@ class AttachFormView:
     model = Attachment
     form_class = AttachForm
     template_name = "proposals/attach_form.html"
+    # The editing variable is set in the URLconf to determine
+    # if we're editing an existing file or adding a new one.
+    editing = True
 
     def set_upload_field_label(self, form):
         # Remind the user of what they're uploading
@@ -182,7 +185,6 @@ class ProposalUpdateAttachmentView(
     model = Attachment
     form_class = AttachForm
     template_name = "proposals/attach_form.html"
-    editing = True
 
     def get_object(
         self,

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -97,10 +97,10 @@ class AttachFormView:
         return owner_class.objects.get(pk=other_pk)
 
     def get_kind(self):
-        if self.extra:
-            return None
-        kind_str = self.kwargs.get("kind")
-        return get_kind_from_str(kind_str)
+        kind_str = self.kwargs.get("kind", None)
+        if kind_str:
+            return get_kind_from_str(kind_str)
+        return None
 
     def get_success_url(
         self,
@@ -119,8 +119,7 @@ class AttachFormView:
                 "other_object": self.get_owner_object(),
             }
         )
-        if not self.extra:
-            kwargs["kind"] = self.get_kind()
+        kwargs["kind"] = self.get_kind()
         return kwargs
 
 
@@ -159,11 +158,6 @@ class ProposalUpdateAttachmentView(
         other_class = self.get_kind().attached_object
         other_pk = self.kwargs.get("other_pk")
         return other_class.objects.get(pk=other_pk)
-
-    def get_kind(self):
-        obj = self.get_object()
-        kind_str = obj.kind
-        return get_kind_from_str(kind_str)
 
 
 class DetachForm(

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -155,7 +155,9 @@ class ProposalUpdateAttachmentView(
         return obj
 
     def get_owner_object(self):
-        other_class = self.get_kind().attached_object
+        instance = self.get_object().get_correct_submodel()
+        attached_field = instance._meta.get_field("attached_to")
+        other_class = attached_field.related_model
         other_pk = self.kwargs.get("other_pk")
         return other_class.objects.get(pk=other_pk)
 

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -10,8 +10,10 @@ from attachments.models import Attachment, ProposalAttachment, StudyAttachment
 from main.forms import ConditionalModelForm
 from cdh.core import forms as cdh_forms
 from django.http import FileResponse
-from attachments.kinds import ATTACHMENTS
+from attachments.kinds import ATTACHMENTS, KIND_CHOICES
 from attachments.utils import AttachmentKind
+from cdh.core import forms as cdh_forms
+from django.utils.translation import gettext as _
 
 
 class AttachForm(
@@ -26,6 +28,11 @@ class AttachForm(
             "name",
             "comments",
         ]
+        widgets = {
+            "kind": cdh_forms.BootstrapSelect(
+                choices=KIND_CHOICES,
+            )
+        }
 
     def __init__(self, kind=None, other_object=None, extra=False, **kwargs):
         self.kind = kind
@@ -36,8 +43,10 @@ class AttachForm(
         elif type(other_object) is Study:
             self._meta.model = StudyAttachment
         super().__init__(**kwargs)
-        if not extra:
+        if kind is not None:
             del self.fields["kind"]
+        else:
+            self.fields["kind"].default = ("other", _("Overig bestand"))
 
     def save(
         self,


### PR DESCRIPTION
This branch allows for the adding for extra attachments to a proposal and its studies.

An additional change to this branch is that we now allow changing the kind ("Type") of an attachment in the attachment update views. 

Earlier I thought it would make sense to always enforce the kind if it was set by a slot. Now, when implementing extra files this felt like an overreach which would require deleting and re-adding of files by the user if they ever wanted to change the type.

Changing the type of a required attachment will simply move it from the required to an extra slot, as the attachment no longer fulfills the requirements for the required slot. Only if you are adding a **new** attachment to a required slot will the kind be enforced by the view.

I recommend taking a look at the changes to `Stepper.attachment_slots()`, which is now a property that matches slots on the fly. Slots generated by checkers now live in `Stepper._attachment_slots`, but that change should be of no consequence as long as the `Stepper.add_slot()` method is used.

