### PR TITLE
Fix/menus user attribute error

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.db.models import Q
 from django.db.models.fields.files import FieldFile
+from django.contrib.auth.models import AnonymousUser
 from django.utils.translation import gettext_lazy as _
 from django.template import loader, Template, Context
 
@@ -163,6 +164,30 @@ def can_view_archive(user):
     # If our tests are inconclusive,
     # check for Humanities affiliation
     return is_member_of_humanities(user)
+
+
+def is_authenticated(request):
+    """
+    Safely checks if a request is authenticated (logged in). Can be used
+    early in the response process when request.user is not guaranteed to
+    be set.
+    """
+    try:
+        return request.user.is_authenticated
+    except AttributeError:
+        return False
+
+
+def get_user(request):
+    """
+    Safely gets the user associated with a request. Can be used
+    early in the response process when request.user is not guaranteed to
+    be set. Returns the authenticated user or AnonymousUser.
+    """
+    try:
+        return request.user
+    except AttributeError:
+        return AnonymousUser()
 
 
 class renderable:

--- a/proposals/menus.py
+++ b/proposals/menus.py
@@ -91,17 +91,17 @@ archive_menu = (
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Algemene Kamer"),
         reverse("proposals:archive", args=["AK"]),
-        check=lambda x: can_view_archive(get_user(x)),
+        check=lambda request: can_view_archive(get_user(request)),
     ),
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Linguïstiek Kamer"),
         reverse("proposals:archive", args=["LK"]),
-        check=lambda x: can_view_archive(get_user(x)),
+        check=lambda request: can_view_archive(get_user(request)),
     ),
     MenuItem(
         _("Site-export"),
         reverse("proposals:archive_export"),
-        check=lambda x: is_secretary(get_user(x)),
+        check=lambda request: is_secretary(get_user(request)),
     ),
 )
 
@@ -113,6 +113,6 @@ Menu.add_item(
         "#",
         slug="archive",  # needed for sub-menu!
         children=archive_menu,
-        check=lambda x: can_view_archive(get_user(x)),
+        check=lambda request: can_view_archive(get_user(request)),
     ),
 )

--- a/proposals/menus.py
+++ b/proposals/menus.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from menu import Menu, MenuItem
 
-from main.utils import is_secretary, can_view_archive
+from main.utils import is_secretary, can_view_archive, is_authenticated, get_user
 
 new_proposal_menu = (
     MenuItem(
@@ -45,7 +45,7 @@ Menu.add_item(
         "#",
         slug="new-studies",  # needed for sub-menu!
         children=new_proposal_menu,
-        check=lambda x: x.user.is_authenticated,
+        check=is_authenticated,
     ),
 )
 
@@ -83,7 +83,7 @@ Menu.add_item(
         reverse("proposals:my_archive"),
         slug="my-studies",  # needed for sub-menu!
         children=my_proposals_menu,
-        check=lambda x: x.user.is_authenticated,
+        check=is_authenticated,
     ),
 )
 
@@ -91,17 +91,17 @@ archive_menu = (
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Algemene Kamer"),
         reverse("proposals:archive", args=["AK"]),
-        check=lambda x: can_view_archive(x.user),
+        check=lambda x: can_view_archive(get_user(x)),
     ),
     MenuItem(
         _("Bekijk alle goedgekeurde aanvragen van de Linguïstiek Kamer"),
         reverse("proposals:archive", args=["LK"]),
-        check=lambda x: can_view_archive(x.user),
+        check=lambda x: can_view_archive(get_user(x)),
     ),
     MenuItem(
         _("Site-export"),
         reverse("proposals:archive_export"),
-        check=lambda x: is_secretary(x.user),
+        check=lambda x: is_secretary(get_user(x)),
     ),
 )
 
@@ -113,6 +113,6 @@ Menu.add_item(
         "#",
         slug="archive",  # needed for sub-menu!
         children=archive_menu,
-        check=lambda x: can_view_archive(x.user),
+        check=lambda x: can_view_archive(get_user(x)),
     ),
 )

--- a/reviews/menus.py
+++ b/reviews/menus.py
@@ -28,37 +28,37 @@ def create_committee_menu(commitee: str) -> List[MenuItem]:
         MenuItem(
             _("Alle openstaande besluiten commissieleden"),
             reverse("reviews:open", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Alle openstaande besluiten eindverantwoordelijken"),
             reverse("reviews:open_supervisors", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Nog af te handelen aanvragen"),
             reverse("reviews:to_conclude", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Aanvragen in revisie"),
             reverse("reviews:in_revision", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Alle lopende aanvragen"),
             reverse("reviews:all_open", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Alle ingezonden aanvragen"),
             reverse("reviews:archive", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(get_user(x)),
+            check=lambda request: is_po_chair_or_secretary(get_user(request)),
         ),
         MenuItem(
             _("Overzicht werkverdeling commissieleden"),
             reverse("reviews:workload", args=[commitee]),
-            check=lambda x: is_chair_or_secretary(get_user(x)),
+            check=lambda request: is_chair_or_secretary(get_user(request)),
         ),
     ]
 
@@ -69,7 +69,7 @@ Menu.add_item(
         _("Algemene Kamer"),
         "#",
         children=create_committee_menu("AK"),
-        check=lambda x: in_general_chamber(get_user(x)),
+        check=lambda request: in_general_chamber(get_user(request)),
     ),
 )
 
@@ -79,6 +79,6 @@ Menu.add_item(
         _("Linguïstiek Kamer"),
         "#",
         children=create_committee_menu("LK"),
-        check=lambda x: in_linguistics_chamber(get_user(x)),
+        check=lambda request: in_linguistics_chamber(get_user(request)),
     ),
 )

--- a/reviews/menus.py
+++ b/reviews/menus.py
@@ -11,6 +11,8 @@ from main.templatetags.fetc_filters import (
     is_po_chair_or_secretary,
 )
 
+from main.utils import get_user
+
 
 def create_committee_menu(commitee: str) -> List[MenuItem]:
 
@@ -26,37 +28,37 @@ def create_committee_menu(commitee: str) -> List[MenuItem]:
         MenuItem(
             _("Alle openstaande besluiten commissieleden"),
             reverse("reviews:open", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Alle openstaande besluiten eindverantwoordelijken"),
             reverse("reviews:open_supervisors", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Nog af te handelen aanvragen"),
             reverse("reviews:to_conclude", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Aanvragen in revisie"),
             reverse("reviews:in_revision", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Alle lopende aanvragen"),
             reverse("reviews:all_open", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Alle ingezonden aanvragen"),
             reverse("reviews:archive", args=[commitee]),
-            check=lambda x: is_po_chair_or_secretary(x.user),
+            check=lambda x: is_po_chair_or_secretary(get_user(x)),
         ),
         MenuItem(
             _("Overzicht werkverdeling commissieleden"),
             reverse("reviews:workload", args=[commitee]),
-            check=lambda x: is_chair_or_secretary(x.user),
+            check=lambda x: is_chair_or_secretary(get_user(x)),
         ),
     ]
 
@@ -67,7 +69,7 @@ Menu.add_item(
         _("Algemene Kamer"),
         "#",
         children=create_committee_menu("AK"),
-        check=lambda x: in_general_chamber(x.user),
+        check=lambda x: in_general_chamber(get_user(x)),
     ),
 )
 
@@ -77,6 +79,6 @@ Menu.add_item(
         _("Linguïstiek Kamer"),
         "#",
         children=create_committee_menu("LK"),
-        check=lambda x: in_linguistics_chamber(x.user),
+        check=lambda x: in_linguistics_chamber(get_user(x)),
     ),
 )


### PR DESCRIPTION
Fixes #944 

I saw four possible ways of fixing this:

1. Change error templates to no longer render menus, which would require modifying `tool-base.html` in DSC.
2. Modify all existing auth helper functions to access `request.user` safely.
3. Subclass MenuItems to do all the processing in a safe manner.
4. Add a couple wrapper functions that access `request.user` safely

I ended up going with number 4 as the least intrusive. But if we were engineering this from scratch I may have preferred a form of solution 1 or 3.