### PR TITLE
Fix/textual bugs

### DIFF
--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -129,15 +129,21 @@
                 {# What should this be in dutch tho? #}
                 <ul>
                     <li>
-                        {% trans "<a href='http://fetc-gw.wp.hum.uu.nl/' target='_blank'>FETC-GW website</a>" %}
+                        {% blocktrans trimmed %}
+                            <a href='http://fetc-gw.wp.hum.uu.nl/' target='_blank'>FETC-GW website</a>
+                        {% endblocktrans %}
                     </li>
                     <li>
-                        {% trans "<a href='https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/'
-   target='_blank'>Reglement van de FETC-GW</a>" %}
+                        {% blocktrans trimmed %}
+                            <a href='https://fetc-gw.wp.hum.uu.nl/reglement-fetc-gw/'
+                               target='_blank'>Reglement van de FETC-GW</a>
+                        {% endblocktrans %}
                     </li>
                     <li>
-                        {% trans "<a href='https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw'
-   target='_blank'>Voorbeelddocumenten</a>" %}
+                        {% blocktrans trimmed %}
+                            <a href='https://intranet.uu.nl/documenten-ethische-toetsingscommissie-gw'
+                               target='_blank'>Voorbeelddocumenten</a>
+                        {% endblocktrans %}
                     </li>
                     <li>
                         <a href="{% url 'faqs:list' %}">{% trans "Veelgestelde vragen m.b.t. dit portal" %}</a>

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -795,6 +795,26 @@ class ProposalSubmitForm(
     class Meta:
         model = Proposal
         fields = ["comments", "inform_local_staff", "embargo", "embargo_end_date"]
+        labels = {
+            "inform_local_staff": mark_safe_lazy(
+                _(
+                    "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één "
+                    "van de faciliteiten van het ILS, namelijk de database, Zep software "
+                    "en/of het ILS lab. Het lab supportteam van het ILS zou graag op "
+                    "de hoogte willen worden gesteld van aankomende onderzoeken. "
+                    "Daarom vragen wij hier jouw toestemming om delen van deze aanvraag door te "
+                    "sturen naar het lab supportteam.</p> "
+                    "<p>Vind je het goed dat de volgende delen uit de aanvraag "
+                    "worden doorgestuurd:</p> "
+                    "- Jouw naam en de namen van de andere betrokkenen <br/> "
+                    "- De eindverantwoordelijke van het onderzoek <br/> "
+                    "- De titel van het onderzoek <br/> "
+                    "- De beoogde startdatum <br/> "
+                    "- Van welke faciliteiten je gebruik wil maken (database, lab, "
+                    "Zep software)"
+                ),
+            ),
+        }
         widgets = {
             "inform_local_staff": BootstrapRadioSelect(choices=YES_NO),
             "embargo": BootstrapRadioSelect(choices=YES_NO),
@@ -815,8 +835,6 @@ class ProposalSubmitForm(
         self.final_validation = kwargs.pop("final_validation", None)
 
         super(ProposalSubmitForm, self).__init__(*args, **kwargs)
-
-        self.fields["inform_local_staff"].label_suffix = ""
 
         self.fields["inform_local_staff"].label = mark_safe(
             self.fields["inform_local_staff"].label

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -237,7 +237,9 @@ class OtherResearchersForm(
 
         applicants = get_user_model().objects.all()
 
-        self.fields["other_stakeholders"].label = self.fields["other_stakeholders"].label
+        self.fields["other_stakeholders"].label = self.fields[
+            "other_stakeholders"
+        ].label
 
         self.fields["applicants"].choices = get_users_as_list(applicants)
 
@@ -834,7 +836,9 @@ class ProposalSubmitForm(
 
         super(ProposalSubmitForm, self).__init__(*args, **kwargs)
 
-        self.fields["inform_local_staff"].label = self.fields["inform_local_staff"].label
+        self.fields["inform_local_staff"].label = self.fields[
+            "inform_local_staff"
+        ].label
 
         if not check_local_facilities(self.proposal):
             del self.fields["inform_local_staff"]

--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -237,9 +237,7 @@ class OtherResearchersForm(
 
         applicants = get_user_model().objects.all()
 
-        self.fields["other_stakeholders"].label = mark_safe(
-            self.fields["other_stakeholders"].label
-        )
+        self.fields["other_stakeholders"].label = self.fields["other_stakeholders"].label
 
         self.fields["applicants"].choices = get_users_as_list(applicants)
 
@@ -836,9 +834,7 @@ class ProposalSubmitForm(
 
         super(ProposalSubmitForm, self).__init__(*args, **kwargs)
 
-        self.fields["inform_local_staff"].label = mark_safe(
-            self.fields["inform_local_staff"].label
-        )
+        self.fields["inform_local_staff"].label = self.fields["inform_local_staff"].label
 
         if not check_local_facilities(self.proposal):
             del self.fields["inform_local_staff"]

--- a/proposals/models.py
+++ b/proposals/models.py
@@ -304,7 +304,7 @@ identiek zijn aan een vorige titel van een aanvraag die je hebt ingediend."
     )
 
     inform_local_staff = models.BooleanField(
-        mark_safe(
+        mark_safe_lazy(
             _(
                 "<p>Je hebt aangegeven dat je gebruik wilt gaan maken van één "
                 "van de faciliteiten van het ILS, namelijk de database, Zep software "
@@ -322,6 +322,7 @@ identiek zijn aan een vorige titel van een aanvraag die je hebt ingediend."
                 "Zep software)"
             ),
         ),
+        # NOTE: lables with html are hardcoded in form Meta class!
         default=None,
         blank=True,
         null=True,


### PR DESCRIPTION
fixes #829

So this fixes two bugs.

**The homepage trans tags:**
Djlint made the html inside the trans tags multi-line, so it required blocktrans tags.

**the inform_local_staff label:**
So ... the big one. I had a closer look at how another label was marked safe, namely `other_stakeholders` ... I've just gone and implemented this the same way. It is really ugly ... but it does work (for now ... seemingly ...), which is nice at this point!

So basically, you just override the label in the form and mark it safe there. This means this label exists in two places. The label in the model is just there for reference. This kinda sucks, but I guess this is how we did it before?

I found that the `other_stakeholders` label in the form was `mark_safe`'d twice, which AFAICT is redundant, so I removed this.

Let me know what you think :)
