### PR TITLE
fix: update qs to exclude supervisor reviews

### DIFF
--- a/reviews/api/views.py
+++ b/reviews/api/views.py
@@ -438,6 +438,7 @@ class InRevisionApiView(BaseReviewApiView):
         revision_reviews = Review.objects.filter(
             proposal__is_revision=True,  # Not a copy
             stage__gte=Review.Stages.ASSIGNMENT,  # Not a supervisor review
+            is_committee_review=True,
         )
         # 2. Get candidate reviews:
         # All reviews whose conclusion is "revision necessary"


### PR DESCRIPTION
Just a small bugfix, so that the in_revision list view does not exclude reviews, with children that are supervisor reviews.