### PR TITLE
Feat/attachments diff

### DIFF
--- a/proposals/utils/pdf_diff_sections.py
+++ b/proposals/utils/pdf_diff_sections.py
@@ -18,6 +18,7 @@ from proposals.utils.pdf_diff_utils import (
     TitleSection,
     get_all_related,
     get_all_related_set,
+    get_all_sessions,
     get_extra_documents,
     multi_sections,
 )
@@ -963,8 +964,8 @@ def create_context_diff(context, old_proposal, new_proposal):
                         or new_study is not None
                         and new_study.get_sessions()
                     ):
-                        old_sessions_set, new_sessions_set = get_all_related_set(
-                            both_studies, "session_set"
+                        old_sessions_set, new_sessions_set = get_all_sessions(
+                            both_studies,
                         )
 
                         for both_sessions in zip_equalize_lists(

--- a/proposals/utils/pdf_diff_utils.py
+++ b/proposals/utils/pdf_diff_utils.py
@@ -467,6 +467,13 @@ def get_all_related(objects, related_name):
     ]
 
 
+def get_all_sessions(studies):
+    """
+    Receives a list of study objects and gets sessions for the study
+    """
+    return [study.get_sessions() if study is not None else None for study in studies]
+
+
 def get_all_related_set(objects, related_name):
     """Helper function for retrieving a set of related objects."""
 

--- a/proposals/utils/pdf_diff_utils.py
+++ b/proposals/utils/pdf_diff_utils.py
@@ -283,21 +283,27 @@ class RowValue:
             output = _("Niet aangeleverd")
 
         return output
-    
+
     def handle_attachment(self, filewrapper):
 
         if filewrapper:
             output = format_html(
-                '<a href="{}">{}</a>',
-                settings.BASE_URL + reverse("proposals:download_attachment_original", kwargs={"proposal_pk": self.proposal.pk, "attachment_pk": self.obj.pk,}),
+                '<a href="{}">{}</a><p>{}</p>',
+                settings.BASE_URL
+                + reverse(
+                    "proposals:download_attachment_original",
+                    kwargs={
+                        "proposal_pk": self.proposal.pk,
+                        "attachment_pk": self.obj.pk,
+                    },
+                ),
                 _("Download"),
+                _(" (Gewijzigd voor revisie)") if self.obj.parent else "",
             )
         else:
             output = _("Niet aangeleverd")
 
         return output
-
-
 
     def yes_no_doubt(self, value):
         from main.models import YesNoDoubt
@@ -420,7 +426,8 @@ class PageBreakMixin(BaseSection):
             }
         )
         return super().render(context)
-    
+
+
 class TitleSection:
     """A little dummy section for adding just a title to the PDF"""
 
@@ -436,6 +443,7 @@ class TitleSection:
             }
         )
         return template.render(context)
+
 
 def get_extra_documents(obj):
     """A function to retrieve all extra documents for a specific proposal."""
@@ -481,5 +489,3 @@ def get_all_related_set(objects, related_name):
         getattr(obj, related_name, None).all() if obj is not None else None
         for obj in objects
     ]
-
-


### PR DESCRIPTION
So this is the diff part of incorporating the attachments into the pdf/diff system.

It build upon how the pdf is created, however it gets a lot more complicated with matching attachments together.

I think this solution is ok ... but it is very _mad scientist-y_ ... But it was quite a logical challenge to match attachments to a study.

This PR also assumes some knowledge of how Diffsections work (which is also quite _mad scientist-y_. A basic rundown:

DiffSections receive two sections, the first for the old_p, the second for the new_p. If either of these objects is missing, it gets replaced with None.

Good luck with this review as well!