### PR TITLE
Feat/exclude submit from final validation

### DIFF
--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -890,13 +890,9 @@ class ProposalSubmitForm(
 
         validator = Stepper(self.instance, request=self.request)
 
-        form_errors = validator.get_form_errors()
+        form_errors = validator.get_form_errors(exclude_submit=True)
 
         if form_errors:
-            # If there are only errors on the submit form, we override this
-            # validation. Otherwise saving the updated data becomes impossible
-            if len(form_errors) == 1 and "proposals/submit" in form_errors[0]["url"]:
-                return
             self.add_error(
                 None,
                 _("Aanvraag bevat nog foutmeldingen"),

--- a/proposals/templates/proposals/proposal_submit.html
+++ b/proposals/templates/proposals/proposal_submit.html
@@ -102,7 +102,7 @@
             {% endif %}
         {% endfor %}
     {% endif %}
-    {% if stepper.get_form_errors %}
+    {% if stepper_errors %}
         <div class="alert alert-primary mt-3">
             <h5 class="mt-1">
                 {% blocktrans trimmed %}
@@ -110,7 +110,7 @@
                 {% endblocktrans %}
             </h5>
             <ul>
-                {% for error_page in stepper.get_form_errors %}
+                {% for error_page in stepper_errors %}
                     <li>
                         <a href="{{ error_page.url }}">{{ error_page.page_name }}</a>
                     </li>

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -16,6 +16,7 @@ from tasks.forms import SessionOverviewForm
 from studies.forms import StudyForm, StudyDesignForm, StudyEndForm
 from observations.forms import ObservationForm
 from interventions.forms import InterventionForm
+from proposals.forms import ProposalSubmitForm
 
 from proposals.utils.validate_sessions_tasks import validate_sessions_tasks
 from attachments.utils import AttachmentSlot, enumerate_slots
@@ -232,7 +233,7 @@ class Stepper(renderable):
         num_studies = self.proposal.study_set.count()
         return num_studies > 1
 
-    def get_form_errors(self):
+    def get_form_errors(self, exclude_submit = False):
         """
         A method providing validation of all the forms making up the proposal.
         It return a list of dicts, with url's and formatted page name's
@@ -258,6 +259,11 @@ class Stepper(renderable):
                     page_name = f"{item.parent.title}: {item.title}"
                 else:
                     page_name = item.title
+                # When using this method on the submit page, we 
+                # use the form's own validation, otherwise it gets
+                # validated twice
+                if exclude_submit and item.form_class == ProposalSubmitForm:
+                    continue
                 troublesome_pages.append(
                     {
                         "url": item.get_url(),

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -233,7 +233,7 @@ class Stepper(renderable):
         num_studies = self.proposal.study_set.count()
         return num_studies > 1
 
-    def get_form_errors(self, exclude_submit = False):
+    def get_form_errors(self, exclude_submit=False):
         """
         A method providing validation of all the forms making up the proposal.
         It return a list of dicts, with url's and formatted page name's
@@ -259,7 +259,7 @@ class Stepper(renderable):
                     page_name = f"{item.parent.title}: {item.title}"
                 else:
                     page_name = item.title
-                # When using this method on the submit page, we 
+                # When using this method on the submit page, we
                 # use the form's own validation, otherwise it gets
                 # validated twice
                 if exclude_submit and item.form_class == ProposalSubmitForm:

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -721,6 +721,7 @@ class ProposalSubmit(
         context["pagenr"] = self._get_page_number()
         context["is_supervisor_edit_phase"] = self.is_supervisor_edit_phase()
         context["start_date_warning"] = self.check_start_date()
+        context["stepper_errors"] = self.get_stepper().get_form_errors(exclude_submit=True)
 
         return context
 

--- a/proposals/views/proposal_views.py
+++ b/proposals/views/proposal_views.py
@@ -721,7 +721,9 @@ class ProposalSubmit(
         context["pagenr"] = self._get_page_number()
         context["is_supervisor_edit_phase"] = self.is_supervisor_edit_phase()
         context["start_date_warning"] = self.check_start_date()
-        context["stepper_errors"] = self.get_stepper().get_form_errors(exclude_submit=True)
+        context["stepper_errors"] = self.get_stepper().get_form_errors(
+            exclude_submit=True
+        )
 
         return context
 


### PR DESCRIPTION
Ok so, hear me out. To me this is a nice fix for removing the submit from the 'all errors' display on the submit page. It can also be reused in the submit form.

I know you did not want this, but consider it :)