### PR TITLE
feat: Do not offer to compare files with identical urls

### DIFF
--- a/reviews/templatetags/documents_list.py
+++ b/reviews/templatetags/documents_list.py
@@ -16,6 +16,10 @@ from proposals.utils.proposal_utils import FilenameFactory
 register = template.Library()
 
 
+def is_identical(new_file, old_file):
+    return new_file.url == old_file.url
+
+
 @register.inclusion_tag("reviews/simple_compare_link.html")
 def simple_compare_link(obj, file):
     """Generates a compare icon"""
@@ -101,6 +105,11 @@ def simple_compare_link(obj, file):
         "new": pk,
         "attribute": file.field.name,
     }
+
+    # Do not offer to compare identical files
+    old_file = getattr(parent_obj, file.field.name)
+    if is_identical(file, old_file):
+        return {}
 
     # CompareDocumentsView expects the following args:
     # - old pk


### PR DESCRIPTION
Apparently the comparison issue in #855 is surprisingly fixable. This is a bit of a dangerous change to be making right now, so I'm open to discussion on if we should fix this at all.

This PR presents the fix in question that I'm carefully optimistic about. But please try and break it.