### PR TITLE
Fix/archive access bug

### DIFF
--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -88,7 +88,7 @@
            href="{% url 'proposals:copy_amendment' %}">{% trans "Nieuw amendement starten" %}</a>
         {% if can_view_archive %}
             <a class="btn btn-outline-secondary"
-            href="{% url 'proposals:archive' 'LK' %}">{% trans "Archief" %}</a>
+               href="{% url 'proposals:archive' 'LK' %}">{% trans "Archief" %}</a>
         {% endif %}
     </div>
     <div class="uu-container">

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -86,8 +86,10 @@
            href="{% url 'proposals:copy_revision' %}">{% trans "Nieuwe revisie starten" %}</a>
         <a class="btn btn-outline-secondary"
            href="{% url 'proposals:copy_amendment' %}">{% trans "Nieuw amendement starten" %}</a>
-        <a class="btn btn-outline-secondary"
-           href="{% url 'proposals:archive' 'LK' %}">{% trans "Archief" %}</a>
+        {% if can_view_archive %}
+            <a class="btn btn-outline-secondary"
+            href="{% url 'proposals:archive' 'LK' %}">{% trans "Archief" %}</a>
+        {% endif %}
     </div>
     <div class="uu-container">
         <div class="row gx-3 gy-4">

--- a/main/views.py
+++ b/main/views.py
@@ -426,6 +426,7 @@ class HumanitiesOrPrivilegeRequiredMixin(UserPassesTestMixin):
     Checks for Humanities faculty affiliation, but also lets in users belonging
     to a privileged set of groups.
     """
+
     raise_exception = True
 
     def test_func(self, user):

--- a/main/views.py
+++ b/main/views.py
@@ -425,6 +425,7 @@ class HumanitiesOrPrivilegeRequiredMixin(UserPassesTestMixin):
     Checks for Humanities faculty affiliation, but also lets in users belonging
     to a privileged set of groups.
     """
+    raise_exception = True
 
     def test_func(self, user):
         return can_view_archive(user)

--- a/main/views.py
+++ b/main/views.py
@@ -124,6 +124,7 @@ class HomeView(LoginRequiredMixin, SeasonalCoverImageMixin, _SystemMessageView):
 
         context["is_humanities"] = is_member_of_humanities(self.request.user)
         context["proposals"] = self.get_priority_proposals()
+        context["can_view_archive"] = can_view_archive(self.request.user)
 
         return context
 

--- a/proposals/utils/proposal_utils.py
+++ b/proposals/utils/proposal_utils.py
@@ -30,6 +30,7 @@ __all__ = [
     "OverwriteStorage",
 ]
 
+
 def generate_ref_number():
     """
     Generates a reference number for a new(!) Proposal.


### PR DESCRIPTION
fixes #815.

A small PR for a change ;p

The mixin used for archive access check `HumanitiesOrPrivilegeRequiredMixin` was not raising a PermissionDenied. It's default behaviour is to ask for login again (which apparently was also not working on the test server). This is now fixed.

The archive button is also removed from the homepage if the user cannot access it.