### PR TITLE
Fix/404 on attachment download

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -4,7 +4,6 @@ from django.utils.translation import gettext as _
 from django.urls import reverse
 from main.utils import renderable
 
-
 from cdh.files.db import FileField as CDHFileField
 
 # Create your models here.
@@ -161,6 +160,6 @@ class StudyAttachment(
         """
         try:
             owner = self.attached_to.get(proposal=proposal)
-        except self.DoesNotExist:
+        except self.attached_to.model.DoesNotExist:
             owner = None
         return owner

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -134,10 +134,13 @@ class ProposalAttachment(
         proposal,
     ):
         """
-        This method doesn't do much, it's just here to provide
-        a consistent interface for getting owner objects.
+        Returns the given proposal if this Attachment is attached to it, or
+        None if that is not the case.
         """
-        return proposal
+        owner = None
+        if proposal in self.attached_to.all():
+            owner = proposal
+        return owner
 
 
 class StudyAttachment(
@@ -153,6 +156,11 @@ class StudyAttachment(
         proposal,
     ):
         """
-        Gets the owner study based on given proposal.
+        Gets the owner study based on given proposal, or None
+        if no such study exists.
         """
-        return self.attached_to.get(proposal=proposal)
+        try:
+            owner = self.attached_to.get(proposal=proposal)
+        except self.DoesNotExist:
+            owner = None
+        return owner


### PR DESCRIPTION
Closes #838 

Not only would `AttachmentDownloadView` previously not return a 404, it also allowed the downloading of any existing attachment given any proposal that the requesting user had access to. Because permissions are checked based on the given proposal, this was a security issue.

To fix this, `Attachment.get_owner_for_proposal()` now actually does something (for proposal attachments) and returns `None` if the given attachment does not have a valid owner for the given proposal. The download view will raise a 403 (`PermissionDenied`) if no owner can be found.

`AttachmentDownloadView` now only gets attachments and proposals from their respective `self.get_` methods, which can each raise a 404, and also cache their object so they only produce one query.