### PR TITLE
fix: make date format alphabetically sortable

### DIFF
--- a/proposals/templates/proposals/proposal_export_list.html
+++ b/proposals/templates/proposals/proposal_export_list.html
@@ -31,7 +31,7 @@
                             <td>
                                 {% if proposal.supervisor %}{{ proposal.supervisor.get_full_name }}{% endif %}
                             </td>
-                            <td>{{ proposal.date_confirmed|date:"d M Y" }}</td>
+                            <td>{{ proposal.date_confirmed|date:"Y-m-d" }}</td>
                             <td>
                                 {# Bad translation hack #}
                                 {% if proposal.reviewing_committee.name == "AK" %}


### PR DESCRIPTION
Thought I would just tackle this as a little snack.

So, I just converted the date format in the export view to be alphabetically sortable (YYYY-mm-dd) See the [docs](https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#date) for more info ...

Think this would be nice to deploy as a little treat for the secretary ;p