### PR TITLE
Fix/remove old dmp filefield

### DIFF
--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -209,7 +209,7 @@ class DataManagementPlan(ProposalAttachmentKind):
         "voorafgaand aan een onderzoeksproject wordt opgesteld. Hierin "
         "worden alle aspecten omtrent de omgang met onderzoeksdata, tijdens "
         "en na afloop van het onderzoek, uiteengezet."
-        )
+    )
     desiredness = desiredness.RECOMMENDED
 
     def num_recommended(self):

--- a/attachments/kinds.py
+++ b/attachments/kinds.py
@@ -204,7 +204,12 @@ class DataManagementPlan(ProposalAttachmentKind):
 
     db_name = "dmp"
     name = _("Data Management Plan")
-    description = _("Omschrijving DMP")
+    description = _(
+        "Een Data Management Plan (DMP) is een document, dat "
+        "voorafgaand aan een onderzoeksproject wordt opgesteld. Hierin "
+        "worden alle aspecten omtrent de omgang met onderzoeksdata, tijdens "
+        "en na afloop van het onderzoek, uiteengezet."
+        )
     desiredness = desiredness.RECOMMENDED
 
     def num_recommended(self):

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -741,7 +741,7 @@ class StudyStartForm(SoftValidationMixin, ConditionalModelForm):
 class ProposalDataManagementForm(SoftValidationMixin, ConditionalModelForm):
     class Meta:
         model = Proposal
-        fields = ["privacy_officer", "dmp_file"]
+        fields = ["privacy_officer"]
         widgets = {
             "privacy_officer": BootstrapRadioSelect(choices=YES_NO),
         }

--- a/proposals/utils/checkers.py
+++ b/proposals/utils/checkers.py
@@ -1010,6 +1010,7 @@ class AttachmentsItem(
                 )
         return errors
 
+
 class DataManagementChecker(
     ModelFormChecker,
 ):
@@ -1034,6 +1035,7 @@ class DataManagementChecker(
                 self.stepper.proposal.pk,
             ],
         )
+
 
 class AttachmentsChecker(
     Checker,
@@ -1108,8 +1110,6 @@ class TranslationChecker(
                 self.stepper.proposal.pk,
             ],
         )
-
-
 
 
 class SubmitChecker(

--- a/proposals/utils/checkers.py
+++ b/proposals/utils/checkers.py
@@ -341,8 +341,8 @@ class TrajectoriesChecker(
     ):
         return [
             KnowledgeSecurityChecker(self.stepper, parent=self.item),
-            AttachmentsChecker,
             DataManagementChecker,
+            AttachmentsChecker,
             SubmitChecker,
         ]
 
@@ -1010,6 +1010,30 @@ class AttachmentsItem(
                 )
         return errors
 
+class DataManagementChecker(
+    ModelFormChecker,
+):
+    title = _("Data management")
+    form_class = proposal_forms.ProposalDataManagementForm
+    location = "data_management"
+
+    def check(
+        self,
+    ):
+        self.stepper.items.append(
+            self.make_stepper_item(),
+        )
+        return []
+
+    def get_url(
+        self,
+    ):
+        return reverse(
+            "proposals:data_management",
+            args=[
+                self.stepper.proposal.pk,
+            ],
+        )
 
 class AttachmentsChecker(
     Checker,
@@ -1086,30 +1110,6 @@ class TranslationChecker(
         )
 
 
-class DataManagementChecker(
-    ModelFormChecker,
-):
-    title = _("Data management")
-    form_class = proposal_forms.ProposalDataManagementForm
-    location = "data_management"
-
-    def check(
-        self,
-    ):
-        self.stepper.items.append(
-            self.make_stepper_item(),
-        )
-        return []
-
-    def get_url(
-        self,
-    ):
-        return reverse(
-            "proposals:data_management",
-            args=[
-                self.stepper.proposal.pk,
-            ],
-        )
 
 
 class SubmitChecker(

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -257,8 +257,8 @@ RegularProposalLayout = [
     ("create", _("Basisgegevens")),
     ("wmo", _("WMO")),
     ("studies", _("Trajecten")),
-    ("attachments", _("Documenten")),
     ("data_management", _("Datamanagement")),
+    ("attachments", _("Documenten")),
     ("submit", _("Indienen")),
 ]
 

--- a/proposals/views/attachment_views.py
+++ b/proposals/views/attachment_views.py
@@ -310,7 +310,7 @@ class ProposalAttachmentsView(
         return reverse("proposals:translated", args=(self.object.pk,))
 
     def get_back_url(self):
-        return reverse("proposals:knowledge_security", args=(self.object.pk,))
+        return reverse("proposals:data_management", args=(self.object.pk,))
 
     def legacy_documents(
         self,

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -574,7 +574,7 @@ class ProposalKnowledgeSecurity(
     template_name = "proposals/knowledge_security_form.html"
 
     def get_next_url(self):
-        return reverse("proposals:attachments", args=(self.object.pk,))
+        return reverse("proposals:data_management", args=(self.object.pk,))
 
     def get_back_url(self):
         return reverse("studies:design_end", args=(self.object.last_study().pk,))
@@ -587,7 +587,7 @@ class TranslatedConsentView(ProposalContextMixin, UpdateView):
 
     def get_next_url(self):
         """Go to the consent form upload page"""
-        return reverse("proposals:data_management", args=(self.object.pk,))
+        return reverse("proposals:submit", args=(self.object.pk,))
 
     def get_back_url(self):
         """Return to the overview of the last Study"""
@@ -601,11 +601,11 @@ class ProposalDataManagement(ProposalContextMixin, UpdateView):
 
     def get_next_url(self):
         """Continue to the submission view"""
-        return reverse("proposals:submit", args=(self.object.pk,))
+        return reverse("proposals:attachments", args=(self.object.pk,))
 
     def get_back_url(self):
         """Return to the consent form overview of the last Study"""
-        return reverse("proposals:translated", args=(self.object.pk,))
+        return reverse("proposals:knowledge_security", args=(self.object.pk,))
 
 
 class ProposalUpdateDataManagement(GroupRequiredMixin, generic.UpdateView):


### PR DESCRIPTION
Pretty straightforward PR, I've removed the old DMP file field and rearranged the order a bit, as decided upon in #756:

Now the order is:

knowledge security > DMP > attachments

As a small bonus, I've added a description to the DMP AttachmentKind.