### PR TITLE
Feature/all attachment kinds

### DIFF
--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -19,6 +19,7 @@ class StudyAttachmentKind(AttachmentKind):
     attached_object = Study
     attachment_class = StudyAttachment
 
+
 #####################
 # Information letters
 #####################
@@ -27,52 +28,171 @@ class InformationLetterAnonymous(StudyAttachmentKind):
 
     db_name = "information_letter_anonymous"
     name = _("Informatiebrief anoniem onderzoek")
-    description = _("Je verzamelt en verwerkt de gegevens van je deelnemers"
-                    " anoniem. Je moet je deelnemers dan wél informeren op"
-                    " ethische gronden (zodat ze kunnen beslissen of ze"
-                    " vrijwillig willen meedoen), maar omdat de AVG niet"
-                    " van toepassing is op anonieme gegevens, hoef je geen"
-                    " informatie te verstrekken over de verwerking van"
-                    " persoonsgegevens.")
+    description = _(
+        "Je verzamelt en verwerkt de gegevens van je deelnemers"
+        " anoniem. Je moet je deelnemers dan wél informeren op"
+        " ethische gronden (zodat ze kunnen beslissen of ze"
+        " vrijwillig willen meedoen), maar omdat de AVG niet"
+        " van toepassing is op anonieme gegevens, hoef je geen"
+        " informatie te verstrekken over de verwerking van"
+        " persoonsgegevens."
+    )
     desiredness = desiredness.REQUIRED
+
 
 class InformationLetterPublicInterest(StudyAttachmentKind):
 
     db_name = "information_letter_public_interest"
     name = _("Informatiebrief algemeen belang")
-    description = _("Je kiest ervoor om de verwerking van persoonsgegevens te"
-                    " baseren op het algemeen belang. In beginsel is dit"
-                    " de standaardwerkwijze. \n"
-                    "Let op! Voor bepaalde aspecten van je onderzoek kan het"
-                    " desondanks nodig zijn om toestemming te vragen.")
+    description = _(
+        "Je kiest ervoor om de verwerking van persoonsgegevens te"
+        " baseren op het algemeen belang. In beginsel is dit"
+        " de standaardwerkwijze. \n"
+        "Let op! Voor bepaalde aspecten van je onderzoek kan het"
+        " desondanks nodig zijn om toestemming te vragen."
+    )
     desiredness = desiredness.REQUIRED
+
 
 class InformationLetterConsent(StudyAttachmentKind):
 
     db_name = "information_letter_consent"
     name = _("Informatiebrief toestemming")
-    description = _("Er zijn redenen om de verwerking van persoonsgegevens"
-                    " te baseren op toestemming van de deelnemers."
-                    " Bijvoorbeeld als er gevoelige data wordt verzameld of"
-                    " er met minderjarigen wordt gewerkt.")
+    description = _(
+        "Er zijn redenen om de verwerking van persoonsgegevens"
+        " te baseren op toestemming van de deelnemers."
+        " Bijvoorbeeld als er gevoelige data wordt verzameld of"
+        " er met minderjarigen wordt gewerkt."
+    )
     desiredness = desiredness.REQUIRED
+
 
 LEGAL_BASIS_KIND_DICT = {
     Study.LegalBases.ANONYMOUS: InformationLetterAnonymous,
     Study.LegalBases.CONSENT: InformationLetterConsent,
-    Study.LegalBases.PUBLIC_INTEREST: InformationLetterPublicInterest,    
+    Study.LegalBases.PUBLIC_INTEREST: InformationLetterPublicInterest,
 }
+
 
 ###############
 # Consent forms
 ###############
 
-class ConsentForm(AttachmentKind):
+class ConsentForm(StudyAttachmentKind):
 
     db_name = "consent_form"
     name = _("Toestemmingsverklaring")
-    description = _("Omschrijving toestemmingsverklaring")
+    description = _(
+        "Je baseert de verwerking van persoonsgegevens binnen je onderzoek op"
+        " de wettelijke grondslag toestemming. De deelnemers zijn volwassenen"
+        " (16 jaar en ouder)."
+    )
+    desiredness = desiredness.REQUIRED
 
+class ConsentPublicInterestSpecialDetails(StudyAttachmentKind):
+
+    db_name = "consent_public_interest_special_details"
+    name = _("Toestemmingsverklaring algemeen belang bijzondere persoonsgegevens")
+    description = _(
+        "Je baseert de verwerking van persoonsgegevens binnen je onderzoek"
+        " weliswaar op de wettelijke grondslag algemeen belang, maar je"
+        " verzamelt zgn. bijzondere persoonsgegevens externe link en daarvoor"
+        " heb je toestemming nodig."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+class ConsentChildrenParents(StudyAttachmentKind):
+
+    db_name = "consent_children_w_parents"
+    name = _("Toestemmingsverklaring kinderen tot 16 jaar, ouders of voogden aanwezig")
+    description = _(
+        "Je baseert de verwerking van persoonsgegevens binnen je"
+        " onderzoek op de wettelijke grondslag toestemming. De"
+        " deelnemers zijn kinderen jonger dan 16 jaar en minimaal"
+        " één van de ouders of voogden is bij het onderzoek aanwezig."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+class ConsentChildrenNoParents(StudyAttachmentKind):
+
+    db_name = "consent_children_no_parents"
+    name = _("Toestemmingsverklaring kinderen tot 16 jaar, ouders of voogden afwezig")
+    description = _(
+        "Je baseert de verwerking van persoonsgegevens binnen je"
+        " onderzoek op de wettelijke grondslag toestemming. De"
+        " deelnemers zijn kinderen jonger dan 16 jaar en er zijn"
+        " geen ouders of voodgen aanwezig."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+####################
+# Recordings consent
+####################
+
+class AgreementRecordingsPublicInterest(StudyAttachmentKind):
+
+    db_name = "agreement_av_recordings"
+    name = _("Akkoordverklaring beeld- en geluidsopnames algemeen belang")
+    description = _(
+        "Je baseert de verwerking van persoonsgegevens weliswaar op de"
+        " wettelijke grondslag algemeen belang, maar je maakt beeld- en/of"
+        " geluidsopnames en daar moeten je deelnemers op ethische gronden"
+        " mee instemmen. Ook voor het verdere gebruik van die opnames kun"
+        " je de afspraken schriftelijk vastleggen."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+class ScriptVerbalConsentRecordings(StudyAttachmentKind):
+
+    db_name = "script_verbal_consent_recordings"
+    name = _("Script voor mondelinge toestemming opnames")
+    description = _(
+        "Je interviewt deelnemers en je maakt daarvan beeld- en/of"
+        " geluidsopnames. De toestemming daarvoor, en de eventuele"
+        " toestemming en afspraken met betrekking tot andere aspecten van"
+        " de verwerking van persoonsgegevens, leg je vast in een aparte opname."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+##############
+# School stuff
+##############
+
+class SchoolInformationLetter(ProposalAttachmentKind):
+
+    db_name = "school_information_letter"
+    name = _("Informatiebrief gatekeeper/schoolleiding")
+    description = _(
+        "Je wilt onderzoek gaan doen binnen een bepaalde instelling (bijv."
+        " een school) en je verzoekt de leiding van die instelling om"
+        " medewerking. Voor het maken van een geïnformeerde keuze moet de"
+        " leiding van de instelling op de hoogte zijn van de opzet van je"
+        " onderzoek en van allerlei praktische aspecten."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+class SchoolConsentForm(ProposalAttachmentKind):
+
+    db_name = "school_consent_form"
+    name = _("Akkoordverklaring gatekeeper/schoolleiding")
+    description = _(
+        "Je wilt onderzoek gaan doen binnen een bepaalde instelling (bijv."
+        " een school) en je verzoekt de leiding van die instelling om"
+        " medewerking. De schoolleiding moet, na goed geïnformeerd te zijn"
+        "toestemming geven voor het onderzoek."
+    )
+    desiredness = desiredness.REQUIRED
+
+
+#############
+# Other stuff
+#############
 
 class DataManagementPlan(ProposalAttachmentKind):
 
@@ -103,10 +223,17 @@ STUDY_ATTACHMENTS = [
     InformationLetterAnonymous,
     InformationLetterPublicInterest,
     InformationLetterConsent,
+    AgreementRecordingsPublicInterest,
+    ScriptVerbalConsentRecordings,
+    ConsentPublicInterestSpecialDetails,
+    ConsentChildrenParents,
+    ConsentChildrenNoParents,
     ConsentForm,
 ]
 
 PROPOSAL_ATTACHMENTS = [
+    SchoolInformationLetter,
+    SchoolConsentForm,
     DataManagementPlan,
     OtherProposalAttachment,
 ]

--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -19,14 +19,53 @@ class StudyAttachmentKind(AttachmentKind):
     attached_object = Study
     attachment_class = StudyAttachment
 
+#####################
+# Information letters
+#####################
 
-class InformationLetter(StudyAttachmentKind):
+class InformationLetterAnonymous(StudyAttachmentKind):
 
-    db_name = "information_letter"
-    name = _("Informatiebrief")
-    description = _("Omschrijving informatiebrief")
+    db_name = "information_letter_anonymous"
+    name = _("Informatiebrief anoniem onderzoek")
+    description = _("Je verzamelt en verwerkt de gegevens van je deelnemers"
+                    " anoniem. Je moet je deelnemers dan wél informeren op"
+                    " ethische gronden (zodat ze kunnen beslissen of ze"
+                    " vrijwillig willen meedoen), maar omdat de AVG niet"
+                    " van toepassing is op anonieme gegevens, hoef je geen"
+                    " informatie te verstrekken over de verwerking van"
+                    " persoonsgegevens.")
     desiredness = desiredness.REQUIRED
 
+class InformationLetterPublicInterest(StudyAttachmentKind):
+
+    db_name = "information_letter_public_interest"
+    name = _("Informatiebrief algemeen belang")
+    description = _("Je kiest ervoor om de verwerking van persoonsgegevens te"
+                    " baseren op het algemeen belang. In beginsel is dit"
+                    " de standaardwerkwijze. \n"
+                    "Let op! Voor bepaalde aspecten van je onderzoek kan het"
+                    " desondanks nodig zijn om toestemming te vragen.")
+    desiredness = desiredness.REQUIRED
+
+class InformationLetterConsent(StudyAttachmentKind):
+
+    db_name = "information_letter_consent"
+    name = _("Informatiebrief toestemming")
+    description = _("Er zijn redenen om de verwerking van persoonsgegevens"
+                    " te baseren op toestemming van de deelnemers."
+                    " Bijvoorbeeld als er gevoelige data wordt verzameld of"
+                    " er met minderjarigen wordt gewerkt.")
+    desiredness = desiredness.REQUIRED
+
+LEGAL_BASIS_KIND_DICT = {
+    Study.LegalBases.ANONYMOUS: InformationLetterAnonymous,
+    Study.LegalBases.CONSENT: InformationLetterConsent,
+    Study.LegalBases.PUBLIC_INTEREST: InformationLetterPublicInterest,    
+}
+
+###############
+# Consent forms
+###############
 
 class ConsentForm(AttachmentKind):
 
@@ -61,7 +100,9 @@ class OtherProposalAttachment(ProposalAttachmentKind):
 
 
 STUDY_ATTACHMENTS = [
-    InformationLetter,
+    InformationLetterAnonymous,
+    InformationLetterPublicInterest,
+    InformationLetterConsent,
     ConsentForm,
 ]
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 09:51+0200\n"
+"POT-Creation-Date: 2024-11-07 10:32+0100\n"
 "PO-Revision-Date: 2024-04-03 12:32+0200\n"
 "Last-Translator: Anna Asbury <anna.asbury@annaasbury.com>\n"
 "Language-Team: \n"
@@ -16,6 +16,241 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.1\n"
+
+#: attachments/kinds.py:30
+msgid "Informatiebrief anoniem onderzoek"
+msgstr "Information letter anonymous research"
+
+#: attachments/kinds.py:32
+msgid ""
+"Je verzamelt en verwerkt de gegevens van je deelnemers anoniem. Je moet je "
+"deelnemers dan wél informeren op ethische gronden (zodat ze kunnen beslissen "
+"of ze vrijwillig willen meedoen), maar omdat de AVG niet van toepassing is "
+"op anonieme gegevens, hoef je geen informatie te verstrekken over de "
+"verwerking van persoonsgegevens."
+msgstr ""
+"You collect and process your participants' data anonymously. You do have "
+"to inform your participants on ethical grounds (so they can decide if they "
+"want to participate voluntarily), but because the GDPR does not apply to "
+"anonymous data, you do not have to provide information about the processing "
+"of personal data."
+
+#: attachments/kinds.py:46
+msgid "Informatiebrief algemeen belang"
+msgstr "Information letter public interest"
+
+#: attachments/kinds.py:48
+msgid ""
+"Je kiest ervoor om de verwerking van persoonsgegevens te baseren op het "
+"algemeen belang. In beginsel is dit de standaardwerkwijze. \n"
+"Let op! Voor bepaalde aspecten van je onderzoek kan het desondanks nodig "
+"zijn om toestemming te vragen."
+msgstr ""
+"You choose to process personal data on the legal basis public interest. "
+"In principle, this is the standard operating procedure. \n"
+"Please note! Certain aspects of your research may nevertheless require you "
+"to obtain consent. Whether this is the case is indicated in the information letter below."
+
+#: attachments/kinds.py:60
+msgid "Informatiebrief toestemming"
+msgstr "Information letter consent"
+
+#: attachments/kinds.py:62
+msgid ""
+"Er zijn redenen om de verwerking van persoonsgegevens te baseren op "
+"toestemming van de deelnemers. Bijvoorbeeld als er gevoelige data wordt "
+"verzameld of er met minderjarigen wordt gewerkt."
+msgstr "There are reasons to base the processing of personal data on "
+"participant consent. Such reasons could be if you are processing sensitive "
+"data, or are working with minors."
+
+#: attachments/kinds.py:84
+msgid "Toestemmingsverklaring"
+msgstr "Declaration of consent"
+
+#: attachments/kinds.py:86
+msgid ""
+"Je baseert de verwerking van persoonsgegevens binnen je onderzoek op de "
+"wettelijke grondslag toestemming. De deelnemers zijn volwassenen (16 jaar en "
+"ouder)."
+msgstr ""
+"You base the processing of personal data within your research on the legal "
+"basis consent. Participants are adults (16 years and older)."
+
+#: attachments/kinds.py:95
+msgid "Toestemmingsverklaring algemeen belang bijzondere persoonsgegevens"
+msgstr "Declaration of consent public interest special categories of data"
+
+#: attachments/kinds.py:97
+msgid ""
+"Je baseert de verwerking van persoonsgegevens binnen je onderzoek weliswaar "
+"op de wettelijke grondslag algemeen belang, maar je verzamelt zgn. "
+"bijzondere persoonsgegevens externe link en daarvoor heb je toestemming "
+"nodig."
+msgstr ""
+"Although you base the processing of personal data within your research on "
+"the legal basis public interest, you collect so-called special categories "
+"of personal data external link and for that you need consent."
+
+#: attachments/kinds.py:108
+msgid "Toestemmingsverklaring kinderen tot 16 jaar, ouders of voogden aanwezig"
+msgstr "Declaration of consent children up to the age of 16, parents or caregivers present"
+
+#: attachments/kinds.py:110
+msgid ""
+"Je baseert de verwerking van persoonsgegevens binnen je onderzoek op de "
+"wettelijke grondslag toestemming. De deelnemers zijn kinderen jonger dan 16 "
+"jaar en minimaal één van de ouders of voogden is bij het onderzoek aanwezig."
+msgstr ""
+"You base the processing of personal data within your research on the legal "
+"basis consent. Your participants are children under the age of 16 and at "
+"least one of the parents or guardians is present during the research."
+
+#: attachments/kinds.py:121
+msgid "Toestemmingsverklaring kinderen tot 16 jaar, ouders of voogden afwezig"
+msgstr "Declaration of consent children up to the age of 16, no parents or caregivers present"
+
+
+#: attachments/kinds.py:123
+msgid ""
+"Je baseert de verwerking van persoonsgegevens binnen je onderzoek op de "
+"wettelijke grondslag toestemming. De deelnemers zijn kinderen jonger dan 16 "
+"jaar en er zijn geen ouders of voodgen aanwezig."
+msgstr ""
+"You base the processing of personal data within your research on the legal "
+"basis consent. Your participants are children under the age of 16 and no "
+"parents or guardians are present during the research."
+
+#: attachments/kinds.py:138
+msgid "Akkoordverklaring beeld- en geluidsopnames algemeen belang"
+msgstr "Agreement video- or audiorecordings public interest"
+
+#: attachments/kinds.py:140
+msgid ""
+"Je baseert de verwerking van persoonsgegevens weliswaar op de wettelijke "
+"grondslag algemeen belang, maar je maakt beeld- en/of geluidsopnames en daar "
+"moeten je deelnemers op ethische gronden mee instemmen. Ook voor het verdere "
+"gebruik van die opnames kun je de afspraken schriftelijk vastleggen."
+msgstr ""
+"Although you base the processing of personal data on the legal basis "
+"public interest, you make video and/or audio recordings and for that you "
+"need consent. For the further use of those recordings, you can also put agreements in writing."
+
+#: attachments/kinds.py:152
+msgid "Script voor mondelinge toestemming opnames"
+msgstr "Script for verbal consent recordings"
+
+#: attachments/kinds.py:154
+msgid ""
+"Je interviewt deelnemers en je maakt daarvan beeld- en/of geluidsopnames. De "
+"toestemming daarvoor, en de eventuele toestemming en afspraken met "
+"betrekking tot andere aspecten van de verwerking van persoonsgegevens, leg "
+"je vast in een aparte opname."
+msgstr ""
+"You interview participants and make video and/or audio recordings of them. "
+"You record consent for this, and any consent and agreements regarding other "
+"aspects of the processing of personal data, in a separate recording."
+
+#: attachments/kinds.py:169
+msgid "Informatiebrief gatekeeper/schoolleiding"
+msgstr "Information letter gatekeeper/schoolmanagement"
+
+#: attachments/kinds.py:171
+msgid ""
+"Je wilt onderzoek gaan doen binnen een bepaalde instelling (bijv. een "
+"school) en je verzoekt de leiding van die instelling om medewerking. Voor "
+"het maken van een geïnformeerde keuze moet de leiding van de instelling op "
+"de hoogte zijn van de opzet van je onderzoek en van allerlei praktische "
+"aspecten."
+msgstr ""
+"You want to conduct research within a particular institution (e.g., a school) "
+"and you request the cooperation of the management of that institution. "
+"To make an informed choice, the management of that institution must be aware "
+"of the design of your research and a variety of practical aspects. "
+
+#: attachments/kinds.py:183
+msgid "Akkoordverklaring gatekeeper/schoolleiding"
+msgstr "Declaration of cooperation gatekeeper/schoolmanagement"
+
+#: attachments/kinds.py:185
+msgid ""
+"Je wilt onderzoek gaan doen binnen een bepaalde instelling (bijv. een "
+"school) en je verzoekt de leiding van die instelling om medewerking. De "
+"schoolleiding moet, na goed geïnformeerd te zijntoestemming geven voor het "
+"onderzoek."
+msgstr ""
+"You want to conduct research within a particular institution (e.g., a school) "
+"and you request the cooperation of the management of that institution. "
+"The school management must, after having been properly informed, give consent"
+"to the students' participation in the research."
+
+#: attachments/kinds.py:200
+#: proposals/templates/proposals/proposal_data_management.html:17
+#: proposals/utils/pdf_diff_logic.py:980
+#: reviews/templatetags/documents_list.py:224
+msgid "Data Management Plan"
+msgstr "Data Management Plan"
+
+#: attachments/kinds.py:201
+msgid "Omschrijving DMP"
+msgstr "description DMP"
+
+#: attachments/kinds.py:210
+msgid "Overige bestanden"
+msgstr "Other attachments"
+
+#: attachments/kinds.py:211
+msgid "Voor alle overige soorten bestanden"
+msgstr "For all other attachments"
+
+#: attachments/models.py:22
+msgid "Bestand"
+msgstr "File"
+
+#: attachments/models.py:23
+msgid "Selecteer hier het bestand om toe te voegen."
+msgstr "Select a file to upload."
+
+#: attachments/models.py:40
+msgid "Gelieve selecteren"
+msgstr "Please select"
+
+#: attachments/models.py:46
+msgid "Geef je bestand een omschrijvende naam, het liefst maar enkele woorden."
+msgstr "Give your file a descriptive name, preferably a short one."
+
+#: attachments/models.py:53
+msgid ""
+"Geef hier optioneel je motivatie om dit bestand toe te voegen en waar je het "
+"voor gaat gebruiken tijdens je onderzoek. Eventuele opmerkingen voor de FETC "
+"kun je hier ook kwijt."
+msgstr ""
+"Optionally, provide your motivation for uploading this file and what you "
+"will be using it for. Other remarks for the FETC can also be provided here."
+
+#: attachments/templates/attachments/slot.html:16
+msgid "Wijzig"
+msgstr "Edit"
+
+#: attachments/templates/attachments/slot.html:18
+msgid "Voeg toe"
+msgstr "Upload"
+
+#: attachments/utils.py:11
+msgid "Verplicht"
+msgstr "Required"
+
+#: attachments/utils.py:12
+msgid "Aangeraden"
+msgstr "Recommended"
+
+#: attachments/utils.py:13
+msgid "Optioneel"
+msgstr "Optional"
+
+#: attachments/utils.py:14
+msgid "Extra"
+msgstr "Extra"
 
 #: faqs/menus.py:7 main/templates/main/index.html:130
 msgid "FETC-GW website"
@@ -63,11 +298,11 @@ msgstr "FAQ"
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-#: fetc/settings.py:135
+#: fetc/settings.py:137
 msgid "Nederlands"
 msgstr "Dutch"
 
-#: fetc/settings.py:136
+#: fetc/settings.py:138
 msgid "Engels"
 msgstr "English"
 
@@ -612,7 +847,7 @@ msgid "Nieuw amendement starten"
 msgstr "Create new amendment"
 
 #: main/templates/main/index.html:90 proposals/menus.py:112
-#: proposals/views/proposal_views.py:190
+#: proposals/views/proposal_views.py:189
 msgid "Archief"
 msgstr "Archive"
 
@@ -1271,23 +1506,23 @@ msgstr "New application"
 msgid "Al mijn aanvragen"
 msgstr "All my applications"
 
-#: proposals/menus.py:58 proposals/views/proposal_views.py:103
+#: proposals/menus.py:58 proposals/views/proposal_views.py:102
 msgid "Mijn conceptaanvragen"
 msgstr "My draft applications"
 
-#: proposals/menus.py:62 proposals/views/proposal_views.py:162
+#: proposals/menus.py:62 proposals/views/proposal_views.py:161
 msgid "Mijn oefenaanvragen"
 msgstr "My practice applications"
 
-#: proposals/menus.py:66 proposals/views/proposal_views.py:117
+#: proposals/menus.py:66 proposals/views/proposal_views.py:116
 msgid "Mijn ingediende aanvragen"
 msgstr "My submitted applications"
 
-#: proposals/menus.py:70 proposals/views/proposal_views.py:131
+#: proposals/menus.py:70 proposals/views/proposal_views.py:130
 msgid "Mijn afgehandelde aanvragen"
 msgstr "My processed applications"
 
-#: proposals/menus.py:74 proposals/views/proposal_views.py:145
+#: proposals/menus.py:74 proposals/views/proposal_views.py:144
 msgid "Mijn aanvragen als eindverantwoordelijke"
 msgstr "My supervised applications"
 
@@ -1818,6 +2053,79 @@ msgstr "Please upload the decision of METC  (in .pdf or .doc(x)-format) here"
 msgid "WMO {title}, status {status}"
 msgstr "WMO {title}, status {status}"
 
+#: proposals/templates/proposals/attach_form.html:7
+msgid "Voeg een bestand toe"
+msgstr "Upload a file"
+
+#: proposals/templates/proposals/attach_form.html:11
+msgid "Maak of wijzig een bestand"
+msgstr "Create of edit a file"
+
+#: proposals/templates/proposals/attach_form.html:14
+msgid "Je voegt een bestand toe aan het volgende:"
+msgstr "You are adding an attachment to the following:"
+
+#: proposals/templates/proposals/attach_form.html:18
+msgid "Je bewerkt het volgende bestand:"
+msgstr "You are editing the following attachment:"
+
+#: proposals/templates/proposals/attach_form.html:22
+msgid "Dit bestand is gekoppeld aan het volgende:"
+msgstr "This file is attached to the following:"
+
+#: proposals/templates/proposals/attach_form.html:29
+msgid "Traject %(order)s: <em>%(name)s</em> van"
+msgstr "Trajectory %(order)s (<em>%(name)s</em>)"
+
+#: proposals/templates/proposals/attach_form.html:33
+msgid "de aanvraag"
+msgstr "the application"
+
+#: proposals/templates/proposals/attach_form.html:36
+#, python-format
+msgid ""
+"Je gaat hier een %(name)s aan toevoegen. Wil je een ander soort bestand "
+"toevoegen? Ga dan terug naar de vorige pagina."
+msgstr ""
+"You are about to add a %(name)s. If you are looking to upload a different "
+"type of attachment, please return to the previous page."
+
+#: proposals/templates/proposals/attach_form.html:47
+#: proposals/templates/proposals/detach_form.html:29
+msgid "<< Ga terug"
+msgstr "<< Go back"
+
+#: proposals/templates/proposals/attach_form.html:52
+msgid "Bestand verwijderen"
+msgstr "Delete file"
+
+#: proposals/templates/proposals/attach_form.html:58
+msgid "Opslaan"
+msgstr "Save"
+
+#: proposals/templates/proposals/attachments.html:7
+#: proposals/templates/proposals/other_researchers_form.html:7
+#: proposals/templates/proposals/other_researchers_form.html:21
+#: proposals/utils/proposal_utils.py:60
+msgid "Informatie over betrokken onderzoekers"
+msgstr "Information about other researchers"
+
+#: proposals/templates/proposals/attachments.html:11
+#: proposals/utils/checkers.py:1039 proposals/utils/stepper.py:226
+#: reviews/templates/reviews/review_detail_sidebar.html:124
+msgid "Documenten"
+msgstr "Documents"
+
+#: proposals/templates/proposals/attachments.html:12
+msgid "Algemeen"
+msgstr "General"
+
+#: proposals/templates/proposals/attachments.html:19
+#: proposals/utils/pdf_diff_logic.py:319 proposals/utils/pdf_diff_logic.py:346
+#: proposals/utils/pdf_diff_logic.py:355 proposals/utils/pdf_diff_logic.py:379
+msgid "Traject "
+msgstr "Trajectory "
+
 #: proposals/templates/proposals/compare_documents.html:8
 #: proposals/templates/proposals/compare_documents.html:50
 msgid "Vergelijk documenten"
@@ -1865,6 +2173,34 @@ msgstr "Old"
 msgid "Nieuw"
 msgstr "New"
 
+#: proposals/templates/proposals/detach_form.html:7
+#: proposals/templates/proposals/detach_form.html:11
+msgid "Verwijder een bestand"
+msgstr "Delete a file"
+
+#: proposals/templates/proposals/detach_form.html:13
+msgid "Je verwijdert het volgende bestand:"
+msgstr "You are deleting the following file:"
+
+#: proposals/templates/proposals/detach_form.html:19
+msgid ""
+"Als je een nieuwe versie van dit document wil aanleveren, verwijder het dan "
+"niet, maar ga dan terug naar de vorige pagina en wijzig het daar. Zo blijft "
+"de geschiedenis van het document bewaard, en dat vergemakkelijkt het "
+"beoordeelproces aanzienlijk."
+msgstr ""
+"If you would like to upload a new version of this file, do not delete it, but"
+"return to the previous page and edit it. This ensures the document's history"
+"will persist and significantly eases the review process."
+
+#: proposals/templates/proposals/detach_form.html:34
+#: proposals/templates/proposals/proposal_confirm_delete.html:22
+#: proposals/templates/proposals/vue_templates/proposal_list.html:66
+#: tasks/templates/tasks/session_confirm_delete.html:22
+#: tasks/templates/tasks/task_confirm_delete.html:22
+msgid "Verwijderen"
+msgstr "Delete"
+
 #: proposals/templates/proposals/funding_form.html:7
 #: proposals/templates/proposals/funding_form.html:21
 #: proposals/utils/proposal_utils.py:68
@@ -1875,12 +2211,6 @@ msgstr "Funding information"
 #: proposals/templates/proposals/knowledge_security_form.html:21
 msgid "Afronding trajecten"
 msgstr "Trajectories conclusion"
-
-#: proposals/templates/proposals/other_researchers_form.html:7
-#: proposals/templates/proposals/other_researchers_form.html:21
-#: proposals/utils/proposal_utils.py:60
-msgid "Informatie over betrokken onderzoekers"
-msgstr "Information about other researchers"
 
 #: proposals/templates/proposals/practice_or_supervisor_warning.html:7
 msgid ""
@@ -1918,13 +2248,6 @@ msgstr "Delete application"
 #, python-format
 msgid "Weet je zeker dat je de aanvraag <em>%(title)s</em> wilt verwijderen?"
 msgstr "Are you sure you want to delete the application <em>%(title)s</em>?"
-
-#: proposals/templates/proposals/proposal_confirm_delete.html:22
-#: proposals/templates/proposals/vue_templates/proposal_list.html:66
-#: tasks/templates/tasks/session_confirm_delete.html:22
-#: tasks/templates/tasks/task_confirm_delete.html:22
-msgid "Verwijderen"
-msgstr "Delete"
 
 #: proposals/templates/proposals/proposal_confirm_delete.html:23
 #: proposals/templates/proposals/proposal_copy.html:93
@@ -2049,7 +2372,7 @@ msgid "Kopiëren"
 msgstr "Copy"
 
 #: proposals/templates/proposals/proposal_data_management.html:7
-#: proposals/utils/proposal_utils.py:136 proposals/utils/stepper.py:216
+#: proposals/utils/proposal_utils.py:136 proposals/utils/stepper.py:227
 msgid "Datamanagement"
 msgstr "Data management"
 
@@ -2068,12 +2391,6 @@ msgstr ""
 "dealing with research data (including personal data). Furthermore, since the "
 "introduction of the GDPR there are clear rules which researchers should "
 "follow with regard to data."
-
-#: proposals/templates/proposals/proposal_data_management.html:17
-#: proposals/utils/pdf_diff_logic.py:980
-#: reviews/templatetags/documents_list.py:224
-msgid "Data Management Plan"
-msgstr "Data Management Plan"
 
 #: proposals/templates/proposals/proposal_data_management.html:20
 msgid ""
@@ -3070,93 +3387,88 @@ msgid ""
 msgstr ""
 "Ethical assessment by a Medical Ethical Testing Committee (METC) required?"
 
-#: proposals/utils/checkers.py:49 proposals/utils/stepper.py:212
-#: proposals/utils/stepper.py:221 proposals/utils/stepper.py:226
+#: proposals/utils/checkers.py:66 proposals/utils/stepper.py:223
+#: proposals/utils/stepper.py:232 proposals/utils/stepper.py:237
 msgid "Basisgegevens"
 msgstr "Basic details"
 
-#: proposals/utils/checkers.py:83
+#: proposals/utils/checkers.py:100
 msgid "Onderzoeker"
 msgstr "Researcher"
 
-#: proposals/utils/checkers.py:100
+#: proposals/utils/checkers.py:117
 msgid "Andere onderzoekers"
 msgstr "Other researchers"
 
-#: proposals/utils/checkers.py:129
+#: proposals/utils/checkers.py:146
 msgid "Financiering"
 msgstr "Funding"
 
-#: proposals/utils/checkers.py:151
+#: proposals/utils/checkers.py:168
 msgid "Onderzoeksdoel"
 msgstr "Research goal"
 
-#: proposals/utils/checkers.py:176
+#: proposals/utils/checkers.py:193
 msgid "Eerdere toetsing"
 msgstr "Prior approval"
 
-#: proposals/utils/checkers.py:275
+#: proposals/utils/checkers.py:292
 msgid "WMO applicatie"
 msgstr "WMO application"
 
-#: proposals/utils/checkers.py:304 proposals/utils/proposal_utils.py:116
-#: proposals/utils/stepper.py:214
+#: proposals/utils/checkers.py:321 proposals/utils/proposal_utils.py:116
+#: proposals/utils/stepper.py:225
 msgid "Trajecten"
 msgstr "Trajectories"
 
-#: proposals/utils/checkers.py:358
+#: proposals/utils/checkers.py:375
 msgid "Traject afronding"
 msgstr "Conclusion trajectory"
 
-#: proposals/utils/checkers.py:362
+#: proposals/utils/checkers.py:379
 msgid "Trajecten afronding"
 msgstr "Conclusion trajectories"
 
-#: proposals/utils/checkers.py:454 studies/utils.py:67
+#: proposals/utils/checkers.py:612 studies/utils.py:67
 msgid "Deelnemers"
 msgstr "Participants"
 
-#: proposals/utils/checkers.py:491
+#: proposals/utils/checkers.py:649
 #: studies/templates/studies/study_personal_data.html:7
 #: studies/templates/studies/study_personal_data.html:22
 msgid "Persoonlijke gegevens"
 msgstr "Personal data"
 
-#: proposals/utils/checkers.py:525
+#: proposals/utils/checkers.py:683
 msgid "Ontwerp"
 msgstr "Design"
 
-#: proposals/utils/checkers.py:556
+#: proposals/utils/checkers.py:714
 msgid "Traject overzicht"
 msgstr "Trajectory overview"
 
-#: proposals/utils/checkers.py:591
+#: proposals/utils/checkers.py:749
 msgid "Interventie"
 msgstr "Intervention"
 
-#: proposals/utils/checkers.py:649
+#: proposals/utils/checkers.py:807
 msgid "Observatie"
 msgstr "Observation"
 
-#: proposals/utils/checkers.py:707
+#: proposals/utils/checkers.py:865
 msgid "Sessies"
 msgstr "Sessions"
 
-#: proposals/utils/checkers.py:852 proposals/utils/stepper.py:215
-#: reviews/templates/reviews/review_detail_sidebar.html:124
-msgid "Documenten"
-msgstr "Documents"
-
-#: proposals/utils/checkers.py:863
+#: proposals/utils/checkers.py:1051
 msgid "Vertalingen"
 msgstr "Translations"
 
-#: proposals/utils/checkers.py:886
+#: proposals/utils/checkers.py:1074
 msgid "Data management"
 msgstr "Data management"
 
-#: proposals/utils/checkers.py:912 proposals/utils/stepper.py:217
-#: proposals/utils/stepper.py:222 proposals/utils/stepper.py:228
+#: proposals/utils/checkers.py:1100 proposals/utils/stepper.py:228
+#: proposals/utils/stepper.py:233 proposals/utils/stepper.py:239
 msgid "Indienen"
 msgstr "Submit"
 
@@ -3191,11 +3503,6 @@ msgstr "Not provided"
 #: tasks/templates/tasks/session_overview.html:7
 msgid "Overzicht van het takenonderzoek"
 msgstr "Overview of task-based research"
-
-#: proposals/utils/pdf_diff_logic.py:319 proposals/utils/pdf_diff_logic.py:346
-#: proposals/utils/pdf_diff_logic.py:355 proposals/utils/pdf_diff_logic.py:379
-msgid "Traject "
-msgstr "Trajectory "
 
 #: proposals/utils/pdf_diff_logic.py:349 proposals/utils/pdf_diff_logic.py:382
 msgid "sessie "
@@ -3264,7 +3571,7 @@ msgstr "FEtC-H: A revised application uses lab facilities"
 msgid "FETC-GW: nieuwe aanvraag gebruikt labfaciliteiten"
 msgstr "FEtC-H: New application uses lab facilities"
 
-#: proposals/utils/stepper.py:213 proposals/utils/stepper.py:227
+#: proposals/utils/stepper.py:224 proposals/utils/stepper.py:238
 msgid "WMO"
 msgstr "WMO"
 
@@ -3280,40 +3587,40 @@ msgstr "Session {}, task {}"
 msgid "Sessie {} overzicht"
 msgstr "Session {} overview"
 
-#: proposals/views/proposal_views.py:68
+#: proposals/views/proposal_views.py:67
 msgid "Publiek archief"
 msgstr "Public archive"
 
-#: proposals/views/proposal_views.py:69
+#: proposals/views/proposal_views.py:68
 msgid "Dit overzicht toont alle goedgekeurde aanvragen."
 msgstr "This overview shows all approved applications."
 
-#: proposals/views/proposal_views.py:88
+#: proposals/views/proposal_views.py:87
 msgid "Mijn aanvraag"
 msgstr "My application"
 
-#: proposals/views/proposal_views.py:89
+#: proposals/views/proposal_views.py:88
 msgid "Dit overzicht toont al je aanvragen."
 msgstr "This overview shows all your applications."
 
-#: proposals/views/proposal_views.py:104
+#: proposals/views/proposal_views.py:103
 msgid "Dit overzicht toont al je nog niet ingediende aanvragen."
 msgstr "This overview shows all the applications you have not yet submitted."
 
-#: proposals/views/proposal_views.py:118
+#: proposals/views/proposal_views.py:117
 msgid "Dit overzicht toont al je ingediende aanvragen."
 msgstr "This overview shows all the applications you have submitted."
 
-#: proposals/views/proposal_views.py:132
+#: proposals/views/proposal_views.py:131
 msgid "Dit overzicht toont al je beoordeelde aanvragen."
 msgstr "This overview shows all your applications that have been assessed."
 
-#: proposals/views/proposal_views.py:147
+#: proposals/views/proposal_views.py:146
 msgid ""
 "Dit overzicht toont alle aanvragen waarvan je eindverantwoordelijke bent."
 msgstr "This overview shows all your supervised applications."
 
-#: proposals/views/proposal_views.py:164
+#: proposals/views/proposal_views.py:163
 msgid ""
 "Dit overzicht toont alle oefenaanvragen waar je als student, onderzoeker of "
 "eindverantwoordelijke bij betrokken bent."
@@ -3321,20 +3628,20 @@ msgstr ""
 "This overview shows all practice applications in which you are involved as a "
 "student, researcher or accountable researcher."
 
-#: proposals/views/proposal_views.py:244
+#: proposals/views/proposal_views.py:243
 #, python-format
 msgid "Aanvraag %(title)s aangemaakt"
 msgstr "Application %(title)s created"
 
-#: proposals/views/proposal_views.py:302
+#: proposals/views/proposal_views.py:301
 msgid "Aanvraag verwijderd"
 msgstr "Application deleted"
 
-#: proposals/views/proposal_views.py:587
+#: proposals/views/proposal_views.py:586
 msgid "Wijzigingen opgeslagen"
 msgstr "Changes saved"
 
-#: proposals/views/proposal_views.py:690
+#: proposals/views/proposal_views.py:689
 msgid "Aanvraag gekopieerd"
 msgstr "Application copied"
 

--- a/proposals/utils/checkers.py
+++ b/proposals/utils/checkers.py
@@ -12,7 +12,7 @@ from tasks.views import task_views, session_views
 from tasks.models import Task, Session
 
 from attachments.utils import AttachmentSlot, desiredness
-from attachments.kinds import InformationLetter, DataManagementPlan
+from attachments.kinds import DataManagementPlan, LEGAL_BASIS_KIND_DICT
 
 from .stepper_helpers import (
     Checker,
@@ -472,12 +472,13 @@ class StudyAttachmentsChecker(
     def check(
         self,
     ):
-        kind = InformationLetter
-        info_slot = AttachmentSlot(
-            self.study,
-            kind=kind,
-        )
-        self.stepper.add_slot(info_slot)
+        if self.study.legal_basis is not None:
+            kind = LEGAL_BASIS_KIND_DICT[self.study.legal_basis]
+            info_slot = AttachmentSlot(
+                self.study,
+                kind=kind,
+            )
+            self.stepper.add_slot(info_slot)
         return []
 
 

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -2,6 +2,7 @@ from django.views import generic
 from django import forms
 from django.urls import reverse
 from django import forms
+from main.views import UpdateView
 from proposals.mixins import ProposalContextMixin
 from proposals.models import Proposal
 from studies.models import Study
@@ -218,14 +219,26 @@ class AttachmentDetailView(
     template_name = "proposals/attachment_detail.html"
     model = Attachment
 
+class ProposalAttachmentsForm(
+    forms.ModelForm,
+):
+    """
+    An empty form, needed to make the navigation work.
+    """
+    class Meta:
+        model = Proposal
+        fields = []
+
 
 class ProposalAttachmentsView(
     ProposalContextMixin,
-    generic.DetailView,
+    UpdateView,
 ):
 
     template_name = "proposals/attachments.html"
     model = Proposal
+    #this form does not do anything, it's just here to make navigation work
+    form_class = ProposalAttachmentsForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -242,6 +255,12 @@ class ProposalAttachmentsView(
         context["study_slots"] = study_slots
         context["proposal_slots"] = proposal_slots
         return context
+    
+    def get_next_url(self):
+        return reverse("proposals:translated", args=(self.object.pk,))
+
+    def get_back_url(self):
+        return reverse("proposals:knowledge_security", args=(self.object.pk,))
 
 
 class ProposalAttachmentDownloadView(

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -491,7 +491,7 @@ class ProposalKnowledgeSecurity(
     template_name = "proposals/knowledge_security_form.html"
 
     def get_next_url(self):
-        return reverse("proposals:consent", args=(self.object.pk,))
+        return reverse("proposals:attachments", args=(self.object.pk,))
 
     def get_back_url(self):
         return reverse("studies:design_end", args=(self.object.last_study().pk,))
@@ -508,7 +508,7 @@ class TranslatedConsentView(ProposalContextMixin, UpdateView):
 
     def get_back_url(self):
         """Return to the overview of the last Study"""
-        return reverse("proposals:consent", args=(self.object.pk,))
+        return reverse("proposals:attachments", args=(self.object.pk,))
 
 
 class ProposalDataManagement(ProposalContextMixin, UpdateView):

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -221,7 +221,7 @@ class PersonalDataForm(SoftValidationMixin, ConditionalModelForm):
         if cleaned_data["has_special_details"] is None:
             self.add_error("has_special_details", _("Dit veld is verplicht."))
 
-        if not cleaned_data["legal_basis"]:
+        if cleaned_data["legal_basis"] is None:
             self.add_error("legal_basis", _("Selecteer een van de opties."))
 
         self.check_dependency_multiple(


### PR DESCRIPTION
Woopee, there we are. While closely reading along the master instruction and [this page](https://intranet.uu.nl/en/knowledgebase/documents-ethics-assessment-committee-humanities?check_logged_in=1) I've implemented all the possible attachment kinds into the new attachment system. While writing up the different kinds was doable ... the logic for when certain slots are to be added with the right desiredness was quite a pain and led me down deep paths of the portal's architecture. The bulk of the action happens in the `StudyAttachmentChecker`. I am not sure if this is the most elegant solution for implementing all this logic ... But it becoming somewhat of a mess was unavoidable ... But I'm open to tips for improvements! I think the best way to understand all this is to keep the document/email with the master instruction close at hand.

Checking whether a study features recordings is especially annoying due to #733... I was also struggling a bit with making sure the other of a pair becomes optional when one is present. The wishes for this are also quite specific, so I could not find a nice way to generalize this behavior.

I added some pretty extensive descriptions taken from the page linked to above. These are currently not used, but might come in handy later.

I though I would also tackle translations, so I did this for the whole attachments branch.

Finally I implemented the attachments page into the general flow of the form, so now the back and forward buttons work correctly ... As of the current state of the portal this requires a form, so I added an empty form for enabling this.

Sorry for the big commits, (6654c4a42259e739f5f5a84af57af6091447d93e & ba2ddfdd3181e1aacddb07f9e546b1b4b5febec9) but it just made most sense as a whole imo.