### PR TITLE
Fix/supervisor editing

### DIFF
--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -103,7 +103,6 @@ class ResearcherForm(
         - If this is a practice Proposal, limit the relation choices
         """
 
-
         self.supervisor_editing_flag = False
         super(ResearcherForm, self).__init__(*args, **kwargs)
         self.fields["relation"].empty_label = None

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -103,6 +103,8 @@ class ResearcherForm(
         - If this is a practice Proposal, limit the relation choices
         """
 
+
+        self.supervisor_editing_flag = False
         super(ResearcherForm, self).__init__(*args, **kwargs)
         self.fields["relation"].empty_label = None
         self.fields["student_context"].empty_label = None
@@ -110,9 +112,10 @@ class ResearcherForm(
         supervisors = get_user_model().objects.exclude(pk=self.user.pk)
 
         instance = kwargs.get("instance")
-
-        # If you are already defined as a supervisor, we have to set it to you
-        if instance is not None and instance.supervisor == self.user:
+        # If you're already set as the supervisor, we remove all other options
+        # and set a flag assuming you're already editing as the supervisor
+        if self.instance.supervisor == self.user:
+            self.supervisor_editing_flag = True
             supervisors = [self.user]
 
         self.fields["supervisor"].choices = [
@@ -157,7 +160,7 @@ van het FETC-GW worden opgenomen."
             if (
                 relation.needs_supervisor
                 and supervisor == self.user
-                and self.instance.status != Proposal.Statuses.SUBMITTED_TO_SUPERVISOR
+                and not self.supervisor_editing_flag
             ):
                 error = forms.ValidationError(
                     _("Je kunt niet jezelf als promotor/begeleider opgeven.")

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -38,9 +38,11 @@ class SupervisorEditingFormMixin:
 
     def __init__(self, *args, **kwargs):
         self.supervisor_editing_flag = kwargs.pop(
-            "supervisor_editing_flag", False,
+            "supervisor_editing_flag",
+            False,
         )
         return super().__init__(*args, **kwargs)
+
 
 class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalModelForm):
     class Meta:
@@ -80,7 +82,10 @@ class ProposalForm(UserKwargModelFormMixin, SoftValidationMixin, ConditionalMode
 
 
 class ResearcherForm(
-        UserKwargModelFormMixin, SupervisorEditingFormMixin, SoftValidationMixin, ConditionalModelForm,
+    UserKwargModelFormMixin,
+    SupervisorEditingFormMixin,
+    SoftValidationMixin,
+    ConditionalModelForm,
 ):
     class Meta:
         model = Proposal

--- a/proposals/mixins.py
+++ b/proposals/mixins.py
@@ -14,6 +14,7 @@ from .models import Proposal
 from .forms import ProposalForm
 from .utils.proposal_utils import pdf_link_callback
 
+
 class SupervisorEditingMixin:
     """
     Mixin that provides a form kwarg indicating if the current

--- a/proposals/mixins.py
+++ b/proposals/mixins.py
@@ -14,6 +14,19 @@ from .models import Proposal
 from .forms import ProposalForm
 from .utils.proposal_utils import pdf_link_callback
 
+class SupervisorEditingMixin:
+    """
+    Mixin that provides a form kwarg indicating if the current
+    request user is editing as a supervisor.
+    """
+
+    def get_form_kwargs(self, *args, **kwargs):
+        kwargs = super().get_form_kwargs(*args, **kwargs)
+        proposal = self.get_proposal()
+        editing_user = self.request.user
+        kwargs["supervisor_editing_flag"] = proposal.supervisor == editing_user
+        return kwargs
+
 
 class StepperContextMixin:
     """

--- a/proposals/models.py
+++ b/proposals/models.py
@@ -304,22 +304,22 @@ identiek zijn aan een vorige titel van een aanvraag die je hebt ingediend."
     )
 
     inform_local_staff = models.BooleanField(
-        _(
-            "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één \
-van de faciliteiten van het ILS, namelijk de database, Zep software \
-en/of het ILS lab. Het lab supportteam van het ILS zou graag op \
-de hoogte willen worden gesteld van aankomende onderzoeken. \
-Daarom vragen wij hier jouw toestemming om delen van deze aanvraag door te \
-sturen naar het lab supportteam.</p> \
-<p>Vind je het goed dat de volgende delen uit de aanvraag \
-worden doorgestuurd:</p> \
-- Jouw naam en de namen van de andere betrokkenen <br/> \
-- De eindverantwoordelijke van het onderzoek <br/> \
-- De titel van het onderzoek <br/> \
-- De beoogde startdatum <br/> \
-- Van welke faciliteiten je gebruik wil maken (database, lab, \
-Zep software)"
-        ),
+        mark_safe(_(
+            "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één "
+            "van de faciliteiten van het ILS, namelijk de database, Zep software "
+            "en/of het ILS lab. Het lab supportteam van het ILS zou graag op "
+            "de hoogte willen worden gesteld van aankomende onderzoeken. "
+            "Daarom vragen wij hier jouw toestemming om delen van deze aanvraag door te "
+            "sturen naar het lab supportteam.</p> "
+            "<p>Vind je het goed dat de volgende delen uit de aanvraag "
+            "worden doorgestuurd:</p> "
+            "- Jouw naam en de namen van de andere betrokkenen <br/> "
+            "- De eindverantwoordelijke van het onderzoek <br/> "
+            "- De titel van het onderzoek <br/> "
+            "- De beoogde startdatum <br/> "
+            "- Van welke faciliteiten je gebruik wil maken (database, lab, "
+            "Zep software)"
+        ),),
         default=None,
         blank=True,
         null=True,

--- a/proposals/models.py
+++ b/proposals/models.py
@@ -304,22 +304,24 @@ identiek zijn aan een vorige titel van een aanvraag die je hebt ingediend."
     )
 
     inform_local_staff = models.BooleanField(
-        mark_safe(_(
-            "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één "
-            "van de faciliteiten van het ILS, namelijk de database, Zep software "
-            "en/of het ILS lab. Het lab supportteam van het ILS zou graag op "
-            "de hoogte willen worden gesteld van aankomende onderzoeken. "
-            "Daarom vragen wij hier jouw toestemming om delen van deze aanvraag door te "
-            "sturen naar het lab supportteam.</p> "
-            "<p>Vind je het goed dat de volgende delen uit de aanvraag "
-            "worden doorgestuurd:</p> "
-            "- Jouw naam en de namen van de andere betrokkenen <br/> "
-            "- De eindverantwoordelijke van het onderzoek <br/> "
-            "- De titel van het onderzoek <br/> "
-            "- De beoogde startdatum <br/> "
-            "- Van welke faciliteiten je gebruik wil maken (database, lab, "
-            "Zep software)"
-        ),),
+        mark_safe(
+            _(
+                "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één "
+                "van de faciliteiten van het ILS, namelijk de database, Zep software "
+                "en/of het ILS lab. Het lab supportteam van het ILS zou graag op "
+                "de hoogte willen worden gesteld van aankomende onderzoeken. "
+                "Daarom vragen wij hier jouw toestemming om delen van deze aanvraag door te "
+                "sturen naar het lab supportteam.</p> "
+                "<p>Vind je het goed dat de volgende delen uit de aanvraag "
+                "worden doorgestuurd:</p> "
+                "- Jouw naam en de namen van de andere betrokkenen <br/> "
+                "- De eindverantwoordelijke van het onderzoek <br/> "
+                "- De titel van het onderzoek <br/> "
+                "- De beoogde startdatum <br/> "
+                "- Van welke faciliteiten je gebruik wil maken (database, lab, "
+                "Zep software)"
+            ),
+        ),
         default=None,
         blank=True,
         null=True,

--- a/proposals/utils/checkers.py
+++ b/proposals/utils/checkers.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from proposals import forms as proposal_forms
 from proposals.models import Wmo
+from proposals.mixins import SupervisorEditingMixin
 from studies import forms as study_forms
 from studies.models import Study
 from interventions import forms as intervention_forms
@@ -97,6 +98,7 @@ class ProposalCreateChecker(
 
 
 class ResearcherChecker(
+    SupervisorEditingMixin,
     ModelFormChecker,
 ):
     title = _("Onderzoeker")

--- a/proposals/utils/stepper_helpers.py
+++ b/proposals/utils/stepper_helpers.py
@@ -13,7 +13,9 @@ class BaseStepperComponent:
         self.proposal = stepper.proposal
         self.parent = parent
 
-    def get_proposal(self,):
+    def get_proposal(
+        self,
+    ):
         return self.proposal
 
 

--- a/proposals/utils/stepper_helpers.py
+++ b/proposals/utils/stepper_helpers.py
@@ -9,8 +9,12 @@ class BaseStepperComponent:
 
     def __init__(self, stepper, parent=None):
         self.stepper = stepper
+        self.request = self.stepper.request
         self.proposal = stepper.proposal
         self.parent = parent
+
+    def get_proposal(self,):
+        return self.proposal
 
 
 class Checker(

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -53,6 +53,7 @@ from ..forms import (
 from ..models import Proposal, Wmo
 from ..utils import generate_pdf, generate_ref_number
 from proposals.mixins import (
+    SupervisorEditingMixin,
     ProposalMixin,
     ProposalContextMixin,
     PDFTemplateResponseMixin,
@@ -471,6 +472,7 @@ class ProposalStart(generic.TemplateView):
 class ProposalResearcherFormView(
     ProposalMixin,
     UserFormKwargsMixin,
+    SupervisorEditingMixin,
     ProposalContextMixin,
     AllowErrorsOnBackbuttonMixin,
     UpdateView,


### PR DESCRIPTION
This should allow supervisors to edit proposals they are supervising, without errors about selecting themselves as the supervisor. This now also works for nonstandard proposals and proposals that have not yet been submitted.

Also an unsuccessful attempt at fixing #796 