### PR TITLE
traits.json updated with genetic data. 

### DIFF
--- a/studies/fixtures/traits.json
+++ b/studies/fixtures/traits.json
@@ -92,11 +92,21 @@
 {
     "fields": {
         "needs_details": true,
-        "order": 10,
+        "order": 11,
         "description_nl": "anders, namelijk",
         "description_en": "otherwise, viz."
     },
     "model": "studies.trait",
     "pk": 10
+},
+{
+"fields": {
+    "needs_details": false,
+    "order": 10,
+    "description_nl": "genetische gegevens",
+    "description_en": "genetic data"
+},
+"model": "studies.trait",
+"pk": 11
 }
 ]


### PR DESCRIPTION
het onderdeel "Perhaps we can have this list always visible, so that the 'information' is not required anymore? We could discuss this further with the privacy officer." uit issue #672 zit er niet bij. Het komt niet over of daar al een besluit over genomen is.

vergeet niet python manage.py load_fixtures opnieuw te runnen.