### PR TITLE
fix: exclude_submit_bug

### DIFF
--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -262,7 +262,7 @@ class Stepper(renderable):
                 # When using this method on the submit page, we
                 # use the form's own validation, otherwise it gets
                 # validated twice
-                if exclude_submit and getattr(item, "form_class", None) == ProposalSubmitForm:
+                if exclude_submit and getattr(item, "form_class", None) is ProposalSubmitForm:
                     continue
                 troublesome_pages.append(
                     {

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -262,7 +262,7 @@ class Stepper(renderable):
                 # When using this method on the submit page, we
                 # use the form's own validation, otherwise it gets
                 # validated twice
-                if exclude_submit and item.form_class == ProposalSubmitForm:
+                if exclude_submit and getattr(item, "form_class", None) == ProposalSubmitForm:
                     continue
                 troublesome_pages.append(
                     {

--- a/proposals/utils/stepper.py
+++ b/proposals/utils/stepper.py
@@ -262,7 +262,10 @@ class Stepper(renderable):
                 # When using this method on the submit page, we
                 # use the form's own validation, otherwise it gets
                 # validated twice
-                if exclude_submit and getattr(item, "form_class", None) is ProposalSubmitForm:
+                if (
+                    exclude_submit
+                    and getattr(item, "form_class", None) is ProposalSubmitForm
+                ):
                     continue
                 troublesome_pages.append(
                     {


### PR DESCRIPTION
This fixes a breaking bug for the new exclude_submit option I added to Stepper.get_form_errors.

If this if statement receives StepperItem's without a form_class attribuge eg. ContainerItem's (used when there are multiple studies), an AttributeError gets raised. This fixes it.