### PR TITLE
Feature/all kinds suggestions

### DIFF
--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -205,6 +205,7 @@ class DataManagementPlan(ProposalAttachmentKind):
     db_name = "dmp"
     name = _("Data Management Plan")
     description = _("Omschrijving DMP")
+    desiredness = desiredness.RECOMMENDED
 
     def num_recommended(self):
         return 1

--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -210,7 +210,7 @@ class DataManagementPlan(ProposalAttachmentKind):
         return 1
 
 
-class OtherProposalAttachment(ProposalAttachmentKind):
+class OtherAttachment(ProposalAttachmentKind):
 
     db_name = "other"
     name = _("Overig bestand")
@@ -241,7 +241,7 @@ PROPOSAL_ATTACHMENTS = [
     SchoolInformationLetter,
     SchoolConsentForm,
     DataManagementPlan,
-    OtherProposalAttachment,
+    OtherAttachment,
 ]
 
 ATTACHMENTS = PROPOSAL_ATTACHMENTS + STUDY_ATTACHMENTS

--- a/attachments/templates/attachments/optionality_group.html
+++ b/attachments/templates/attachments/optionality_group.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<div class="border-start border-4 p-2 m-0 ps-4 pe-0">
+    <h6 class="m-0 p-0">{% blocktrans trimmed with count=group.count%}
+        Een van deze {{ count }} documenten is voldoende
+        {% endblocktrans %}
+    </h6>
+    {% for slot in group.members %}
+        {% include slot %}
+    {% endfor %}
+</div>

--- a/attachments/templates/attachments/optionality_group.html
+++ b/attachments/templates/attachments/optionality_group.html
@@ -1,8 +1,9 @@
 {% load i18n %}
 
 <div class="border-start border-4 p-2 m-0 ps-4 pe-0">
-    <h6 class="m-0 p-0">{% blocktrans trimmed with count=group.count%}
-        Een van deze {{ count }} documenten is voldoende
+    <h6 class="m-0 p-0">
+        {% blocktrans trimmed with count=group.count %}
+            Een van deze {{ count }} documenten is voldoende
         {% endblocktrans %}
     </h6>
     {% for slot in group.members %}

--- a/attachments/templates/attachments/slot.html
+++ b/attachments/templates/attachments/slot.html
@@ -1,21 +1,27 @@
 {% load i18n %}
 
-<div class="row mt-4 mb-4 p-3 border-3 border-bottom rounded {{classes}} bg-light">
-    <div class="col-2 align-middle">{{ slot.desiredness }}</div>
-    <div class="col-7 align-middle">
-        <h5>{{ slot.kind.name }}</h5>
-        {% if slot.attachment %}
-            {% include slot.attachment with proposal=proposal %}
-        {% else %}
-            {% trans "Nog toe te voegen" %}
-        {% endif %}
-        {{ kind.reason }}
+<div class="uu-form-row mt-4 mb-4">
+    <div class="">
+        <div class="row border-3 p-3 border-bottom rounded {{classes}} bg-light">
+            <div class="col-2 align-middle">{{ slot.desiredness }}</div>
+            <div class="col-7 align-middle">
+                <h5>{{ slot.kind.name }}</h5>
+                {% if slot.attachment %}
+                    {% include slot.attachment with proposal=proposal %}
+                {% else %}
+                    {% trans "Nog toe te voegen" %}
+                {% endif %}
+                {{ kind.reason }}
+            </div>
+            <div class="col-3 align-middle text-end flex-end">
+                {% if slot.attachment %}
+                    <a class="btn btn-primary" href="{{ slot.get_edit_url }}">{% trans "Wijzig" %}</a>
+                {% else %}
+                    <a class="btn btn-primary" href="{{ slot.get_attach_url }}">{% trans "Voeg toe" %}</a>
+                {% endif %}
+            </div>
+        </div>
     </div>
-    <div class="col-3 align-middle text-end flex-end">
-        {% if slot.attachment %}
-            <a class="btn btn-primary" href="{{ slot.get_edit_url }}">{% trans "Wijzig" %}</a>
-        {% else %}
-            <a class="btn btn-primary" href="{{ slot.get_attach_url }}">{% trans "Voeg toe" %}</a>
-        {% endif %}
-    </div>
+    <div class="uu-form-help">
+        <details><summary class="text-muted">Meer info</summary>{{ slot.kind.description }}</details></div>
 </div>

--- a/attachments/templates/attachments/slot.html
+++ b/attachments/templates/attachments/slot.html
@@ -2,7 +2,7 @@
 
 <div class="uu-form-row mt-4 mb-4">
     <div class="">
-        <div class="row border-3 p-3 border-bottom rounded {{classes}} bg-light">
+        <div class="row border-3 p-3 border-bottom rounded {{ classes }} bg-light">
             <div class="col-2 align-middle">{{ slot.desiredness }}</div>
             <div class="col-7 align-middle">
                 <h5>{{ slot.kind.name }}</h5>
@@ -23,5 +23,9 @@
         </div>
     </div>
     <div class="uu-form-help">
-        <details><summary class="text-muted">Meer info</summary>{{ slot.kind.description }}</details></div>
+        <details>
+            <summary class="text-muted">Meer info</summary>
+            {{ slot.kind.description }}
+        </details>
+    </div>
 </div>

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -142,10 +142,10 @@ class AttachmentSlot(renderable):
 
 
 def get_kind_from_str(db_name):
-    from attachments.kinds import ATTACHMENTS, OtherProposalAttachment
+    from attachments.kinds import ATTACHMENTS, OtherAttachment
 
     kinds = {kind.db_name: kind for kind in ATTACHMENTS}
     try:
         return kinds[db_name]
     except KeyError:
-        return OtherProposalAttachment
+        return OtherAttachment

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -35,11 +35,15 @@ class AttachmentSlot(renderable):
         attachment=None,
         kind=None,
         force_desiredness=None,
+        optionality_group=None,
     ):
         self.attachment = attachment
         self.attached_object = attached_object
         self.kind = kind
         self.force_desiredness = force_desiredness
+        self.optionality_group = optionality_group
+        if self.optionality_group:
+            self.optionality_group.members.add(self)
 
     def match(self, exclude):
         """
@@ -139,6 +143,51 @@ class AttachmentSlot(renderable):
                 "other_pk": self.attached_object.pk,
             },
         )
+
+class OptionalityGroup(renderable):
+
+    template_name = "attachments/optionality_group.html"
+
+    def __init__(self, members=set()):
+        self.members = set(members)
+
+    @property
+    def count(self,):
+        return len(self.members)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["group"] = self
+        return context
+
+def merge_groups(slots):
+    """
+    Takes a list of slots and merges slots that belong to the same
+    optionality group together. This results in a mixed output list
+    of bare slots and optionality groups.
+    """
+    grouped = []
+    for slot in slots:
+        if not slot.optionality_group:
+            # No group, so we just append it
+            grouped.append(slot)
+            continue
+        if slot.optionality_group not in grouped:
+            # We only append the group if it's not already in the
+            # output list to avoid duplication
+            grouped.append(slot.optionality_group)
+    # Final pass to remove single-member groups
+    out = []
+    for item in grouped:
+        if type(item) is OptionalityGroup:
+            if item.count < 2:
+                # If we have fewer than two members, we just append
+                # the members. Addition allows for the empty list edge
+                # case to work.
+                out += item.members
+                continue
+        out.append(item)
+    return out
 
 
 def get_kind_from_str(db_name):

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -144,6 +144,7 @@ class AttachmentSlot(renderable):
             },
         )
 
+
 class OptionalityGroup(renderable):
 
     template_name = "attachments/optionality_group.html"
@@ -152,13 +153,16 @@ class OptionalityGroup(renderable):
         self.members = set(members)
 
     @property
-    def count(self,):
+    def count(
+        self,
+    ):
         return len(self.members)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["group"] = self
         return context
+
 
 def merge_groups(slots):
     """

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -142,7 +142,10 @@ class AttachmentSlot(renderable):
 
 
 def get_kind_from_str(db_name):
-    from attachments.kinds import ATTACHMENTS
+    from attachments.kinds import ATTACHMENTS, OtherProposalAttachment
 
     kinds = {kind.db_name: kind for kind in ATTACHMENTS}
-    return kinds[db_name]
+    try:
+        return kinds[db_name]
+    except KeyError:
+        return OtherProposalAttachment

--- a/proposals/templates/proposals/attach_form.html
+++ b/proposals/templates/proposals/attach_form.html
@@ -39,7 +39,7 @@
             {% endblocktrans %}
         {% endif %}
     {% endif %}
-    </p>
+</p>
 {% endblock %}
 
 {% block form-buttons %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -9,32 +9,37 @@
 
 {% block pre-form-text %}
     <h2>{% trans "Documenten" %}</h2>
-    <h3 class="mt-4">{% trans "Algemeen" %}</h3>
-    {% for slot in proposal_slots %}
-        {% include slot %}
-    {% endfor %}
-        <div class="text-center mb-5 mt-3">
+    {% endblock %}
+    {% block auto-form-render %}
+        <h3 class="mt-4 mb-3">{% trans "Algemeen" %}</h3>
+            {% for slot in proposal_slots %}
+                {% include slot %}
+            {% endfor %}
+        <div class="uu-form-row mb-5 mt-3">
+            <div class="text-center">
             <a class="btn btn-light align-bottom" href="{% url "proposals:attach_proposal" proposal.pk %}">
                 <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
                      title="{% trans 'Toevoegen' %}" />
                 <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan aanvraag</h6>
             </a>
+            </div>
         </div>
         {% for study, slots in study_slots.items %}
-        <h3>
-            {% trans "Traject " %} {{ study.order }}
-            {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
-        </h3>
-        {% for slot in slots %}
-            {% include slot with manager=manager %}
+            <h3>
+                {% trans "Traject " %} {{ study.order }}
+                {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
+            </h3>
+            {% for slot in slots %}
+                {% include slot with manager=manager %}
+            {% endfor %}
+            <div class="uu-form-row mb-5 mt-3">
+            <div class="text-center">
+                <a class="btn btn-light align-bottom" href="{% url "proposals:attach_study" study.pk %}">
+                    <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
+                         title="{% trans 'Toevoegen' %}" />
+                    <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan traject {{study.order}}</h6>
+                </a>
+            </div>
+            </div>
         {% endfor %}
-        <div class="text-center mb-5 mt-3">
-            <a class="btn btn-light align-bottom" href="{% url "proposals:attach_study" study.pk %}">
-                <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
-                     title="{% trans 'Toevoegen' %}" />
-                <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan traject {{study.order}}</h6>
-            </a>
-        </div>
-    {% endfor %}
-    {% block auto-form-render %}{% endblock %}
 {% endblock %}

--- a/proposals/templates/proposals/attachments.html
+++ b/proposals/templates/proposals/attachments.html
@@ -9,37 +9,42 @@
 
 {% block pre-form-text %}
     <h2>{% trans "Documenten" %}</h2>
-    {% endblock %}
-    {% block auto-form-render %}
-        <h3 class="mt-4 mb-3">{% trans "Algemeen" %}</h3>
-            {% for slot in proposal_slots %}
-                {% include slot %}
-            {% endfor %}
-        <div class="uu-form-row mb-5 mt-3">
-            <div class="text-center">
-            <a class="btn btn-light align-bottom" href="{% url "proposals:attach_proposal" proposal.pk %}">
-                <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
+{% endblock %}
+
+{% block auto-form-render %}
+    <h3 class="mt-4 mb-3">{% trans "Algemeen" %}</h3>
+    {% for slot in proposal_slots %}
+        {% include slot %}
+    {% endfor %}
+    <div class="uu-form-row mb-5 mt-3">
+        <div class="text-center">
+            <a class="btn btn-light align-bottom"
+               href="{% url "proposals:attach_proposal" proposal.pk %}">
+                <img class="mb-1 me-2"
+                     src="{% static 'proposals/images/add.png' %}"
                      title="{% trans 'Toevoegen' %}" />
                 <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan aanvraag</h6>
             </a>
-            </div>
         </div>
-        {% for study, slots in study_slots.items %}
-            <h3>
-                {% trans "Traject " %} {{ study.order }}
-                {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
-            </h3>
-            {% for slot in slots %}
-                {% include slot with manager=manager %}
-            {% endfor %}
-            <div class="uu-form-row mb-5 mt-3">
+    </div>
+    {% for study, slots in study_slots.items %}
+        <h3>
+            {% trans "Traject " %} {{ study.order }}
+            {% if study.name %}: <em>{{ study.name }}</em>{% endif %}
+        </h3>
+        {% for slot in slots %}
+            {% include slot with manager=manager %}
+        {% endfor %}
+        <div class="uu-form-row mb-5 mt-3">
             <div class="text-center">
-                <a class="btn btn-light align-bottom" href="{% url "proposals:attach_study" study.pk %}">
-                    <img class="mb-1 me-2" src="{% static 'proposals/images/add.png' %}"
+                <a class="btn btn-light align-bottom"
+                   href="{% url "proposals:attach_study" study.pk %}">
+                    <img class="mb-1 me-2"
+                         src="{% static 'proposals/images/add.png' %}"
                          title="{% trans 'Toevoegen' %}" />
-                    <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan traject {{study.order}}</h6>
+                    <h6 class="d-inline" style="--bs-btn-font-weight: 200; ">Voeg optioneel bestand toe aan traject {{ study.order }}</h6>
                 </a>
             </div>
-            </div>
-        {% endfor %}
+        </div>
+    {% endfor %}
 {% endblock %}

--- a/proposals/utils/checkers.py
+++ b/proposals/utils/checkers.py
@@ -14,7 +14,7 @@ from tasks.models import Registration as task_registration
 from tasks.views import task_views, session_views
 from tasks.models import Task, Session
 
-from attachments.utils import AttachmentSlot, desiredness
+from attachments.utils import AttachmentSlot, desiredness, OptionalityGroup
 from attachments.kinds import (
     DataManagementPlan,
     LEGAL_BASIS_KIND_DICT,
@@ -500,14 +500,17 @@ class StudyAttachmentsChecker(
 
             if self.check_has_recordings():
                 # if a study features registration, add two slots
+                recording_group = OptionalityGroup()
                 recordings_slots = [
                     AttachmentSlot(
                         self.study,
                         kind=AgreementRecordingsPublicInterest,
+                        optionality_group=recording_group,
                     ),
                     AttachmentSlot(
                         self.study,
                         kind=ScriptVerbalConsentRecordings,
+                        optionality_group=recording_group,
                     ),
                 ]
                 # if one of them has been fulfilled, this becomes the fulfilled slot
@@ -533,14 +536,17 @@ class StudyAttachmentsChecker(
         if self.study.legal_basis == Study.LegalBases.CONSENT:
             fulfilled_children_slot = None
             if self.study.has_children():
+                child_group = OptionalityGroup()
                 children_slots = [
                     AttachmentSlot(
                         self.study,
                         kind=ConsentChildrenParents,
+                        optionality_group=child_group,
                     ),
                     AttachmentSlot(
                         self.study,
                         kind=ConsentChildrenNoParents,
+                        optionality_group=child_group,
                     ),
                 ]
 

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -13,7 +13,7 @@ from main.forms import ConditionalModelForm
 from cdh.core import forms as cdh_forms
 from django.http import FileResponse
 from attachments.kinds import ATTACHMENTS, KIND_CHOICES
-from attachments.utils import AttachmentKind
+from attachments.utils import AttachmentKind, merge_groups
 from cdh.core import forms as cdh_forms
 from django.utils.translation import gettext as _
 from reviews.mixins import UsersOrGroupsAllowedMixin
@@ -299,8 +299,11 @@ class ProposalAttachmentsView(
         for slot in all_slots:
             if type(slot.attached_object) is Study:
                 study_slots[slot.attached_object].append(slot)
+        # Final step to merge optionality groups
+        for obj, slots in study_slots.items():
+            study_slots[obj] = merge_groups(slots)
         context["study_slots"] = study_slots
-        context["proposal_slots"] = proposal_slots
+        context["proposal_slots"] = merge_groups(proposal_slots)
         return context
 
     def get_next_url(self):


### PR DESCRIPTION
This PR attempts to make relationships between optional files more clear.

![image](https://github.com/user-attachments/assets/e231ed6e-0bbc-42b5-bafc-8b8bc6f32979)

Slots can now receive an `OptionalityGroup`, which in the general case does nothing except be a renderable. However, the `merge_groups` utility can use these groups to add some structure to a list of slots.

Currently only one layer of optionality groups is supported. However, multiple layers can be implemented with recursion if necessary.

Also I've added help texts to the side of the attachment slots.